### PR TITLE
Use Options for Handles Somewhat More

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -245,7 +245,7 @@ fn main() {
     let game_scene = create_scene_async(engine.resource_manager.clone());
 
     // Initially these handles are None, once scene is loaded they'll be assigned.
-    let mut scene_handle = Handle::NONE;
+    let mut scene_handle = None;
     let mut model_handle = Handle::NONE;
     let mut walk_animation = Handle::NONE;
 
@@ -288,7 +288,7 @@ fn main() {
                             // Add scene to engine - engine will take ownership over scene and will return
                             // you a handle to scene which can be used later on to borrow it and do some
                             // actions you need.
-                            scene_handle = engine.scenes.add(game_scene.scene);
+                            scene_handle = Some(engine.scenes.add(game_scene.scene));
                             model_handle = game_scene.model_handle;
                             walk_animation = game_scene.walk_animation;
 
@@ -305,7 +305,7 @@ fn main() {
                     }
 
                     // Update scene only if it is loaded.
-                    if scene_handle.is_some() {
+                    if let Some(scene_handle) = scene_handle {
                         // Use stored scene handle to borrow a mutable reference of scene in
                         // engine.
                         let scene = &mut engine.scenes[scene_handle];

--- a/examples/lightmap.rs
+++ b/examples/lightmap.rs
@@ -336,7 +336,7 @@ fn main() {
     };
 
     // Initially these handles are None, once scene is loaded they'll be assigned.
-    let mut scene_handle = Handle::NONE;
+    let mut scene_handle = None;
     let mut model_handle = Handle::NONE;
 
     let clock = Instant::now();
@@ -378,7 +378,7 @@ fn main() {
                             // Add scene to engine - engine will take ownership over scene and will return
                             // you a handle to scene which can be used later on to borrow it and do some
                             // actions you need.
-                            scene_handle = engine.scenes.add(game_scene.scene);
+                            scene_handle = Some(engine.scenes.add(game_scene.scene));
                             model_handle = game_scene.root;
 
                             // Once scene is loaded, we should hide progress bar and text.
@@ -435,7 +435,7 @@ fn main() {
                     }
 
                     // Update scene only if it is loaded.
-                    if scene_handle.is_some() {
+                    if let Some(scene_handle) = scene_handle {
                         // Use stored scene handle to borrow a mutable reference of scene in
                         // engine.
                         let scene = &mut engine.scenes[scene_handle];

--- a/rg3d-core/src/visitor.rs
+++ b/rg3d-core/src/visitor.rs
@@ -524,15 +524,15 @@ impl Visitor {
     pub fn enter_region(&mut self, name: &str) -> VisitResult {
         if self.reading {
             let node = self.nodes.borrow(self.current_node);
-            let mut region = Handle::NONE;
+            let mut region = None;
             for child_handle in node.children.iter() {
                 let child = self.nodes.borrow(*child_handle);
                 if child.name == name {
-                    region = *child_handle;
+                    region = Some(*child_handle);
                     break;
                 }
             }
-            if region.is_some() {
+            if let Some(region) = region {
                 self.current_node = region;
                 Ok(())
             } else {

--- a/rg3d-sound/src/context.rs
+++ b/rg3d-sound/src/context.rs
@@ -213,9 +213,9 @@ impl State {
         let last_time = time::Instant::now();
 
         for i in 0..self.sources.get_capacity() {
-            if let Some(source) = self.sources.at(i) {
+            if let Some((handle, source)) = self.sources.at_pair(i) {
                 if source.is_play_once() && source.status() == Status::Stopped {
-                    self.sources.free(self.sources.handle_from_index(i));
+                    self.sources.free(handle);
                 }
             }
         }

--- a/rg3d-ui/src/dock.rs
+++ b/rg3d-ui/src/dock.rs
@@ -719,8 +719,8 @@ impl<M: MessageData, C: Control<M, C>> Tile<M, C> {
         first: bool,
     ) {
         let existing_content = match self.content {
-            TileContent::Window(existing_window) => existing_window,
-            _ => Handle::NONE,
+            TileContent::Window(existing_window) => Some(existing_window).filter(|h| h.is_some()),
+            _ => None,
         };
 
         let first_tile = TileBuilder::new(WidgetBuilder::new())
@@ -743,7 +743,7 @@ impl<M: MessageData, C: Control<M, C>> Tile<M, C> {
             })
             .build(&mut ui.build_ctx());
 
-        if existing_content.is_some() {
+        if let Some(existing_content) = existing_content {
             ui.send_message(TileMessage::content(
                 if first { second_tile } else { first_tile },
                 MessageDirection::ToWidget,

--- a/rg3d-ui/src/lib.rs
+++ b/rg3d-ui/src/lib.rs
@@ -1705,7 +1705,7 @@ impl<M: MessageData, C: Control<M, C>> UserInterface<M, C> {
         for i in 0..self.nodes.get_capacity() {
             let handle = self.nodes.handle_from_index(i);
 
-            if self.nodes.is_valid_handle(handle) {
+            if let Some(handle) = handle.filter(|h| self.nodes.is_valid_handle(*h)) {
                 let (ticket, mut node) = self.nodes.take_reserve(handle);
 
                 node.handle_os_event(handle, self, event);

--- a/src/scene/graph.rs
+++ b/src/scene/graph.rs
@@ -785,7 +785,7 @@ impl Graph {
         self.update_hierarchical_data();
 
         for i in 0..self.pool.get_capacity() {
-            if let Some(node) = self.pool.at_mut(i) {
+            if let Some((handle, node)) = self.pool.at_pair_mut(i) {
                 let remove = if let Some(lifetime) = node.lifetime.as_mut() {
                     *lifetime -= dt;
                     *lifetime <= 0.0
@@ -794,7 +794,7 @@ impl Graph {
                 };
 
                 if remove {
-                    self.remove_node(self.pool.handle_from_index(i));
+                    self.remove_node(handle);
                 } else {
                     match node {
                         Node::Camera(camera) => {
@@ -843,7 +843,7 @@ impl Graph {
     /// graph.add_node(Node::Base(Default::default()));
     /// for i in 0..graph.capacity() {
     ///     let handle = graph.handle_from_index(i);
-    ///     if handle.is_some() {
+    ///     if let Some(handle) = handle {
     ///         let node = &mut graph[handle];
     ///         // Do something with node.
     ///     }
@@ -864,13 +864,13 @@ impl Graph {
     /// graph.add_node(Node::Base(Default::default()));
     /// for i in 0..graph.capacity() {
     ///     let handle = graph.handle_from_index(i);
-    ///     if handle.is_some() {
+    ///     if let Some(handle) = handle {
     ///         let node = &mut graph[handle];
     ///         // Do something with node.
     ///     }
     /// }
     /// ```
-    pub fn handle_from_index(&self, index: usize) -> Handle<Node> {
+    pub fn handle_from_index(&self, index: usize) -> Option<Handle<Node>> {
         self.pool.handle_from_index(index)
     }
 

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -176,12 +176,12 @@ impl PhysicsBinder {
     }
 
     /// Unlinks given body from a node that is linked with the body.
-    pub fn unbind_by_body(&mut self, body: RigidBodyHandle) -> Handle<Node> {
+    pub fn unbind_by_body(&mut self, body: RigidBodyHandle) -> Option<Handle<Node>> {
         if let Some(node) = self.backward_map.get(&body) {
             self.forward_map.remove(node);
-            *node
+            Some(*node)
         } else {
-            Handle::NONE
+            None
         }
     }
 

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1003,7 +1003,7 @@ impl NavMeshContainer {
     }
 
     /// Creates a handle to navmesh from its index.
-    pub fn handle_from_index(&self, i: usize) -> Handle<Navmesh> {
+    pub fn handle_from_index(&self, i: usize) -> Option<Handle<Navmesh>> {
         self.pool.handle_from_index(i)
     }
 


### PR DESCRIPTION
This PR does not do anything too major. Mainly changing a few functions to returning `Option<Handle<T>>` rather than using `None`, and making some code within functions use `Option`s rather than `Handle::None`.  
(Essentially trying to split apart the big change of using `Option` with `Handle`s into smaller prs which are more manageable, and allow for better comments on progress)

# Commit #1  
  
## Return Changes  
- `Pool::handle_from_index` returns `Option<Handle<T>>` rather than `Handle<T>`.  
    - Note: StationIapetus uses this once. (Would make a PR for it, but see end)
- `NavMeshContainer::handle_from_index` See above.  
- `Graph::handle_from_index` See above.  
  
## Extra Methods  
- `Pool::at_pair(&self, n: usize) -> Option<(Handle<T>, &T)>` Returns the value and the handle to it. This avoids extra unneeded checks. (Ex: `rg3d-sound/src/context.rs` line 220)  
- `Pool::at_pair_mut(&mut self, n: usize) -> Option<(Handle<T>, &mut T)>`  
  
# Commit #2
This commit was (mostly) trying to only change some minor handling within functions. Replacing usage of `Handle::NONE` with `Option`.  
## Return changes
- `find_tree` (internal function) returns `Option<Handle<T>>` rather than `Handle<T>`  
- `unbind_by_body` returns `Option<Handle<T>>` rather than `Handle<T>`. This is public. (Grepped for it in my project, rusty-editor, rg3d-tutorials, StationIapetus, rusty-shooter and got no results for usage. Though, rusty-editor has its own version which is not changed.)
  
  
# Non-Added Methods
This section is for methods that were thought of but weren't actually added. Essentially to give an idea of what could be useful/nice to have but I didn't deem worthy enough to add at the moment.  
- `Pool::unwrap_valid_handle(&self, handle: Option<Handle<T>>) -> Option<Handle<T>>` If it is `None`, return `None`. If it is Invalid, return `None`. If it is Valid, return it. Allows:  
```rust
let handle: Option<Handle<T>> = pool.handle_from_index(i);
if let Some(handle) = pool.unwrap_valid_handle(handle) {
    //
}
```
(Ex: `rg3d-ui/src/lib.rs` line 1708)  
Trivial implementation: `handle.filter(|h| self.is_valid_handle(*h))`  
  
  
# Testing
Tested changes with:
 - `cargo test --release` in rg3d 
 - My own small project (No changes needed)
 - rusty-editor (No changes needed)
 - rg3d-tutorials (No changes needed)
 - StationIapetus: `src/level/mod.rs` line #688 uses `handle_from_index`. This should be `scene.navmeshes.handle_from_index().unwrap_or(Handle::None)` or use `.expect` if it should certainly exist. (For a bigger change to rg3d like a future PR might bring, I'd make a PR on Iapetus too, but this one is small)  
 - rusty-shooter (No changes needed)