### PR TITLE
hide `Tree` panel unless created in expanded state

### DIFF
--- a/rg3d-ui/src/tree.rs
+++ b/rg3d-ui/src/tree.rs
@@ -360,6 +360,7 @@ impl TreeBuilder {
                             .on_row(1)
                             .on_column(0)
                             .with_margin(Thickness::left(15.0))
+                            .with_visibility(self.is_expanded)
                             .with_children(self.items.iter().cloned()),
                     )
                     .build(ctx);


### PR DESCRIPTION
I noticed my tree was in a broken state when I built the items ".with_expanded(false)". It looked expanded, but clicking the icon didn't make the subtree go away. Clicking the icon again then collapsed the subtree. So the state was "partially expanded, partially collapsed" at first.

I hope this is the correct approach to fix it.

I also hope I used the tree correctly and it's not a bug in my code. For reference, this is my code:

```rust
    let mut module_items = Vec::new();

    for module in modules {
        let module_content = TextBuilder::new(WidgetBuilder::new())
            .with_text(module.file.file_name().unwrap_or_default().to_string_lossy())
            .build(&mut ctx);

        let mut viewpoint_items = Vec::new();

        for view_position in &module.view_positions {
            let button = ButtonBuilder::new(
                WidgetBuilder::new()
                    .with_user_data(Rc::new((module.utm, view_position.clone())))
                    .with_width(370.0)
                )
                .with_content(TextBuilder::new(WidgetBuilder::new())
                    .with_text(view_position.name.clone())
                    .with_horizontal_text_alignment(HorizontalAlignment::Left)
                    .with_vertical_text_alignment(VerticalAlignment::Center)
                    .build(&mut ctx)
                )
                .build(&mut ctx);

            viewpoint_items.push(button);
        }

        module_items.push(TreeBuilder::new(WidgetBuilder::new())
            .with_content(module_content)
            .with_items(viewpoint_items)
            .with_expanded(false)
            .build(&mut ctx));
    }
    

    let tree = TreeRootBuilder::new(WidgetBuilder::new())
        .with_items(module_items)
        .build(&mut ctx);
```