### PR TITLE
resize GL context on window size change

### DIFF
--- a/examples/3rd_person.rs
+++ b/examples/3rd_person.rs
@@ -169,7 +169,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = game.engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = game.engine.set_frame_size(size.into()) {
                             Log::writeln(
                                 MessageKind::Error,
                                 format!("Unable to set frame size: {:?}", e),

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -255,7 +255,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = engine.set_frame_size(size.into()) {
                             Log::writeln(
                                 MessageKind::Error,
                                 format!("Unable to set frame size: {:?}", e),

--- a/examples/lightmap.rs
+++ b/examples/lightmap.rs
@@ -529,7 +529,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = engine.set_frame_size(size.into()) {
                             Log::writeln(
                                 MessageKind::Error,
                                 format!("Unable to set frame size: {:?}", e),

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -241,7 +241,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = engine.set_frame_size(size.into()) {
                             Log::writeln(MessageKind::Error, format!("Unable to set frame size: {:?}", e));
                         }
                     }

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -301,7 +301,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = engine.set_frame_size(size.into()) {
                             Log::writeln(
                                 MessageKind::Error,
                                 format!("Unable to set frame size: {:?}", e),

--- a/examples/save_load.rs
+++ b/examples/save_load.rs
@@ -254,7 +254,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = game.engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = game.engine.set_frame_size(size.into()) {
                             Log::writeln(MessageKind::Error, format!("Unable to set frame size: {:?}", e));
                         }
 

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -184,7 +184,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = engine.set_frame_size(size.into()) {
                             Log::writeln(
                                 MessageKind::Error,
                                 format!("Unable to set frame size: {:?}", e),

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -231,7 +231,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = game.engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = game.engine.set_frame_size(size.into()) {
                             Log::writeln(MessageKind::Error, format!("Unable to set frame size: {:?}", e));
                         }
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -467,7 +467,7 @@ fn main() {
                                         ));
 
                                         // Due to some weird bug in winit it does not send Resized event.
-                                        if let Err(e) = engine.renderer.set_frame_size((
+                                        if let Err(e) = engine.set_frame_size((
                                             video_mode.size().width,
                                             video_mode.size().height,
                                         )) {
@@ -498,7 +498,7 @@ fn main() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        if let Err(e) = engine.renderer.set_frame_size(size.into()) {
+                        if let Err(e) = engine.set_frame_size(size.into()) {
                             Log::writeln(
                                 MessageKind::Error,
                                 format!("Unable to set frame size: {:?}", e),

--- a/src/engine/framework.rs
+++ b/src/engine/framework.rs
@@ -115,7 +115,7 @@ impl<State: GameState> Framework<State> {
                     match event {
                         WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                         WindowEvent::Resized(size) => {
-                            if let Err(e) = engine.renderer.set_frame_size(size.into()) {
+                            if let Err(e) = engine.set_frame_size(size.into()) {
                                 Log::writeln(
                                     MessageKind::Error,
                                     format!("Unable to set frame size: {:?}", e),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -162,6 +162,18 @@ impl Engine {
         })
     }
 
+    /// Adjust size of the frame to be rendered. Must be called after the window size changes.
+    /// Will update the renderer and GL context frame size.
+    /// When using the [`framework::Framework`], you don't need to call this yourself.
+    pub fn set_frame_size(&mut self, new_size: (u32, u32)) -> Result<(), FrameworkError> {
+        self.renderer.set_frame_size(new_size)?;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        self.context.resize(new_size.into());
+
+        Ok(())
+    }
+
     /// Returns reference to main window. Could be useful to set fullscreen mode, change
     /// size of window, its title, etc.
     #[inline]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1102,13 +1102,15 @@ impl Renderer {
         }
     }
 
-    /// Sets new frame size, should be called when received a Resize event.
+    /// Sets new frame size. You should call the same method on [`crate::engine::Engine`]
+    /// instead, which will update the size for the user interface and rendering context
+    /// as well as this one.
     ///
     /// # Notes
     ///
     /// Input values will be set to 1 pixel if new size is 0. Rendering cannot
     /// be performed into 0x0 texture.
-    pub fn set_frame_size(&mut self, new_size: (u32, u32)) -> Result<(), FrameworkError> {
+    pub(in crate) fn set_frame_size(&mut self, new_size: (u32, u32)) -> Result<(), FrameworkError> {
         self.frame_size.0 = new_size.0.max(1);
         self.frame_size.1 = new_size.1.max(1);
 


### PR DESCRIPTION
Edit: Ugh, I have never compiled for wasm to be honest, and I haven't noticed that wasm example directory. If this change is fine otherwise, I'll update this to fix the example code obviously.

This might be problematic because it changes the public API of the renderer in a pretty prominent place. Since the renderer doesn't have easy access to the glutin context (as far as I can tell), this was the best I could come up with, other than possible workarounds like "set a dirty flag in the renderer, then resize the context on next render_and_swap_buffers() call where the context is passed in". Let me know if you prefer that solution. :-)

Both input and "windowing" seem to work pretty well on Wayland Gnome for me with that change. The window decoration appears to be rather "simple" but that's okay.

---------------------------------------

This is an API-breaking change for anyone not using the `Framework`
helper. Instead of calling the `set_frame_size()` method on the
`Renderer` after a window size change, it is now necessary to call the
`set_frame_size()` method on the `Engine`. `Framework` was updated to
handle this correctly.

Explicitly changing the GL context size (backbuffer) after window resize
events happens automatically on most platforms, but is needed for
Wayland and macOS according to glutin docs.

This fixes an issue on Wayland, where the window content size did not
change after a window resize, only the window title bar.

Might help for issues #167 and #10.