### PR TITLE
update wasm example to use new `set_frame_size()`

### DIFF
--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -414,7 +414,7 @@ pub fn main_js() {
                         // It is very important to handle Resized event from window, because
                         // renderer knows nothing about window size - it must be notified
                         // directly when window size has changed.
-                        engine.renderer.set_frame_size(size.into());
+                        engine.set_frame_size(size.into());
                     }
                     WindowEvent::KeyboardInput { input, .. } => {
                         // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)


### PR DESCRIPTION
I'll be honest, I don't have a wasm build environment set up and I'm low on disk space right now, so this is not even compile-tested. But since I already broke the wasm CI with my last commit, this can't make it worse, right? Let's see...