### PR TITLE
set TEXTURE_MAX_LEVEL if we can't generate mipmaps

### DIFF
--- a/src/renderer/framework/gpu_texture.rs
+++ b/src/renderer/framework/gpu_texture.rs
@@ -925,6 +925,8 @@ impl GpuTexture {
                 && mip_count == 1
             {
                 state.gl.generate_mipmap(target);
+            } else {
+                state.gl.tex_parameter_i32(target, glow::TEXTURE_MAX_LEVEL, mip_count as i32 - 1);
             }
 
             state.set_texture(0, target, Default::default());


### PR DESCRIPTION
I have another PR, this fixed a bridge object that rendered 100% black instead of using the texture. Thanks to renderdoc, it was easy to figure out though. The bridge uses a texture with only 2 mip levels (and it's a compressed texture, but this doesn't even matter because generating mipmaps will only be triggered by rg3d if there is exactly 1 level in the texture). OpenGL attempted to use up to 1000 mip levels, which is the default value for TEXTURE_MAX_LEVEL, so that failed and renderdoc displayed a very helpful hint about that issue.

This sets the max level even when mipmap filtering is disabled for the texture, but I guess that shouldn't cause any issues (without having tested it).

-------------------------------------------------

This prevents "mipmap incomplete textures" when mipmaps are used for
sampling, but there are not enough mipmaps (down to 1x1 size) available
in the texture. This caused meshes to be rendered with a black texture
instead of the mimap incomplete texture.