### PR TITLE
add `PropertyInfo::is_modified` #285

### DIFF
--- a/fyrox-core-derive/src/inspect/args.rs
+++ b/fyrox-core-derive/src/inspect/args.rs
@@ -97,6 +97,12 @@ pub struct FieldArgs {
     /// Description of the property.
     #[darling(default)]
     pub description: Option<String>,
+
+    /// `#[inspect(getter = "<method_name>")]`
+    ///
+    /// True if the value has been modified.
+    #[darling(default)]
+    pub is_modified: Option<String>,
 }
 
 #[derive(FromVariant)]

--- a/fyrox-core-derive/tests/it/inspect.rs
+++ b/fyrox-core-derive/tests/it/inspect.rs
@@ -16,6 +16,7 @@ fn default_prop() -> PropertyInfo<'static> {
         step: None,
         precision: None,
         description: "".to_string(),
+        is_modified: false,
     }
 }
 
@@ -100,6 +101,7 @@ fn inspect_attributes() {
             step: Some(0.1),
             precision: Some(3),
             description: "This is a property description.".to_string(),
+            ..default_prop()
         },
     ];
 
@@ -311,6 +313,25 @@ fn inspect_with_custom_getter() {
             name: "0",
             display_name: "0",
             value: &*a.0,
+            ..default_prop()
+        }]
+    );
+}
+
+#[test]
+fn inspect_modified() {
+    #[derive(Inspect)]
+    struct S(#[inspect(is_modified = "clone")] bool);
+
+    let s = S(true);
+    assert_eq!(
+        s.properties(),
+        vec![PropertyInfo {
+            owner_type_id: TypeId::of::<S>(),
+            name: "0",
+            display_name: "0",
+            value: &s.0,
+            is_modified: true,
             ..default_prop()
         }]
     );

--- a/fyrox-core/src/inspect.rs
+++ b/fyrox-core/src/inspect.rs
@@ -68,6 +68,9 @@ pub struct PropertyInfo<'a> {
 
     /// Description of the property.
     pub description: String,
+
+    /// True if the value has been modified.
+    pub is_modified: bool,
 }
 
 impl<'a> PartialEq<Self> for PropertyInfo<'a> {
@@ -173,6 +176,7 @@ macro_rules! impl_self_inspect {
                     step: Some($step),
                     precision: Some($precision),
                     description: "".to_string(),
+                    is_modified: false,
                 }]
             }
         }

--- a/fyrox-core/src/pool.rs
+++ b/fyrox-core/src/pool.rs
@@ -81,6 +81,7 @@ impl<T: 'static> Inspect for Handle<T> {
                 step: None,
                 precision: None,
                 description: "Index of an object in a pool.".to_string(),
+                is_modified: false,
             },
             PropertyInfo {
                 owner_type_id: TypeId::of::<Self>(),
@@ -93,6 +94,7 @@ impl<T: 'static> Inspect for Handle<T> {
                 step: None,
                 precision: None,
                 description: "Generation of an object in a pool.".to_string(),
+                is_modified: false,
             },
         ]
     }


### PR DESCRIPTION
Closes [#285](https://github.com/FyroxEngine/Fyrox/issues/285):

```rust
#[derive(Inspect)]
struct S(#[inspect(is_modified = "Clone::clone")] bool);
```

I personally preferred to allow any path, but changing it to method name is also easy :)
