### PR TITLE
Impl Debug for all Statistics structs

### DIFF
--- a/src/renderer/framework/geometry_buffer.rs
+++ b/src/renderer/framework/geometry_buffer.rs
@@ -169,7 +169,7 @@ pub struct GeometryBufferBinding<'a> {
     buffer: &'a GeometryBuffer,
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct DrawCallStatistics {
     pub triangles: usize,
 }

--- a/src/renderer/framework/state.rs
+++ b/src/renderer/framework/state.rs
@@ -7,7 +7,7 @@ use glow::{Framebuffer, HasContext};
 use serde::Deserialize;
 use std::fmt::{Display, Formatter};
 
-#[derive(Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct PipelineStatistics {
     pub texture_binding_changes: usize,
     pub vbo_binding_changes: usize,

--- a/src/renderer/light/mod.rs
+++ b/src/renderer/light/mod.rs
@@ -60,7 +60,7 @@ pub mod directional;
 pub mod point;
 pub mod spot;
 
-#[derive(Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct LightingStatistics {
     pub point_lights_rendered: usize,
     pub point_shadow_maps_rendered: usize,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -88,7 +88,7 @@ use std::{
 
 /// Renderer statistics for one frame, also includes current frames per second
 /// amount.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Statistics {
     /// Shows how many pipeline state changes was made per frame.
     pub pipeline: PipelineStatistics,
@@ -130,7 +130,7 @@ impl Display for Statistics {
 }
 
 /// GPU statistics for single frame.
-#[derive(Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct RenderPassStatistics {
     /// Amount of draw calls per frame - lower the better.
     pub draw_calls: usize,


### PR DESCRIPTION
Something i ran into while i was trying to quickly get perf info.

In general, libs should make most public types Debug if possible so those types can be effortlessly used as fields in structs that derive Debug.