### PR TITLE
Make everything called from Engine::update public

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -279,7 +279,7 @@ impl Engine {
         let window_size = Vector2::new(inner_size.width as f32, inner_size.height as f32);
 
         self.resource_manager.state().update(dt);
-        self.renderer.update(dt);
+        self.renderer.update_caches(dt);
         self.handle_model_events();
 
         for scene in self.scenes.iter_mut().filter(|s| s.enabled) {
@@ -299,7 +299,8 @@ impl Engine {
         self.ui_time = instant::Instant::now() - time;
     }
 
-    pub(crate) fn handle_model_events(&mut self) {
+    /// Handle hot-reloading of resources.
+    pub fn handle_model_events(&mut self) {
         while let Ok(event) = self.model_events_receiver.try_recv() {
             if let ResourceEvent::Reloaded(model) = event {
                 Log::info(format!(

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -300,6 +300,9 @@ impl Engine {
     }
 
     /// Handle hot-reloading of resources.
+    ///
+    /// Normally, this is called from `Engine::update()`.
+    /// You should only call this manually if you don't use that method.
     pub fn handle_model_events(&mut self) {
         while let Ok(event) = self.model_events_receiver.try_recv() {
             if let ResourceEvent::Reloaded(model) = event {

--- a/src/engine/resource_manager/container/mod.rs
+++ b/src/engine/resource_manager/container/mod.rs
@@ -99,7 +99,7 @@ where
                     let path = resource.state().path().to_path_buf();
 
                     Log::info(format!(
-                        "Resource {} destroyed because it not used anymore!",
+                        "Resource {} destroyed because it is not used anymore!",
                         path.display()
                     ));
 

--- a/src/engine/resource_manager/mod.rs
+++ b/src/engine/resource_manager/mod.rs
@@ -370,7 +370,8 @@ impl ResourceManagerState {
         containers.curves.destroy_unused();
     }
 
-    pub(in crate) fn update(&mut self, dt: f32) {
+    /// Reload resources if they have changed in disk.
+    pub fn update(&mut self, dt: f32) {
         let containers = self.containers_mut();
         containers.textures.update(dt);
         containers.models.update(dt);

--- a/src/engine/resource_manager/mod.rs
+++ b/src/engine/resource_manager/mod.rs
@@ -370,7 +370,13 @@ impl ResourceManagerState {
         containers.curves.destroy_unused();
     }
 
-    /// Reload resources if they have changed in disk.
+    /// Update resource containers and do hot-reloading.
+    ///
+    /// Resources are removed if they're not used
+    /// or reloaded if they have changed in disk.
+    ///
+    /// Normally, this is called from `Engine::update()`.
+    /// You should only call this manually if you don't use that method.
     pub fn update(&mut self, dt: f32) {
         let containers = self.containers_mut();
         containers.textures.update(dt);

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1283,11 +1283,11 @@ impl Renderer {
         self.texture_cache.update(dt);
     }
 
-    pub(in crate) fn update(&mut self, dt: f32) {
-        // Update caches - this will remove timed out resources.
+    /// Update caches - this will remove timed out resources.
+    pub fn update_caches(&mut self, dt: f32) {
         self.update_texture_cache(dt);
         self.geometry_cache.update(dt);
-        self.renderer2d.update(dt);
+        self.renderer2d.update_caches(dt);
     }
 
     fn render_frame(

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1284,6 +1284,9 @@ impl Renderer {
     }
 
     /// Update caches - this will remove timed out resources.
+    ///
+    /// Normally, this is called from `Engine::update()`.
+    /// You should only call this manually if you don't use that method.
     pub fn update_caches(&mut self, dt: f32) {
         self.update_texture_cache(dt);
         self.geometry_cache.update(dt);

--- a/src/renderer/renderer2d/mod.rs
+++ b/src/renderer/renderer2d/mod.rs
@@ -182,7 +182,7 @@ impl Renderer2d {
         })
     }
 
-    pub(in crate) fn update(&mut self, dt: f32) {
+    pub(in crate) fn update_caches(&mut self, dt: f32) {
         self.geometry_cache.update(dt);
     }
 


### PR DESCRIPTION
As discussed on discord, this is needed to be able to split physics and UI updates.

I also renamed renderer's `update` to `update_caches` to make it clearer what it does (i thought it did more and found it surprising renderer updated before physics).