### PR TITLE
Add option to define custom resource loaders

### DIFF
--- a/editor/src/main.rs
+++ b/editor/src/main.rs
@@ -1574,7 +1574,9 @@ fn main() {
         .with_title("rusty editor")
         .with_resizable(true);
 
-    let mut engine = GameEngine::new(window_builder, &event_loop, true).unwrap();
+    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+
+    let mut engine = GameEngine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     let overlay_pass = OverlayRenderPass::new(engine.renderer.pipeline_state());
     engine.renderer.add_render_pass(overlay_pass);

--- a/editor/src/main.rs
+++ b/editor/src/main.rs
@@ -1576,7 +1576,8 @@ fn main() {
 
     let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = GameEngine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+    let mut engine =
+        GameEngine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     let overlay_pass = OverlayRenderPass::new(engine.renderer.pipeline_state());
     engine.renderer.add_render_pass(overlay_pass);

--- a/editor/src/main.rs
+++ b/editor/src/main.rs
@@ -1574,10 +1574,10 @@ fn main() {
         .with_title("rusty editor")
         .with_resizable(true);
 
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
 
     let mut engine =
-        GameEngine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+        GameEngine::new(window_builder, resource_manager, &event_loop, true).unwrap();
 
     let overlay_pass = OverlayRenderPass::new(engine.renderer.pipeline_state());
     engine.renderer.add_render_pass(overlay_pass);

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,3 +80,7 @@ impact.
 ## Example 11 - Simple game
 
 - TODO
+
+## Example 12 - Custom resource loader
+
+This example shows how to register custom resource loaders. (WIP)

--- a/examples/custom_loader.rs
+++ b/examples/custom_loader.rs
@@ -216,7 +216,7 @@ fn main() {
     }
 
     let mut engine = Engine::new(window_builder, resource_manager, &event_loop, false).unwrap();
-    engine.get_window().set_title("Example 11 - Custom resource loader");
+    engine.get_window().set_title("Example 12 - Custom resource loader");
     
     let mut state = Game::init(&mut engine);
     let clock = Instant::now();

--- a/examples/custom_loader.rs
+++ b/examples/custom_loader.rs
@@ -1,0 +1,203 @@
+//! Example 12. Custom loader
+//!
+//! Difficulty: Moderate.
+//!
+//! This example shows how to create a custom loader. It is a very basic example and in future it should be improved by 
+//! writing some more complex loader such as loading a model from ply or obj file.
+
+/// For simplicity we just simply wrap the default loader and log the invocation t
+pub mod shared;
+
+use crate::shared::create_camera;
+use fyrox::engine::framework::{GameState, Framework};
+use fyrox::engine::resource_manager::ResourceManager;
+use fyrox::engine::Engine;
+use fyrox::engine::resource_manager::container::event::ResourceEventBroadcaster;
+use fyrox::engine::resource_manager::loader::{ResourceLoader, BoxedLoaderFuture};
+use fyrox::engine::resource_manager::loader::model::ModelLoader;
+use fyrox::engine::resource_manager::loader::texture::TextureLoader;
+use fyrox::material::{Material, PropertyValue};
+use fyrox::material::shader::SamplerFallback;
+use fyrox::resource::model::{ModelImportOptions, Model};
+use fyrox::resource::texture::{TextureImportOptions, Texture};
+use fyrox::scene::Scene;
+use fyrox::scene::base::BaseBuilder;
+use fyrox::scene::light::BaseLightBuilder;
+use fyrox::scene::light::point::PointLightBuilder;
+use fyrox::scene::mesh::MeshBuilder;
+use fyrox::scene::mesh::surface::{SurfaceBuilder, SurfaceData};
+use fyrox::scene::transform::TransformBuilder;
+use fyrox_core::algebra::{Matrix4, Vector3};
+use fyrox_core::color::Color;
+use fyrox_core::parking_lot::Mutex;
+use fyrox_core::pool::Handle;
+use fyrox_core::sstorage::ImmutableString;
+use std::sync::Arc;
+
+struct CustomModelLoader(Arc<ModelLoader>);
+
+impl ResourceLoader<Model, ModelImportOptions> for CustomModelLoader {
+    fn load(
+        &self,
+        resource: Model,
+        default_import_options: ModelImportOptions,
+        event_broadcaster: ResourceEventBroadcaster<Model>,
+        reload: bool,
+    ) -> BoxedLoaderFuture {
+        // Arc is required as BoxedLoaderFuture has a static lifetime and hence self cannot be 
+        // moved into an async block. 
+        let loader = self.0.clone();
+
+        Box::pin(async move {
+            println!(
+                "CUSTOM LOADER: loading model {:?}",
+                resource.state().path()
+            );
+            loader
+                .load(
+                    resource,
+                    default_import_options,
+                    event_broadcaster,
+                    reload,
+                )
+                .await
+        })
+    }
+}
+
+/// For simplicity we just simply wrap the default loader and log the invocation to the console.
+struct CustomTextureLoader(Arc<TextureLoader>);
+
+impl ResourceLoader<Texture, TextureImportOptions> for CustomTextureLoader {
+    fn load(
+        &self,
+        resource: Texture,
+        default_import_options: TextureImportOptions,
+        event_broadcaster: ResourceEventBroadcaster<Texture>,
+        reload: bool,
+    ) -> BoxedLoaderFuture {
+        // Arc is required as BoxedLoaderFuture has a static lifetime and hence self cannot be 
+        // moved into an async block. 
+        let loader = self.0.clone();
+
+        Box::pin(async move {
+            println!(
+                "CUSTOM LOADER: loading texture {:?}",
+                resource.state().path()
+            );
+            loader
+                .load(
+                    resource,
+                    default_import_options,
+                    event_broadcaster,
+                    reload,
+                )
+                .await
+        })
+    }
+}
+
+struct GameSceneLoader {
+    scene: Scene
+}
+
+impl GameSceneLoader {
+    async fn load_with(resource_manager: ResourceManager) -> Self {
+        let mut scene = Scene::new();
+
+        // Set ambient light.
+        scene.ambient_lighting_color = Color::opaque(200, 200, 200);
+
+        // Camera is our eyes in the world - you won't see anything without it.
+        create_camera(
+            resource_manager.clone(),
+            Vector3::new(0.0, 6.0, -12.0),
+            &mut scene.graph,
+        )
+        .await;
+
+        // Add some light.
+        PointLightBuilder::new(BaseLightBuilder::new(
+            BaseBuilder::new().with_local_transform(
+                TransformBuilder::new()
+                    .with_local_position(Vector3::new(0.0, 12.0, 0.0))
+                    .build(),
+            ),
+        ))
+        .with_radius(20.0)
+        .build(&mut scene.graph);
+
+        // Add some model with animation.
+        let (model_resource, walk_animation_resource) = fyrox::core::futures::join!(
+            resource_manager.request_model("examples/data/mutant/mutant.FBX",),
+            resource_manager.request_model("examples/data/mutant/walk.fbx",)
+        );
+
+        let model_handle = model_resource.unwrap().instantiate_geometry(&mut scene);
+        scene.graph[model_handle]
+            .local_transform_mut()
+            .set_scale(Vector3::new(0.05, 0.05, 0.05));
+
+        let walk_animation = *walk_animation_resource
+            .unwrap()
+            .retarget_animations(model_handle, &mut scene)
+            .get(0)
+            .unwrap();
+
+        let mut material = Material::standard();
+        material
+            .set_property(
+                &ImmutableString::new("diffuseTexture"),
+                PropertyValue::Sampler {
+                    value: Some(resource_manager.request_texture("examples/data/concrete2.dds")),
+                    fallback: SamplerFallback::White,
+                },
+            )
+            .unwrap();
+
+        // Add floor.
+        MeshBuilder::new(
+            BaseBuilder::new().with_local_transform(
+                TransformBuilder::new()
+                    .with_local_position(Vector3::new(0.0, -0.25, 0.0))
+                    .build(),
+            ),
+        )
+        .with_surfaces(vec![SurfaceBuilder::new(Arc::new(Mutex::new(
+            SurfaceData::make_cube(Matrix4::new_nonuniform_scaling(&Vector3::new(
+                25.0, 0.25, 25.0,
+            ))),
+        )))
+        .with_material(Arc::new(Mutex::new(material)))
+        .build()])
+        .build(&mut scene.graph);
+
+        Self {
+            scene,
+        }
+    }
+}
+
+struct Game {
+    scene: Handle<Scene>,
+}
+
+impl GameState for Game {
+    fn init(engine: &mut Engine) -> Self
+    where
+        Self: Sized,
+    {
+        let scene = fyrox::core::futures::executor::block_on(GameSceneLoader::load_with(
+            engine.resource_manager.clone(),
+        ));
+
+        Game{ scene: engine.scenes.add(scene.scene) }
+    }
+}
+
+fn main() {
+    Framework::<Game>::new()
+        .unwrap()
+        .title("Example 11 - Custom resource loader")
+        .run();
+}

--- a/examples/custom_loop.rs
+++ b/examples/custom_loop.rs
@@ -22,11 +22,12 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example - Custom Game Loop")
         .with_resizable(true);
-            
+
     let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
     // Then initialize the engine.
-    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+    let mut engine =
+        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Define game loop variables.
     let clock = Instant::now();

--- a/examples/custom_loop.rs
+++ b/examples/custom_loop.rs
@@ -22,9 +22,11 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example - Custom Game Loop")
         .with_resizable(true);
+            
+    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
     // Then initialize the engine.
-    let mut engine = Engine::new(window_builder, &event_loop, true).unwrap();
+    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Define game loop variables.
     let clock = Instant::now();

--- a/examples/custom_loop.rs
+++ b/examples/custom_loop.rs
@@ -23,11 +23,11 @@ fn main() {
         .with_title("Example - Custom Game Loop")
         .with_resizable(true);
 
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
 
     // Then initialize the engine.
     let mut engine =
-        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+        Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
 
     // Define game loop variables.
     let clock = Instant::now();

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -114,8 +114,10 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example - User Interface")
         .with_resizable(true);
+        
+    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, &event_loop, true).unwrap();
+    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let interface = create_ui(&mut engine);

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -115,10 +115,10 @@ fn main() {
         .with_title("Example - User Interface")
         .with_resizable(true);
 
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
 
     let mut engine =
-        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+        Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let interface = create_ui(&mut engine);

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -114,10 +114,11 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example - User Interface")
         .with_resizable(true);
-        
+
     let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+    let mut engine =
+        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let interface = create_ui(&mut engine);

--- a/examples/lightmap.rs
+++ b/examples/lightmap.rs
@@ -288,10 +288,10 @@ fn main() {
         .with_title("Example 09 - Lightmap")
         .with_resizable(true);
 
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
 
     let mut engine =
-        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+        Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let window = engine.get_window();

--- a/examples/lightmap.rs
+++ b/examples/lightmap.rs
@@ -287,10 +287,11 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example 09 - Lightmap")
         .with_resizable(true);
-        
+
     let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+    let mut engine =
+        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let window = engine.get_window();

--- a/examples/lightmap.rs
+++ b/examples/lightmap.rs
@@ -287,8 +287,10 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example 09 - Lightmap")
         .with_resizable(true);
+        
+    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, &event_loop, true).unwrap();
+    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let window = engine.get_window();

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -135,8 +135,10 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example 08 - Level of detail")
         .with_resizable(true);
+        
+    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, &event_loop, true).unwrap();
+    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -136,10 +136,10 @@ fn main() {
         .with_title("Example 08 - Level of detail")
         .with_resizable(true);
 
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
 
     let mut engine =
-        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+        Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -135,10 +135,11 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example 08 - Level of detail")
         .with_resizable(true);
-        
+
     let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+    let mut engine =
+        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -143,10 +143,11 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example 12 - Navigation Mesh")
         .with_resizable(true);
-        
+
     let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+    let mut engine =
+        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -144,10 +144,10 @@ fn main() {
         .with_title("Example 12 - Navigation Mesh")
         .with_resizable(true);
 
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
 
     let mut engine =
-        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+        Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -143,8 +143,10 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example 12 - Navigation Mesh")
         .with_resizable(true);
+        
+    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, &event_loop, true).unwrap();
+    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/save_load.rs
+++ b/examples/save_load.rs
@@ -17,17 +17,19 @@
 
 pub mod shared;
 
-use crate::shared::{create_ui, fix_shadows_distance, create_scene_async, Game, GameScene, LocomotionMachine, Player};
-use fyrox::engine::Engine;
-use fyrox::engine::resource_manager::ResourceManager;
+use crate::shared::{
+    create_scene_async, create_ui, fix_shadows_distance, Game, GameScene, LocomotionMachine, Player,
+};
 use fyrox::engine::resource_manager::container::event::ResourceEventBroadcaster;
 use fyrox::engine::resource_manager::loader::model::ModelLoader;
 use fyrox::engine::resource_manager::loader::texture::TextureLoader;
-use fyrox::engine::resource_manager::loader::{ResourceLoader, BoxedLoaderFuture};
+use fyrox::engine::resource_manager::loader::{BoxedLoaderFuture, ResourceLoader};
 use fyrox::engine::resource_manager::options::ImportOptions;
+use fyrox::engine::resource_manager::ResourceManager;
+use fyrox::engine::Engine;
 use fyrox::event_loop::EventLoop;
-use fyrox::resource::model::{ModelImportOptions, Model};
-use fyrox::resource::texture::{TextureImportOptions, Texture};
+use fyrox::resource::model::{Model, ModelImportOptions};
+use fyrox::resource::texture::{Texture, TextureImportOptions};
 use fyrox::scene::SceneLoader;
 use fyrox::{
     core::{
@@ -169,8 +171,16 @@ impl ResourceLoader<Model, ModelImportOptions> for CustomModelLoader {
         let loader = self.0.clone();
 
         Box::pin(async move {
-            println!("CUSTOM LOADER: loading model {:?}", resource.state().path() );
-            loader.load(resource, default_import_options, resource_manager, event_broadcaster, reload).await
+            println!("CUSTOM LOADER: loading model {:?}", resource.state().path());
+            loader
+                .load(
+                    resource,
+                    default_import_options,
+                    resource_manager,
+                    event_broadcaster,
+                    reload,
+                )
+                .await
         })
     }
 }
@@ -190,12 +200,22 @@ impl ResourceLoader<Texture, TextureImportOptions> for CustomTextureLoader {
         let loader = self.0.clone();
 
         Box::pin(async move {
-            println!("CUSTOM LOADER: loading texture {:?}", resource.state().path() );
-            loader.load(resource, default_import_options, resource_manager, event_broadcaster, reload).await
+            println!(
+                "CUSTOM LOADER: loading texture {:?}",
+                resource.state().path()
+            );
+            loader
+                .load(
+                    resource,
+                    default_import_options,
+                    resource_manager,
+                    event_broadcaster,
+                    reload,
+                )
+                .await
         })
     }
 }
-
 
 fn create_game(title: &str) -> (Game, EventLoop<()>) {
     let event_loop = EventLoop::new();
@@ -208,7 +228,8 @@ fn create_game(title: &str) -> (Game, EventLoop<()>) {
         .with_texture_loader(CustomTextureLoader(Arc::new(TextureLoader)))
         .with_model_loader(CustomModelLoader(Arc::new(ModelLoader)));
 
-    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, false).unwrap();
+    let mut engine =
+        Engine::new(window_builder, resource_manager_builder, &event_loop, false).unwrap();
 
     engine
         .renderer

--- a/examples/save_load.rs
+++ b/examples/save_load.rs
@@ -17,19 +17,7 @@
 
 pub mod shared;
 
-use crate::shared::{
-    create_scene_async, create_ui, fix_shadows_distance, Game, GameScene, LocomotionMachine, Player,
-};
-use fyrox::engine::resource_manager::container::event::ResourceEventBroadcaster;
-use fyrox::engine::resource_manager::loader::model::ModelLoader;
-use fyrox::engine::resource_manager::loader::texture::TextureLoader;
-use fyrox::engine::resource_manager::loader::{BoxedLoaderFuture, ResourceLoader};
-use fyrox::engine::resource_manager::options::ImportOptions;
-use fyrox::engine::resource_manager::ResourceManager;
-use fyrox::engine::Engine;
-use fyrox::event_loop::EventLoop;
-use fyrox::resource::model::{Model, ModelImportOptions};
-use fyrox::resource::texture::{Texture, TextureImportOptions};
+use crate::shared::{create_ui, fix_shadows_distance, Game, GameScene, LocomotionMachine, Player};
 use fyrox::scene::SceneLoader;
 use fyrox::{
     core::{
@@ -49,9 +37,7 @@ use fyrox::{
     },
 };
 use fyrox_core::futures::executor::block_on;
-use std::marker::PhantomData;
 use std::path::Path;
-use std::sync::Arc;
 
 // Start implementing Visit trait for simple types which are used by more complex.
 // At first implement trait for LocomotionMachine.
@@ -156,99 +142,8 @@ async fn load(game: &mut Game) {
     }
 }
 
-struct CustomModelLoader(Arc<ModelLoader>);
-
-impl ResourceLoader<Model, ModelImportOptions> for CustomModelLoader {
-    fn load(
-        &self,
-        resource: Model,
-        default_import_options: ModelImportOptions,
-        resource_manager: ResourceManager,
-        event_broadcaster: ResourceEventBroadcaster<Model>,
-        reload: bool,
-    ) -> BoxedLoaderFuture {
-        // cannot borrow self for the async block as BoxedLoaderFuture is 'static due to the task_pool requirements
-        let loader = self.0.clone();
-
-        Box::pin(async move {
-            println!("CUSTOM LOADER: loading model {:?}", resource.state().path());
-            loader
-                .load(
-                    resource,
-                    default_import_options,
-                    resource_manager,
-                    event_broadcaster,
-                    reload,
-                )
-                .await
-        })
-    }
-}
-
-struct CustomTextureLoader(Arc<TextureLoader>);
-
-impl ResourceLoader<Texture, TextureImportOptions> for CustomTextureLoader {
-    fn load(
-        &self,
-        resource: Texture,
-        default_import_options: TextureImportOptions,
-        resource_manager: ResourceManager,
-        event_broadcaster: ResourceEventBroadcaster<Texture>,
-        reload: bool,
-    ) -> BoxedLoaderFuture {
-        // cannot borrow self for the async block as BoxedLoaderFuture is 'static due to the task_pool requirements
-        let loader = self.0.clone();
-
-        Box::pin(async move {
-            println!(
-                "CUSTOM LOADER: loading texture {:?}",
-                resource.state().path()
-            );
-            loader
-                .load(
-                    resource,
-                    default_import_options,
-                    resource_manager,
-                    event_broadcaster,
-                    reload,
-                )
-                .await
-        })
-    }
-}
-
-fn create_game(title: &str) -> (Game, EventLoop<()>) {
-    let event_loop = EventLoop::new();
-
-    let window_builder = fyrox::window::WindowBuilder::new()
-        .with_title(title)
-        .with_resizable(true);
-
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new()
-        .with_texture_loader(CustomTextureLoader(Arc::new(TextureLoader)))
-        .with_model_loader(CustomModelLoader(Arc::new(ModelLoader)));
-
-    let mut engine =
-        Engine::new(window_builder, resource_manager_builder, &event_loop, false).unwrap();
-
-    engine
-        .renderer
-        .set_quality_settings(&fix_shadows_distance(QualitySettings::high()))
-        .unwrap();
-
-    let game = Game {
-        // Initially scene is None, once scene is loaded it'll have actual state.
-        game_scene: None,
-        // Create scene asynchronously - this method immediately returns empty load context
-        // which will be filled with data over time.
-        load_context: Some(create_scene_async(engine.resource_manager.clone())),
-        engine,
-    };
-    (game, event_loop)
-}
-
 fn main() {
-    let (mut game, event_loop) = create_game("Example 06 - Save/load");
+    let (mut game, event_loop) = Game::new("Example 06 - Save/load");
 
     // Create simple user interface that will show some useful info.
     let window = game.engine.get_window();

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -79,10 +79,11 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example - Scene")
         .with_resizable(true);
-        
+
     let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+    let mut engine =
+        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -80,10 +80,10 @@ fn main() {
         .with_title("Example - Scene")
         .with_resizable(true);
 
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
 
     let mut engine =
-        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+        Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -79,8 +79,10 @@ fn main() {
     let window_builder = fyrox::window::WindowBuilder::new()
         .with_title("Example - Scene")
         .with_resizable(true);
+        
+    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, &event_loop, true).unwrap();
+    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -119,9 +119,11 @@ impl Game {
             .with_title(title)
             .with_resizable(true);
 
-        let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+        let resource_manager_builder =
+            fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-        let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, false).unwrap();
+        let mut engine =
+            Engine::new(window_builder, resource_manager_builder, &event_loop, false).unwrap();
 
         engine
             .renderer

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -119,7 +119,9 @@ impl Game {
             .with_title(title)
             .with_resizable(true);
 
-        let mut engine = Engine::new(window_builder, &event_loop, false).unwrap();
+        let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+
+        let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, false).unwrap();
 
         engine
             .renderer

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -119,11 +119,11 @@ impl Game {
             .with_title(title)
             .with_resizable(true);
 
-        let resource_manager_builder =
-            fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+        let resource_manager =
+            fyrox::engine::resource_manager::ResourceManager::new();
 
         let mut engine =
-            Engine::new(window_builder, resource_manager_builder, &event_loop, false).unwrap();
+            Engine::new(window_builder, resource_manager, &event_loop, false).unwrap();
 
         engine
             .renderer

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -335,7 +335,8 @@ fn main() {
 
     let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
 
-    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+    let mut engine =
+        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let interface = create_ui(&mut engine);

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -333,10 +333,10 @@ fn main() {
         .with_title("Example - User Interface")
         .with_resizable(true);
 
-    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
 
     let mut engine =
-        Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
+        Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let interface = create_ui(&mut engine);

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -333,7 +333,9 @@ fn main() {
         .with_title("Example - User Interface")
         .with_resizable(true);
 
-    let mut engine = Engine::new(window_builder, &event_loop, true).unwrap();
+    let resource_manager_builder = fyrox::engine::resource_manager::ResourceManagerBuilder::new();
+
+    let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, true).unwrap();
 
     // Create simple user interface that will show some useful info.
     let interface = create_ui(&mut engine);

--- a/src/engine/framework.rs
+++ b/src/engine/framework.rs
@@ -8,11 +8,11 @@ use crate::gui::message::UiMessage;
 use crate::utils::log::{Log, MessageKind};
 use crate::{
     core::instant::Instant,
-    engine::{error::EngineError, Engine},
+    engine::{error::EngineError, Engine, resource_manager::ResourceManagerBuilder},
     event::{DeviceEvent, DeviceId, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     utils::translate_event,
-    window::WindowBuilder,
+    window::WindowBuilder,    
 };
 
 #[doc(hidden)]
@@ -62,8 +62,9 @@ impl<State: GameState> Framework<State> {
         let event_loop = EventLoop::new();
 
         let window_builder = WindowBuilder::new().with_title("Game").with_resizable(true);
+        let resource_manager_builder = ResourceManagerBuilder::new();
 
-        let mut engine = Engine::new(window_builder, &event_loop, false)?;
+        let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, false)?;
 
         Ok(Self {
             title: "Game".to_owned(),

--- a/src/engine/framework.rs
+++ b/src/engine/framework.rs
@@ -8,7 +8,7 @@ use crate::gui::message::UiMessage;
 use crate::utils::log::{Log, MessageKind};
 use crate::{
     core::instant::Instant,
-    engine::{error::EngineError, resource_manager::ResourceManagerBuilder, Engine},
+    engine::{error::EngineError, resource_manager::ResourceManager, Engine},
     event::{DeviceEvent, DeviceId, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     utils::translate_event,
@@ -62,9 +62,9 @@ impl<State: GameState> Framework<State> {
         let event_loop = EventLoop::new();
 
         let window_builder = WindowBuilder::new().with_title("Game").with_resizable(true);
-        let resource_manager_builder = ResourceManagerBuilder::new();
+        let resource_manager = ResourceManager::new();
 
-        let mut engine = Engine::new(window_builder, resource_manager_builder, &event_loop, false)?;
+        let mut engine = Engine::new(window_builder, resource_manager, &event_loop, false)?;
 
         Ok(Self {
             title: "Game".to_owned(),

--- a/src/engine/framework.rs
+++ b/src/engine/framework.rs
@@ -8,11 +8,11 @@ use crate::gui::message::UiMessage;
 use crate::utils::log::{Log, MessageKind};
 use crate::{
     core::instant::Instant,
-    engine::{error::EngineError, Engine, resource_manager::ResourceManagerBuilder},
+    engine::{error::EngineError, resource_manager::ResourceManagerBuilder, Engine},
     event::{DeviceEvent, DeviceId, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     utils::translate_event,
-    window::WindowBuilder,    
+    window::WindowBuilder,
 };
 
 #[doc(hidden)]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -13,7 +13,9 @@ use crate::{
     core::{algebra::Vector2, instant},
     engine::{
         error::EngineError,
-        resource_manager::{container::event::ResourceEvent, ResourceManager, ResourceManagerBuilder},
+        resource_manager::{
+            container::event::ResourceEvent, ResourceManager, ResourceManagerBuilder,
+        },
     },
     event_loop::EventLoop,
     gui::UserInterface,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     engine::{
         error::EngineError,
         resource_manager::{
-            container::event::ResourceEvent, ResourceManager, ResourceManagerBuilder,
+            container::event::ResourceEvent, ResourceManager,
         },
     },
     event_loop::EventLoop,
@@ -141,20 +141,20 @@ impl Engine {
     /// ```no_run
     /// use fyrox::engine::Engine;
     /// use fyrox::window::WindowBuilder;
-    /// use fyrox::resource_manager::ResourceManagerBuilder;
+    /// use fyrox::resource_manager::ResourceManager;
     /// use fyrox::event_loop::EventLoop;
     ///
     /// let evt = EventLoop::new();
-    /// let resource_manager_builder = WindowBuilder::new()
+    /// let resource_manager = ResourceManager::new();
     /// let window_builder = WindowBuilder::new()
     ///     .with_title("Test")
     ///     .with_fullscreen(None);
-    /// let mut engine: Engine = Engine::new(window_builder, resource_manager_builder, &evt, true).unwrap();
+    /// let mut engine: Engine = Engine::new(window_builder, resource_manager, &evt, true).unwrap();
     /// ```
     #[inline]
     pub fn new(
         window_builder: WindowBuilder,
-        resource_manager_builder: ResourceManagerBuilder,
+        resource_manager: ResourceManager,
         events_loop: &EventLoop<()>,
         #[allow(unused_variables)] vsync: bool,
     ) -> Result<Self, EngineError> {
@@ -218,8 +218,6 @@ impl Engine {
             { unsafe { glow::Context::from_loader_function(|s| context.get_proc_address(s)) } };
 
         let sound_engine = SoundEngine::new();
-
-        let resource_manager = ResourceManager::new(resource_manager_builder);
 
         let renderer = Renderer::new(
             glow_context,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     core::{algebra::Vector2, instant},
     engine::{
         error::EngineError,
-        resource_manager::{container::event::ResourceEvent, ResourceManager},
+        resource_manager::{container::event::ResourceEvent, ResourceManager, ResourceManagerBuilder},
     },
     event_loop::EventLoop,
     gui::UserInterface,
@@ -139,17 +139,20 @@ impl Engine {
     /// ```no_run
     /// use fyrox::engine::Engine;
     /// use fyrox::window::WindowBuilder;
+    /// use fyrox::resource_manager::ResourceManagerBuilder;
     /// use fyrox::event_loop::EventLoop;
     ///
     /// let evt = EventLoop::new();
+    /// let resource_manager_builder = WindowBuilder::new()
     /// let window_builder = WindowBuilder::new()
     ///     .with_title("Test")
     ///     .with_fullscreen(None);
-    /// let mut engine: Engine = Engine::new(window_builder, &evt, true).unwrap();
+    /// let mut engine: Engine = Engine::new(window_builder, resource_manager_builder, &evt, true).unwrap();
     /// ```
     #[inline]
     pub fn new(
         window_builder: WindowBuilder,
+        resource_manager_builder: ResourceManagerBuilder,
         events_loop: &EventLoop<()>,
         #[allow(unused_variables)] vsync: bool,
     ) -> Result<Self, EngineError> {
@@ -214,7 +217,7 @@ impl Engine {
 
         let sound_engine = SoundEngine::new();
 
-        let resource_manager = ResourceManager::new();
+        let resource_manager = ResourceManager::new(resource_manager_builder);
 
         let renderer = Renderer::new(
             glow_context,

--- a/src/engine/resource_manager/container/mod.rs
+++ b/src/engine/resource_manager/container/mod.rs
@@ -12,7 +12,6 @@ use crate::{
         loader::ResourceLoader,
         options::ImportOptions,
         task::TaskPool,
-        ResourceManager,
     },
     scene::variable::TemplateVariable,
     utils::log::Log,
@@ -38,7 +37,6 @@ where
     resources: Vec<TimedEntry<T>>,
     default_import_options: O,
     task_pool: Arc<TaskPool>,
-    resource_manager: ResourceManager,
     loader: Box<dyn ResourceLoader<T, O>>,
 
     /// Event broadcaster can be used to "subscribe" for events happening inside the container.    
@@ -54,17 +52,23 @@ where
 {
     pub(crate) fn new(
         task_pool: Arc<TaskPool>,
-        resource_manager: ResourceManager,
         loader: Box<dyn ResourceLoader<T, O>>,
     ) -> Self {
         Self {
             resources: Default::default(),
             default_import_options: Default::default(),
             task_pool,
-            resource_manager,
             loader,
             event_broadcaster: ResourceEventBroadcaster::new(),
         }
+    }
+
+    /// Sets the loader to load resources with.
+    pub fn set_loader<L>(&mut self, loader: L)
+    where
+        L: 'static + ResourceLoader<T, O>,
+    {
+        self.loader = Box::new(loader);
     }
 
     /// Adds a new resource in the container.
@@ -219,7 +223,6 @@ where
                 self.task_pool.spawn_task(self.loader.load(
                     resource.clone(),
                     self.default_import_options.clone(),
-                    self.resource_manager.clone(),
                     self.event_broadcaster.clone(),
                     false,
                 ));
@@ -236,7 +239,6 @@ where
         self.task_pool.spawn_task(self.loader.load(
             resource,
             self.default_import_options.clone(),
-            self.resource_manager.clone(),
             self.event_broadcaster.clone(),
             true,
         ));
@@ -256,7 +258,6 @@ where
             self.task_pool.spawn_task(self.loader.load(
                 resource,
                 self.default_import_options.clone(),
-                self.resource_manager.clone(),
                 self.event_broadcaster.clone(),
                 true,
             ));

--- a/src/engine/resource_manager/container/mod.rs
+++ b/src/engine/resource_manager/container/mod.rs
@@ -52,7 +52,11 @@ where
     E: ResourceLoadError,
     O: ImportOptions,
 {
-    pub(crate) fn new(task_pool: Arc<TaskPool>, resource_manager: ResourceManager, loader: Box<dyn ResourceLoader<T, O>>) -> Self {
+    pub(crate) fn new(
+        task_pool: Arc<TaskPool>,
+        resource_manager: ResourceManager,
+        loader: Box<dyn ResourceLoader<T, O>>,
+    ) -> Self {
         Self {
             resources: Default::default(),
             default_import_options: Default::default(),

--- a/src/engine/resource_manager/loader/curve.rs
+++ b/src/engine/resource_manager/loader/curve.rs
@@ -1,13 +1,15 @@
+//! Curve loader. 
+
 use crate::{
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
-        ResourceManager,
     },
     resource::curve::{CurveImportOptions, CurveResource, CurveResourceState},
     utils::log::Log,
 };
 
+/// Default implementation for curve loading.
 pub struct CurveLoader;
 
 impl ResourceLoader<CurveResource, CurveImportOptions> for CurveLoader {
@@ -15,7 +17,6 @@ impl ResourceLoader<CurveResource, CurveImportOptions> for CurveLoader {
         &self,
         curve: CurveResource,
         _default_import_options: CurveImportOptions,
-        _resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<CurveResource>,
         reload: bool,
     ) -> BoxedLoaderFuture {

--- a/src/engine/resource_manager/loader/curve.rs
+++ b/src/engine/resource_manager/loader/curve.rs
@@ -2,6 +2,7 @@ use crate::{
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
+        ResourceManager
     },
     resource::curve::{CurveImportOptions, CurveResource, CurveResourceState},
     utils::log::Log,
@@ -10,15 +11,14 @@ use crate::{
 pub struct CurveLoader;
 
 impl ResourceLoader<CurveResource, CurveImportOptions> for CurveLoader {
-    type Output = BoxedLoaderFuture;
-
     fn load(
-        &mut self,
+        &self,
         curve: CurveResource,
         _default_import_options: CurveImportOptions,
+        _resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<CurveResource>,
         reload: bool,
-    ) -> Self::Output {
+    ) -> BoxedLoaderFuture {
         Box::pin(async move {
             let path = curve.state().path().to_path_buf();
 

--- a/src/engine/resource_manager/loader/curve.rs
+++ b/src/engine/resource_manager/loader/curve.rs
@@ -2,7 +2,7 @@ use crate::{
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
-        ResourceManager
+        ResourceManager,
     },
     resource::curve::{CurveImportOptions, CurveResource, CurveResourceState},
     utils::log::Log,

--- a/src/engine/resource_manager/loader/mod.rs
+++ b/src/engine/resource_manager/loader/mod.rs
@@ -1,5 +1,5 @@
 use crate::engine::resource_manager::{
-    container::event::ResourceEventBroadcaster, options::ImportOptions, ResourceManager
+    container::event::ResourceEventBroadcaster, options::ImportOptions, ResourceManager,
 };
 use std::{future::Future, pin::Pin};
 
@@ -27,7 +27,6 @@ where
         reload: bool,
     ) -> BoxedLoaderFuture;
 }
-
 
 #[cfg(not(target_arch = "wasm32"))]
 pub type BoxedLoaderFuture = Pin<Box<dyn Future<Output = ()> + Send>>;

--- a/src/engine/resource_manager/loader/mod.rs
+++ b/src/engine/resource_manager/loader/mod.rs
@@ -1,5 +1,7 @@
+//! Resource loader. It manages resource loading.
+
 use crate::engine::resource_manager::{
-    container::event::ResourceEventBroadcaster, options::ImportOptions, ResourceManager,
+    container::event::ResourceEventBroadcaster, options::ImportOptions,
 };
 use std::{future::Future, pin::Pin};
 
@@ -9,39 +11,43 @@ pub mod shader;
 pub mod sound;
 pub mod texture;
 
+/// Future type for resource loading. See 'ResourceLoader'.
 #[cfg(target_arch = "wasm32")]
 pub type BoxedLoaderFuture = Pin<Box<dyn Future<Output = ()>>>;
 
+/// Trait for resource loading.
 #[cfg(target_arch = "wasm32")]
 pub trait ResourceLoader<T, O>
 where
     T: Clone,
     O: ImportOptions,
 {
+    /// Loads or reloads a resource.
     fn load(
         &self,
         resource: T,
         default_import_options: O,
-        resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<T>,
         reload: bool,
     ) -> BoxedLoaderFuture;
 }
 
+/// Future type for resource loading. See 'ResourceLoader'.
 #[cfg(not(target_arch = "wasm32"))]
 pub type BoxedLoaderFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
+/// Trait for resource loading.
 #[cfg(not(target_arch = "wasm32"))]
 pub trait ResourceLoader<T, O>: Send
 where
     T: Clone,
     O: ImportOptions,
 {
+    /// Loads or reloads a resource.
     fn load(
         &self,
         resource: T,
         default_import_options: O,
-        resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<T>,
         reload: bool,
     ) -> BoxedLoaderFuture;

--- a/src/engine/resource_manager/loader/model.rs
+++ b/src/engine/resource_manager/loader/model.rs
@@ -1,3 +1,5 @@
+//! Model loader. 
+
 use crate::{
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
@@ -9,17 +11,22 @@ use crate::{
     utils::log::Log,
 };
 
-pub struct ModelLoader;
+/// Default implementation for model loading.
+pub struct ModelLoader {
+    /// Resource manager to allow complex model loading.
+    pub resource_manager: ResourceManager,
+}
 
 impl ResourceLoader<Model, ModelImportOptions> for ModelLoader {
     fn load(
         &self,
         model: Model,
         default_import_options: ModelImportOptions,
-        resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<Model>,
         reload: bool,
     ) -> BoxedLoaderFuture {
+        let resource_manager = self.resource_manager.clone();
+
         Box::pin(async move {
             let path = model.state().path().to_path_buf();
 

--- a/src/engine/resource_manager/loader/model.rs
+++ b/src/engine/resource_manager/loader/model.rs
@@ -9,22 +9,17 @@ use crate::{
     utils::log::Log,
 };
 
-pub struct ModelLoader {
-    pub resource_manager: ResourceManager,
-}
+pub struct ModelLoader;
 
 impl ResourceLoader<Model, ModelImportOptions> for ModelLoader {
-    type Output = BoxedLoaderFuture;
-
     fn load(
-        &mut self,
+        &self,
         model: Model,
         default_import_options: ModelImportOptions,
+        resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<Model>,
         reload: bool,
-    ) -> Self::Output {
-        let resource_manager = self.resource_manager.clone();
-
+    ) -> BoxedLoaderFuture {
         Box::pin(async move {
             let path = model.state().path().to_path_buf();
 

--- a/src/engine/resource_manager/loader/shader.rs
+++ b/src/engine/resource_manager/loader/shader.rs
@@ -2,7 +2,7 @@ use crate::{
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
-        ResourceManager
+        ResourceManager,
     },
     material::shader::{Shader, ShaderImportOptions, ShaderState},
     utils::log::Log,

--- a/src/engine/resource_manager/loader/shader.rs
+++ b/src/engine/resource_manager/loader/shader.rs
@@ -2,6 +2,7 @@ use crate::{
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
+        ResourceManager
     },
     material::shader::{Shader, ShaderImportOptions, ShaderState},
     utils::log::Log,
@@ -10,15 +11,14 @@ use crate::{
 pub struct ShaderLoader;
 
 impl ResourceLoader<Shader, ShaderImportOptions> for ShaderLoader {
-    type Output = BoxedLoaderFuture;
-
     fn load(
-        &mut self,
+        &self,
         shader: Shader,
         _default_import_options: ShaderImportOptions,
+        _resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<Shader>,
         reload: bool,
-    ) -> Self::Output {
+    ) -> BoxedLoaderFuture {
         Box::pin(async move {
             let path = shader.state().path().to_path_buf();
 

--- a/src/engine/resource_manager/loader/shader.rs
+++ b/src/engine/resource_manager/loader/shader.rs
@@ -1,13 +1,15 @@
+//! Shader loader. 
+
 use crate::{
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
-        ResourceManager,
     },
     material::shader::{Shader, ShaderImportOptions, ShaderState},
     utils::log::Log,
 };
 
+/// Default implementation for shader loading.
 pub struct ShaderLoader;
 
 impl ResourceLoader<Shader, ShaderImportOptions> for ShaderLoader {
@@ -15,7 +17,6 @@ impl ResourceLoader<Shader, ShaderImportOptions> for ShaderLoader {
         &self,
         shader: Shader,
         _default_import_options: ShaderImportOptions,
-        _resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<Shader>,
         reload: bool,
     ) -> BoxedLoaderFuture {

--- a/src/engine/resource_manager/loader/sound.rs
+++ b/src/engine/resource_manager/loader/sound.rs
@@ -4,6 +4,7 @@ use crate::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
         options::{try_get_import_settings, ImportOptions},
+        ResourceManager
     },
     utils::log::Log,
 };
@@ -24,15 +25,14 @@ impl ImportOptions for SoundBufferImportOptions {}
 pub struct SoundBufferLoader;
 
 impl ResourceLoader<SoundBufferResource, SoundBufferImportOptions> for SoundBufferLoader {
-    type Output = BoxedLoaderFuture;
-
     fn load(
-        &mut self,
+        &self,
         resource: SoundBufferResource,
         default_import_options: SoundBufferImportOptions,
+        _resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<SoundBufferResource>,
         reload: bool,
-    ) -> Self::Output {
+    ) -> BoxedLoaderFuture {
         Box::pin(async move {
             let path = resource.state().path().to_path_buf();
 

--- a/src/engine/resource_manager/loader/sound.rs
+++ b/src/engine/resource_manager/loader/sound.rs
@@ -1,10 +1,11 @@
+//! Sound buffer loader. 
+
 use crate::{
     core::inspect::{Inspect, PropertyInfo},
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
         options::{try_get_import_settings, ImportOptions},
-        ResourceManager,
     },
     utils::log::Log,
 };
@@ -22,6 +23,7 @@ pub struct SoundBufferImportOptions {
 
 impl ImportOptions for SoundBufferImportOptions {}
 
+/// Default implementation for sound buffer loading.
 pub struct SoundBufferLoader;
 
 impl ResourceLoader<SoundBufferResource, SoundBufferImportOptions> for SoundBufferLoader {
@@ -29,7 +31,6 @@ impl ResourceLoader<SoundBufferResource, SoundBufferImportOptions> for SoundBuff
         &self,
         resource: SoundBufferResource,
         default_import_options: SoundBufferImportOptions,
-        _resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<SoundBufferResource>,
         reload: bool,
     ) -> BoxedLoaderFuture {

--- a/src/engine/resource_manager/loader/sound.rs
+++ b/src/engine/resource_manager/loader/sound.rs
@@ -4,7 +4,7 @@ use crate::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
         options::{try_get_import_settings, ImportOptions},
-        ResourceManager
+        ResourceManager,
     },
     utils::log::Log,
 };

--- a/src/engine/resource_manager/loader/texture.rs
+++ b/src/engine/resource_manager/loader/texture.rs
@@ -1,15 +1,17 @@
+//! Texture loader. 
+
 use crate::{
     core::instant,
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
         options::try_get_import_settings,
-        ResourceManager,
     },
     resource::texture::{Texture, TextureData, TextureImportOptions},
     utils::log::Log,
 };
 
+/// Default implementation for texture loading.
 pub struct TextureLoader;
 
 impl ResourceLoader<Texture, TextureImportOptions> for TextureLoader {
@@ -17,7 +19,6 @@ impl ResourceLoader<Texture, TextureImportOptions> for TextureLoader {
         &self,
         texture: Texture,
         default_import_options: TextureImportOptions,
-        _resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<Texture>,
         reload: bool,
     ) -> BoxedLoaderFuture {

--- a/src/engine/resource_manager/loader/texture.rs
+++ b/src/engine/resource_manager/loader/texture.rs
@@ -4,7 +4,7 @@ use crate::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
         options::try_get_import_settings,
-        ResourceManager
+        ResourceManager,
     },
     resource::texture::{Texture, TextureData, TextureImportOptions},
     utils::log::Log,

--- a/src/engine/resource_manager/loader/texture.rs
+++ b/src/engine/resource_manager/loader/texture.rs
@@ -4,6 +4,7 @@ use crate::{
         container::event::ResourceEventBroadcaster,
         loader::{BoxedLoaderFuture, ResourceLoader},
         options::try_get_import_settings,
+        ResourceManager
     },
     resource::texture::{Texture, TextureData, TextureImportOptions},
     utils::log::Log,
@@ -12,15 +13,14 @@ use crate::{
 pub struct TextureLoader;
 
 impl ResourceLoader<Texture, TextureImportOptions> for TextureLoader {
-    type Output = BoxedLoaderFuture;
-
     fn load(
-        &mut self,
+        &self,
         texture: Texture,
         default_import_options: TextureImportOptions,
+        _resource_manager: ResourceManager,
         event_broadcaster: ResourceEventBroadcaster<Texture>,
         reload: bool,
-    ) -> Self::Output {
+    ) -> BoxedLoaderFuture {
         Box::pin(async move {
             let path = texture.state().path().to_path_buf();
 

--- a/src/engine/resource_manager/mod.rs
+++ b/src/engine/resource_manager/mod.rs
@@ -45,8 +45,7 @@ pub struct ContainersStorage {
     pub models: ResourceContainer<Model, ModelImportOptions>,
 
     /// Container for sound buffer resources.
-    pub sound_buffers:
-        ResourceContainer<SoundBufferResource, SoundBufferImportOptions>,
+    pub sound_buffers: ResourceContainer<SoundBufferResource, SoundBufferImportOptions>,
 
     /// Container for shader resources.
     pub shaders: ResourceContainer<Shader, ShaderImportOptions>,
@@ -76,42 +75,47 @@ impl ResourceManagerBuilder {
 
     #[must_use]
     pub fn with_texture_loader<L>(mut self, loader: L) -> Self
-    where L : 'static + ResourceLoader<Texture, TextureImportOptions> {
+    where
+        L: 'static + ResourceLoader<Texture, TextureImportOptions>,
+    {
         self.texture_loader = Box::new(loader);
         self
-
     }
 
     #[must_use]
     pub fn with_model_loader<L>(mut self, loader: L) -> Self
-    where L : 'static + ResourceLoader<Model, ModelImportOptions> {
+    where
+        L: 'static + ResourceLoader<Model, ModelImportOptions>,
+    {
         self.model_loader = Box::new(loader);
         self
-
     }
 
     #[must_use]
     pub fn with_sound_buffer_loader<L>(mut self, loader: L) -> Self
-    where L : 'static + ResourceLoader<SoundBufferResource, SoundBufferImportOptions> {
+    where
+        L: 'static + ResourceLoader<SoundBufferResource, SoundBufferImportOptions>,
+    {
         self.sound_buffer_loader = Box::new(loader);
         self
-
     }
 
     #[must_use]
     pub fn with_shader_loader<L>(mut self, loader: L) -> Self
-    where L : 'static + ResourceLoader<Shader, ShaderImportOptions> {
+    where
+        L: 'static + ResourceLoader<Shader, ShaderImportOptions>,
+    {
         self.shader_loader = Box::new(loader);
         self
-
     }
 
     #[must_use]
     pub fn with_curve_loader<L>(mut self, loader: L) -> Self
-    where L : 'static + ResourceLoader<CurveResource, CurveImportOptions> {
+    where
+        L: 'static + ResourceLoader<CurveResource, CurveImportOptions>,
+    {
         self.curve_loader = Box::new(loader);
         self
-
     }
 }
 
@@ -156,11 +160,31 @@ impl ResourceManager {
         let task_pool = Arc::new(TaskPool::new());
 
         resource_manager.state().containers_storage = Some(ContainersStorage {
-            textures: ResourceContainer::new(task_pool.clone(), resource_manager.clone(), builder.texture_loader),
-            models: ResourceContainer::new(task_pool.clone(), resource_manager.clone(), builder.model_loader),
-            sound_buffers: ResourceContainer::new(task_pool.clone(), resource_manager.clone(), builder.sound_buffer_loader),
-            shaders: ResourceContainer::new(task_pool.clone(), resource_manager.clone(), builder.shader_loader),
-            curves: ResourceContainer::new(task_pool, resource_manager.clone(), builder.curve_loader),
+            textures: ResourceContainer::new(
+                task_pool.clone(),
+                resource_manager.clone(),
+                builder.texture_loader,
+            ),
+            models: ResourceContainer::new(
+                task_pool.clone(),
+                resource_manager.clone(),
+                builder.model_loader,
+            ),
+            sound_buffers: ResourceContainer::new(
+                task_pool.clone(),
+                resource_manager.clone(),
+                builder.sound_buffer_loader,
+            ),
+            shaders: ResourceContainer::new(
+                task_pool.clone(),
+                resource_manager.clone(),
+                builder.shader_loader,
+            ),
+            curves: ResourceContainer::new(
+                task_pool,
+                resource_manager.clone(),
+                builder.curve_loader,
+            ),
         });
 
         resource_manager


### PR DESCRIPTION
The loaders for the resources can be customized when the engine is created:
- Engine requires the ResourceManager to be created explicitly.
- The default loader and ResourceLoader traits were made public
- Some minor API changes were made on the ResourceLoader to easy its usage
  - removed the associated Future type
  -  `&self` instead of `&mut self`
  - Send for not wasm targets
  
A new example was added. Later it could be improved to add real loader (ex load model from other file formats)

It seems as this is only a first step because the resource data (ModelData, TextureData etc.) has no functionality yet to create them "by hand".

A next step could be to move the fbx loader into it's own crate and it'd prove that complex scene can be loaded without the need of any internals of the engine. But it requires some refactor - I don't see yet -  to avoid a circular dependency (engine depends on fbx to enable the loader, and fbx depends on engine for the scene features).