### PR TITLE
Add FontBuilder

### DIFF
--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -72,7 +72,7 @@ use crate::{
         UiMessage,
     },
     popup::{Placement, PopupMessage},
-    ttf::{Font, SharedFont},
+    ttf::{Font, FontBuilder, SharedFont},
     widget::{Widget, WidgetBuilder, WidgetMessage},
 };
 use copypasta::ClipboardContext;
@@ -83,10 +83,7 @@ use std::{
     collections::VecDeque,
     fmt::Debug,
     ops::{Deref, DerefMut, Index, IndexMut},
-    sync::{
-        mpsc::{self, Receiver, Sender, TryRecvError},
-        Arc, Mutex,
-    },
+    sync::mpsc::{self, Receiver, Sender, TryRecvError},
 };
 
 // TODO: Make this part of UserInterface struct.
@@ -531,11 +528,8 @@ pub struct UserInterface {
 }
 
 lazy_static! {
-    pub static ref DEFAULT_FONT: SharedFont = {
-        let font_bytes = std::include_bytes!("./built_in_font.ttf").to_vec();
-        let font = Font::from_memory(font_bytes, 16.0, Font::default_char_set()).unwrap();
-        Arc::new(Mutex::new(font)).into()
-    };
+    pub static ref DEFAULT_FONT: SharedFont =
+        SharedFont::new(FontBuilder::new().build_builtin().unwrap());
 }
 
 fn draw_node(


### PR DESCRIPTION
I wanted to make the default font size a little bigger because I had trouble reading it on my screen. I searched the discord and there didn't seem to be a good way to do it yet.

I decided the best way would be to make a `FontBuilder` that also encapsulates the idea of the `DEFAULT_FONT`.

This isn't a general solution to the issue of dynamic font size changes, and font atlases etc. but it might lower the barrier to getting started.

I also changed `Font:: from_memory` to take `Deref<Target = [u8]>` so you don't need to copy it into a `Vec` if you already have the slice. I don't think this will break existing code, but it may give a clippy warning (if they use it) telling them they don't need to call `.into()`.