### PR TITLE
Add custom plugins and scripting

### DIFF
--- a/.idea/rg3d-core.iml
+++ b/.idea/rg3d-core.iml
@@ -26,6 +26,7 @@
       <sourceFolder url="file://$MODULE_DIR$/fyrox-sound/examples" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/fyrox-sound/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/fyrox-ui/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/examples/scripting/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/examples/wasm/target" />
     </content>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/examples/scripting" vcs="Git" />
   </component>
 </project>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "fyrox-ui",
     "fyrox-resource",
     "examples/wasm",
+    "examples/scripting",
 	"editor"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ fxhash = "0.2.1"
 strum = "0.23.0"
 strum_macros = "0.23.1"
 notify = "4.0"
+libloading = "0.7.3"
 
 [features]
 enable_profiler = ["fyrox-core/enable_profiler"]

--- a/editor/src/inspector/editors/handle.rs
+++ b/editor/src/inspector/editors/handle.rs
@@ -2,6 +2,7 @@ use crate::{
     world::graph::item::SceneItem, Message, UiMessage, UiNode, UserInterface, VerticalAlignment,
 };
 use fyrox::gui::button::ButtonMessage;
+use fyrox::gui::inspector::editors::PropertyEditorTranslationContext;
 use fyrox::{
     core::pool::Handle,
     gui::{
@@ -291,19 +292,14 @@ impl<T: 'static> PropertyEditorDefinition for HandlePropertyEditorDefinition<T> 
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
             if let Some(HandlePropertyEditorMessage::Value(value)) =
-                message.data::<HandlePropertyEditorMessage<T>>()
+                ctx.message.data::<HandlePropertyEditorMessage<T>>()
             {
                 return Some(PropertyChanged {
-                    owner_type_id,
-                    name: name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
+                    name: ctx.name.to_string(),
                     value: FieldKind::object(*value),
                 });
             }

--- a/editor/src/inspector/editors/material.rs
+++ b/editor/src/inspector/editors/material.rs
@@ -1,4 +1,5 @@
 use crate::Message;
+use fyrox::gui::inspector::editors::PropertyEditorTranslationContext;
 use fyrox::{
     asset::core::pool::Handle,
     core::parking_lot::Mutex,
@@ -165,12 +166,7 @@ impl PropertyEditorDefinition for MaterialPropertyEditorDefinition {
         Ok(None)
     }
 
-    fn translate_message(
-        &self,
-        _name: &str,
-        _owner_type_id: TypeId,
-        _message: &UiMessage,
-    ) -> Option<PropertyChanged> {
+    fn translate_message(&self, _ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
         None
     }
 }

--- a/editor/src/inspector/editors/mod.rs
+++ b/editor/src/inspector/editors/mod.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::script::ScriptPropertyEditorDefinition;
 use crate::{
     inspector::editors::{
         handle::HandlePropertyEditorDefinition,
@@ -57,6 +58,7 @@ use std::{rc::Rc, sync::mpsc::Sender};
 pub mod handle;
 pub mod material;
 pub mod resource;
+pub mod script;
 pub mod texture;
 
 pub fn make_status_enum_editor_definition() -> EnumPropertyEditorDefinition<Status> {
@@ -137,6 +139,7 @@ pub fn make_property_editors_container(
     container.insert(EnumPropertyEditorDefinition::<MaterialSearchOptions>::new());
     container.insert(EnumPropertyEditorDefinition::<DistanceModel>::new());
     container.insert(EnumPropertyEditorDefinition::<sound::Renderer>::new());
+    container.insert(ScriptPropertyEditorDefinition {});
 
     Rc::new(container)
 }

--- a/editor/src/inspector/editors/resource.rs
+++ b/editor/src/inspector/editors/resource.rs
@@ -1,4 +1,5 @@
 use crate::{asset::item::AssetItem, inspector::EditorEnvironment, load_image};
+use fyrox::gui::inspector::editors::PropertyEditorTranslationContext;
 use fyrox::{
     asset::{Resource, ResourceData, ResourceLoadError},
     core::{futures::executor::block_on, make_relative_path, pool::Handle},
@@ -75,12 +76,7 @@ impl PropertyEditorDefinition for ModelResourcePropertyEditorDefinition {
         )))
     }
 
-    fn translate_message(
-        &self,
-        _name: &str,
-        _owner_type_id: TypeId,
-        _message: &UiMessage,
-    ) -> Option<PropertyChanged> {
+    fn translate_message(&self, _ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
         None
     }
 }
@@ -284,19 +280,14 @@ impl PropertyEditorDefinition for SoundBufferResourcePropertyEditorDefinition {
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
             if let Some(SoundBufferFieldMessage::Value(value)) =
-                message.data::<SoundBufferFieldMessage>()
+                ctx.message.data::<SoundBufferFieldMessage>()
             {
                 return Some(PropertyChanged {
-                    owner_type_id,
-                    name: name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
+                    name: ctx.name.to_string(),
                     value: FieldKind::object(value.clone()),
                 });
             }

--- a/editor/src/inspector/editors/script.rs
+++ b/editor/src/inspector/editors/script.rs
@@ -182,15 +182,24 @@ fn create_items(
     definition_containers: &[Arc<ScriptDefinitionStorage>],
     ctx: &mut BuildContext,
 ) -> Vec<Handle<UiNode>> {
-    definition_containers
-        .iter()
-        .flat_map(|c| c.iter())
-        .map(|d| {
-            let item = make_dropdown_list_option(ctx, &d.name);
-            ctx[item].user_data = Some(Rc::new(d.type_uuid.clone()));
-            item
-        })
-        .collect()
+    let mut items = vec![{
+        let empty = make_dropdown_list_option(ctx, "<No Script>");
+        ctx[empty].user_data = Some(Rc::new(Uuid::default()));
+        empty
+    }];
+
+    items.extend(
+        definition_containers
+            .iter()
+            .flat_map(|c| c.iter())
+            .map(|d| {
+                let item = make_dropdown_list_option(ctx, &d.name);
+                ctx[item].user_data = Some(Rc::new(d.type_uuid.clone()));
+                item
+            }),
+    );
+
+    items
 }
 
 fn selected_script(
@@ -247,7 +256,7 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
         let items = create_items(&environment.script_definitions, ctx.build_context);
 
         let variant_selector = DropdownListBuilder::new(WidgetBuilder::new())
-            .with_opt_selected(selected_script(&environment.script_definitions, value))
+            .with_selected(selected_script(&environment.script_definitions, value).unwrap_or(0))
             .with_items(items)
             .build(ctx.build_context);
 

--- a/editor/src/inspector/editors/script.rs
+++ b/editor/src/inspector/editors/script.rs
@@ -1,30 +1,47 @@
-use crate::{inspector::EditorEnvironment, DropdownListBuilder};
+use crate::{gui::make_dropdown_list_option, inspector::EditorEnvironment, DropdownListBuilder};
+use fyrox::gui::inspector::{Inspector, InspectorMessage};
 use fyrox::{
-    core::pool::Handle,
+    core::{pool::Handle, uuid::Uuid},
     gui::{
+        define_constructor,
+        dropdown_list::{DropdownList, DropdownListMessage},
         inspector::{
             editors::{
-                PropertyEditorBuildContext, PropertyEditorDefinition, PropertyEditorInstance,
+                PropertyEditorBuildContext, PropertyEditorDefinition,
+                PropertyEditorDefinitionContainer, PropertyEditorInstance,
                 PropertyEditorMessageContext,
             },
-            make_expander_container, InspectorEnvironment, InspectorError, PropertyChanged,
+            make_expander_container, FieldKind, InspectorBuilder, InspectorContext,
+            InspectorEnvironment, InspectorError, PropertyChanged,
         },
-        message::UiMessage,
+        message::{MessageDirection, UiMessage},
         widget::{Widget, WidgetBuilder},
         BuildContext, Control, UiNode, UserInterface,
     },
-    script::Script,
+    script::{Script, ScriptDefinitionStorage},
 };
 use std::{
     any::{Any, TypeId},
     ops::{Deref, DerefMut},
     rc::Rc,
+    sync::Arc,
 };
+
+#[derive(Debug, PartialEq)]
+pub enum ScriptPropertyEditorMessage {
+    Value(Option<Uuid>),
+}
+
+impl ScriptPropertyEditorMessage {
+    define_constructor!(ScriptPropertyEditorMessage:Value => fn value(Option<Uuid>), layout: false);
+}
 
 #[derive(Clone, Debug)]
 pub struct ScriptPropertyEditor {
     widget: Widget,
+    inspector: Handle<UiNode>,
     variant_selector: Handle<UiNode>,
+    selected_script_uuid: Option<Uuid>,
 }
 
 impl Deref for ScriptPropertyEditor {
@@ -51,7 +68,44 @@ impl Control for ScriptPropertyEditor {
     }
 
     fn handle_routed_message(&mut self, ui: &mut UserInterface, message: &mut UiMessage) {
-        self.widget.handle_routed_message(ui, message)
+        self.widget.handle_routed_message(ui, message);
+
+        if let Some(ScriptPropertyEditorMessage::Value(id)) = message.data() {
+            if message.destination() == self.handle()
+                && message.direction() == MessageDirection::ToWidget
+            {
+                if self.selected_script_uuid != id.clone() {
+                    self.selected_script_uuid = id.clone();
+                    ui.send_message(message.reverse());
+                }
+            }
+        }
+    }
+
+    fn preview_message(&self, ui: &UserInterface, message: &mut UiMessage) {
+        if let Some(DropdownListMessage::SelectionChanged(Some(i))) = message.data() {
+            if message.destination() == self.variant_selector
+                && message.direction() == MessageDirection::FromWidget
+            {
+                let selected_item = ui
+                    .node(self.variant_selector)
+                    .cast::<DropdownList>()
+                    .expect("Must be DropdownList")
+                    .items()[*i];
+
+                let new_selected_script_uuid = ui
+                    .node(selected_item)
+                    .user_data_ref::<Uuid>()
+                    .expect("Must be script UUID")
+                    .clone();
+
+                ui.send_message(ScriptPropertyEditorMessage::value(
+                    self.handle(),
+                    MessageDirection::ToWidget,
+                    Some(new_selected_script_uuid),
+                ));
+            }
+        }
     }
 }
 
@@ -61,13 +115,10 @@ pub struct ScriptPropertyEditorBuilder {
 
 fn get_editor_environment(
     environment: &Option<Rc<dyn InspectorEnvironment>>,
-) -> &EditorEnvironment {
+) -> Option<&EditorEnvironment> {
     environment
         .as_ref()
-        .unwrap()
-        .as_any()
-        .downcast_ref::<EditorEnvironment>()
-        .unwrap()
+        .and_then(|e| e.as_any().downcast_ref::<EditorEnvironment>())
 }
 
 impl ScriptPropertyEditorBuilder {
@@ -75,12 +126,92 @@ impl ScriptPropertyEditorBuilder {
         Self { widget_builder }
     }
 
-    pub fn build(self, variant_selector: Handle<UiNode>, ctx: &mut BuildContext) -> Handle<UiNode> {
+    pub fn build(
+        self,
+        variant_selector: Handle<UiNode>,
+        script_uuid: Option<Uuid>,
+        environment: Option<Rc<dyn InspectorEnvironment>>,
+        sync_flag: u64,
+        layer_index: usize,
+        script: &Option<Script>,
+        definition_container: Rc<PropertyEditorDefinitionContainer>,
+        ctx: &mut BuildContext,
+    ) -> Handle<UiNode> {
+        let context = script.as_ref().map(|script| {
+            InspectorContext::from_object(
+                script,
+                ctx,
+                definition_container,
+                environment,
+                sync_flag,
+                layer_index,
+            )
+        });
+
+        let inspector = InspectorBuilder::new(WidgetBuilder::new())
+            .with_opt_context(context)
+            .build(ctx);
+
         ctx.add_node(UiNode::new(ScriptPropertyEditor {
-            widget: self.widget_builder.build(),
+            widget: self
+                .widget_builder
+                .with_preview_messages(true)
+                .with_child(inspector)
+                .build(),
+            selected_script_uuid: script_uuid,
             variant_selector,
+            inspector,
         }))
     }
+}
+
+fn create_items(
+    definition_containers: &[Arc<ScriptDefinitionStorage>],
+    ctx: &mut BuildContext,
+) -> Vec<Handle<UiNode>> {
+    definition_containers
+        .iter()
+        .flat_map(|c| c.iter())
+        .map(|d| {
+            let item = make_dropdown_list_option(ctx, &d.name);
+            ctx[item].user_data = Some(Rc::new(d.type_uuid.clone()));
+            item
+        })
+        .collect()
+}
+
+fn selected_script(
+    definition_containers: &[Arc<ScriptDefinitionStorage>],
+    value: &Option<Script>,
+) -> Option<usize> {
+    value.as_ref().and_then(|s| {
+        definition_containers
+            .iter()
+            .flat_map(|c| c.iter())
+            .position(|d| d.type_uuid == s.type_uuid())
+    })
+}
+
+fn fetch_script_definitions(
+    instance: Handle<UiNode>,
+    ui: &mut UserInterface,
+) -> Option<Vec<Handle<UiNode>>> {
+    let instance_ref = ui
+        .node(instance)
+        .cast::<ScriptPropertyEditor>()
+        .expect("Must be ScriptPropertyEditor!");
+
+    let environment = ui
+        .node(instance_ref.inspector)
+        .cast::<Inspector>()
+        .expect("Must be Inspector!")
+        .context()
+        .environment
+        .clone();
+
+    let editor_environment = get_editor_environment(&environment);
+
+    editor_environment.map(|e| create_items(&e.script_definitions, &mut ui.build_ctx()))
 }
 
 #[derive(Debug)]
@@ -97,8 +228,15 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
     ) -> Result<PropertyEditorInstance, InspectorError> {
         let value = ctx.property_info.cast_value::<Option<Script>>()?;
 
-        let variant_selector =
-            DropdownListBuilder::new(WidgetBuilder::new()).build(ctx.build_context);
+        let environment =
+            get_editor_environment(&ctx.environment).expect("Must have editor environment!");
+
+        let items = create_items(&environment.script_definitions, ctx.build_context);
+
+        let variant_selector = DropdownListBuilder::new(WidgetBuilder::new())
+            .with_opt_selected(selected_script(&environment.script_definitions, value))
+            .with_items(items)
+            .build(ctx.build_context);
 
         let editor;
         let container = make_expander_container(
@@ -106,8 +244,16 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
             ctx.property_info.display_name,
             variant_selector,
             {
-                editor = ScriptPropertyEditorBuilder::new(WidgetBuilder::new())
-                    .build(variant_selector, ctx.build_context);
+                editor = ScriptPropertyEditorBuilder::new(WidgetBuilder::new()).build(
+                    variant_selector,
+                    value.as_ref().map(|s| s.type_uuid()),
+                    ctx.environment.clone(),
+                    ctx.sync_flag,
+                    ctx.layer_index,
+                    value,
+                    ctx.definition_container.clone(),
+                    ctx.build_context,
+                );
                 editor
             },
             ctx.build_context,
@@ -120,7 +266,91 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
         &self,
         ctx: PropertyEditorMessageContext,
     ) -> Result<Option<UiMessage>, InspectorError> {
-        Ok(None)
+        let value = ctx.property_info.cast_value::<Option<Script>>()?;
+
+        let new_script_definitions_items = fetch_script_definitions(ctx.instance, ctx.ui);
+
+        let instance_ref = ctx
+            .ui
+            .node(ctx.instance)
+            .cast::<ScriptPropertyEditor>()
+            .expect("Must be EnumPropertyEditor!");
+
+        let environment = ctx
+            .ui
+            .node(instance_ref.inspector)
+            .cast::<Inspector>()
+            .expect("Must be Inspector!")
+            .context()
+            .environment
+            .clone();
+
+        let editor_environment = get_editor_environment(&environment);
+
+        let variant_selector_ref = ctx
+            .ui
+            .node(instance_ref.variant_selector)
+            .cast::<DropdownList>()
+            .expect("Must be a DropDownList");
+
+        // Script list might change over time if some plugins were reloaded.
+        if Some(variant_selector_ref.items().len())
+            != editor_environment
+                .map(|e| e.script_definitions.iter().flat_map(|c| c.iter()).count())
+        {
+            if let Some(items) = new_script_definitions_items {
+                ctx.ui.send_message(DropdownListMessage::items(
+                    instance_ref.variant_selector,
+                    MessageDirection::ToWidget,
+                    items,
+                ));
+                ctx.ui.send_message(ScriptPropertyEditorMessage::value(
+                    ctx.instance,
+                    MessageDirection::ToWidget,
+                    value.as_ref().map(|s| s.type_uuid()).clone(),
+                ))
+            }
+        }
+
+        if instance_ref.selected_script_uuid != value.as_ref().map(|s| s.type_uuid()) {
+            ctx.ui.send_message(ScriptPropertyEditorMessage::value(
+                ctx.instance,
+                MessageDirection::ToWidget,
+                value.as_ref().map(|s| s.type_uuid()).clone(),
+            ));
+
+            let inspector = instance_ref.inspector;
+
+            let context = InspectorContext::from_object(
+                value,
+                &mut ctx.ui.build_ctx(),
+                ctx.definition_container.clone(),
+                environment,
+                ctx.sync_flag,
+                ctx.layer_index + 1,
+            );
+
+            Ok(Some(InspectorMessage::context(
+                inspector,
+                MessageDirection::ToWidget,
+                context,
+            )))
+        } else {
+            let layer_index = ctx.layer_index;
+            let inspector_ctx = ctx
+                .ui
+                .node(instance_ref.inspector)
+                .cast::<Inspector>()
+                .expect("Must be Inspector!")
+                .context()
+                .clone();
+
+            if let Err(e) = inspector_ctx.sync(value, ctx.ui, layer_index + 1) {
+                Err(InspectorError::Group(e))
+            } else {
+                Ok(None)
+            }
+        }
     }
 
     fn translate_message(
@@ -129,6 +359,15 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
         owner_type_id: TypeId,
         message: &UiMessage,
     ) -> Option<PropertyChanged> {
+        if message.direction() == MessageDirection::FromWidget {
+            if let Some(ScriptPropertyEditorMessage::Value(value)) = message.data() {
+                return Some(PropertyChanged {
+                    owner_type_id,
+                    name: name.to_string(),
+                    value: FieldKind::object(value.clone()),
+                });
+            }
+        }
         None
     }
 }

--- a/editor/src/inspector/editors/script.rs
+++ b/editor/src/inspector/editors/script.rs
@@ -1,0 +1,134 @@
+use crate::{inspector::EditorEnvironment, DropdownListBuilder};
+use fyrox::{
+    core::pool::Handle,
+    gui::{
+        inspector::{
+            editors::{
+                PropertyEditorBuildContext, PropertyEditorDefinition, PropertyEditorInstance,
+                PropertyEditorMessageContext,
+            },
+            make_expander_container, InspectorEnvironment, InspectorError, PropertyChanged,
+        },
+        message::UiMessage,
+        widget::{Widget, WidgetBuilder},
+        BuildContext, Control, UiNode, UserInterface,
+    },
+    script::Script,
+};
+use std::{
+    any::{Any, TypeId},
+    ops::{Deref, DerefMut},
+    rc::Rc,
+};
+
+#[derive(Clone, Debug)]
+pub struct ScriptPropertyEditor {
+    widget: Widget,
+    variant_selector: Handle<UiNode>,
+}
+
+impl Deref for ScriptPropertyEditor {
+    type Target = Widget;
+
+    fn deref(&self) -> &Self::Target {
+        &self.widget
+    }
+}
+
+impl DerefMut for ScriptPropertyEditor {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.widget
+    }
+}
+
+impl Control for ScriptPropertyEditor {
+    fn query_component(&self, type_id: TypeId) -> Option<&dyn Any> {
+        if type_id == TypeId::of::<Self>() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+
+    fn handle_routed_message(&mut self, ui: &mut UserInterface, message: &mut UiMessage) {
+        self.widget.handle_routed_message(ui, message)
+    }
+}
+
+pub struct ScriptPropertyEditorBuilder {
+    widget_builder: WidgetBuilder,
+}
+
+fn get_editor_environment(
+    environment: &Option<Rc<dyn InspectorEnvironment>>,
+) -> &EditorEnvironment {
+    environment
+        .as_ref()
+        .unwrap()
+        .as_any()
+        .downcast_ref::<EditorEnvironment>()
+        .unwrap()
+}
+
+impl ScriptPropertyEditorBuilder {
+    pub fn new(widget_builder: WidgetBuilder) -> Self {
+        Self { widget_builder }
+    }
+
+    pub fn build(self, variant_selector: Handle<UiNode>, ctx: &mut BuildContext) -> Handle<UiNode> {
+        ctx.add_node(UiNode::new(ScriptPropertyEditor {
+            widget: self.widget_builder.build(),
+            variant_selector,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct ScriptPropertyEditorDefinition {}
+
+impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
+    fn value_type_id(&self) -> TypeId {
+        TypeId::of::<Option<Script>>()
+    }
+
+    fn create_instance(
+        &self,
+        ctx: PropertyEditorBuildContext,
+    ) -> Result<PropertyEditorInstance, InspectorError> {
+        let value = ctx.property_info.cast_value::<Option<Script>>()?;
+
+        let variant_selector =
+            DropdownListBuilder::new(WidgetBuilder::new()).build(ctx.build_context);
+
+        let editor;
+        let container = make_expander_container(
+            ctx.layer_index,
+            ctx.property_info.display_name,
+            variant_selector,
+            {
+                editor = ScriptPropertyEditorBuilder::new(WidgetBuilder::new())
+                    .build(variant_selector, ctx.build_context);
+                editor
+            },
+            ctx.build_context,
+        );
+
+        Ok(PropertyEditorInstance::Custom { container, editor })
+    }
+
+    fn create_message(
+        &self,
+        ctx: PropertyEditorMessageContext,
+    ) -> Result<Option<UiMessage>, InspectorError> {
+        Ok(None)
+    }
+
+    fn translate_message(
+        &self,
+        name: &str,
+        owner_type_id: TypeId,
+        message: &UiMessage,
+    ) -> Option<PropertyChanged> {
+        None
+    }
+}

--- a/editor/src/inspector/editors/texture.rs
+++ b/editor/src/inspector/editors/texture.rs
@@ -1,4 +1,5 @@
 use crate::{asset::item::AssetItem, inspector::EditorEnvironment};
+use fyrox::gui::inspector::editors::PropertyEditorTranslationContext;
 use fyrox::{
     core::{make_relative_path, pool::Handle},
     engine::resource_manager::ResourceManager,
@@ -197,19 +198,14 @@ impl PropertyEditorDefinition for TexturePropertyEditorDefinition {
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
             if let Some(TextureEditorMessage::Texture(value)) =
-                message.data::<TextureEditorMessage>()
+                ctx.message.data::<TextureEditorMessage>()
             {
                 return Some(PropertyChanged {
-                    owner_type_id,
-                    name: name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
+                    name: ctx.name.to_string(),
                     value: FieldKind::object(value.clone()),
                 });
             }

--- a/editor/src/inspector/handlers/node/base.rs
+++ b/editor/src/inspector/handlers/node/base.rs
@@ -4,12 +4,14 @@ use crate::{
     scene::commands::{graph::*, lod::*},
     SceneCommand,
 };
-use fyrox::scene::base::{LodControlledObject, LodGroup};
 use fyrox::{
     core::pool::Handle,
     gui::inspector::{CollectionChanged, FieldKind, PropertyChanged},
     scene::{
-        base::{Base, LevelOfDetail, Property, PropertyValue},
+        base::{
+            serialize_script, Base, LevelOfDetail, LodControlledObject, LodGroup, Property,
+            PropertyValue,
+        },
         node::Node,
     },
 };
@@ -17,7 +19,7 @@ use fyrox::{
 pub fn handle_base_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    base: &Base,
+    base: &mut Base,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Object(ref value) => {
@@ -193,11 +195,21 @@ pub fn handle_base_property_changed(
 fn handle_script_property_changed(
     args: &PropertyChanged,
     node_handle: Handle<Node>,
-    base: &Base,
+    base: &mut Base,
 ) -> Option<SceneCommand> {
-    /*
     if let Some(script) = base.script.as_mut() {
+        let old_data = serialize_script(script).expect("Script must be serializable!");
+
         script.on_property_changed(args);
-    }*/
-    None
+
+        let new_data = serialize_script(script).expect("Script must be serializable!");
+
+        Some(SceneCommand::new(ScriptDataBlobCommand {
+            handle: node_handle,
+            old_value: old_data,
+            new_value: new_data,
+        }))
+    } else {
+        None
+    }
 }

--- a/editor/src/inspector/handlers/node/base.rs
+++ b/editor/src/inspector/handlers/node/base.rs
@@ -29,7 +29,8 @@ pub fn handle_base_property_changed(
                 Base::LIFETIME => SetLifetimeCommand,
                 Base::DEPTH_OFFSET => SetDepthOffsetCommand,
                 Base::LOD_GROUP => SetLodGroupCommand,
-                Base::CAST_SHADOWS => SetCastShadowsCommand
+                Base::CAST_SHADOWS => SetCastShadowsCommand,
+                Base::SCRIPT => SetScriptCommand
             )
         }
         FieldKind::Collection(ref collection_changed) => match args.name.as_ref() {

--- a/editor/src/inspector/handlers/node/base.rs
+++ b/editor/src/inspector/handlers/node/base.rs
@@ -183,8 +183,21 @@ pub fn handle_base_property_changed(
                 },
                 _ => None,
             },
+            Base::SCRIPT => handle_script_property_changed(inner_value, handle, base),
             Base::LOCAL_TRANSFORM => handle_transform_property_changed(inner_value, handle, base),
             _ => None,
         },
     }
+}
+
+fn handle_script_property_changed(
+    args: &PropertyChanged,
+    node_handle: Handle<Node>,
+    base: &Base,
+) -> Option<SceneCommand> {
+    /*
+    if let Some(script) = base.script.as_mut() {
+        script.on_property_changed(args);
+    }*/
+    None
 }

--- a/editor/src/inspector/handlers/node/camera.rs
+++ b/editor/src/inspector/handlers/node/camera.rs
@@ -90,7 +90,7 @@ fn modify_skybox(
 pub fn handle_camera_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if let Some(camera) = node.cast::<Camera>() {
         match args.value {

--- a/editor/src/inspector/handlers/node/collider.rs
+++ b/editor/src/inspector/handlers/node/collider.rs
@@ -16,7 +16,7 @@ use std::any::TypeId;
 pub fn handle_collider_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    collider: &Collider,
+    collider: &mut Collider,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Object(ref value) => {

--- a/editor/src/inspector/handlers/node/collider2d.rs
+++ b/editor/src/inspector/handlers/node/collider2d.rs
@@ -17,7 +17,7 @@ use std::any::TypeId;
 pub fn handle_collider2d_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    collider: &Collider,
+    collider: &mut Collider,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Object(ref value) => {

--- a/editor/src/inspector/handlers/node/decal.rs
+++ b/editor/src/inspector/handlers/node/decal.rs
@@ -11,7 +11,7 @@ use fyrox::{
 pub fn handle_decal_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if node.is_decal() {
         match args.value {

--- a/editor/src/inspector/handlers/node/joint.rs
+++ b/editor/src/inspector/handlers/node/joint.rs
@@ -13,7 +13,7 @@ use std::any::TypeId;
 pub fn handle_joint_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    joint: &Joint,
+    joint: &mut Joint,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Object(ref value) => {

--- a/editor/src/inspector/handlers/node/joint2d.rs
+++ b/editor/src/inspector/handlers/node/joint2d.rs
@@ -13,7 +13,7 @@ use std::any::TypeId;
 pub fn handle_joint2d_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    joint: &Joint,
+    joint: &mut Joint,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Object(ref value) => {

--- a/editor/src/inspector/handlers/node/light.rs
+++ b/editor/src/inspector/handlers/node/light.rs
@@ -19,7 +19,7 @@ use fyrox::{
 pub fn handle_base_light_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Object(ref value) => {
@@ -42,7 +42,7 @@ pub fn handle_base_light_property_changed(
 pub fn handle_spot_light_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if node.is_spot_light() {
         match args.value {
@@ -69,7 +69,7 @@ pub fn handle_spot_light_property_changed(
 pub fn handle_point_light_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if node.is_point_light() {
         match args.value {
@@ -93,7 +93,7 @@ pub fn handle_point_light_property_changed(
 pub fn handle_directional_light_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if node.is_directional_light() {
         match args.value {

--- a/editor/src/inspector/handlers/node/listener.rs
+++ b/editor/src/inspector/handlers/node/listener.rs
@@ -8,7 +8,7 @@ use fyrox::{
 pub fn handle_listener_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if node.is_listener() {
         match args.value {

--- a/editor/src/inspector/handlers/node/mesh.rs
+++ b/editor/src/inspector/handlers/node/mesh.rs
@@ -11,7 +11,7 @@ use fyrox::{
 pub fn handle_mesh_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if node.is_mesh() {
         match args.value {

--- a/editor/src/inspector/handlers/node/mod.rs
+++ b/editor/src/inspector/handlers/node/mod.rs
@@ -68,9 +68,8 @@ impl SceneNodePropertyChangedHandler {
         &self,
         args: &PropertyChanged,
         handle: Handle<Node>,
-        node: &Node,
+        node: &mut Node,
         ui: &UserInterface,
-        scene: &Scene,
     ) -> Option<SceneCommand> {
         if args.owner_type_id == TypeId::of::<Base>() {
             handle_base_property_changed(args, handle, node)
@@ -91,21 +90,21 @@ impl SceneNodePropertyChangedHandler {
         } else if args.owner_type_id == TypeId::of::<Decal>() {
             handle_decal_property_changed(args, handle, node)
         } else if args.owner_type_id == TypeId::of::<Terrain>() {
-            handle_terrain_property_changed(args, handle, node, &scene.graph)
+            handle_terrain_property_changed(args, handle, node)
         } else if args.owner_type_id == TypeId::of::<Mesh>() {
             handle_mesh_property_changed(args, handle, node)
         } else if args.owner_type_id == TypeId::of::<RigidBody>() {
-            handle_rigid_body_property_changed(args, handle, node.as_rigid_body())
+            handle_rigid_body_property_changed(args, handle, node.as_rigid_body_mut())
         } else if args.owner_type_id == TypeId::of::<dim2::rigidbody::RigidBody>() {
-            handle_rigid_body2d_property_changed(args, handle, node.as_rigid_body2d())
+            handle_rigid_body2d_property_changed(args, handle, node.as_rigid_body2d_mut())
         } else if args.owner_type_id == TypeId::of::<Collider>() {
-            handle_collider_property_changed(args, handle, node.as_collider())
+            handle_collider_property_changed(args, handle, node.as_collider_mut())
         } else if args.owner_type_id == TypeId::of::<dim2::collider::Collider>() {
-            handle_collider2d_property_changed(args, handle, node.as_collider2d())
+            handle_collider2d_property_changed(args, handle, node.as_collider2d_mut())
         } else if args.owner_type_id == TypeId::of::<Joint>() {
-            handle_joint_property_changed(args, handle, node.as_joint())
+            handle_joint_property_changed(args, handle, node.as_joint_mut())
         } else if args.owner_type_id == TypeId::of::<dim2::joint::Joint>() {
-            handle_joint2d_property_changed(args, handle, node.as_joint2d())
+            handle_joint2d_property_changed(args, handle, node.as_joint2d_mut())
         } else if args.owner_type_id == TypeId::of::<dim2::rectangle::Rectangle>() {
             handle_rectangle_property_changed(args, handle, node)
         } else if args.owner_type_id == TypeId::of::<Sound>() {

--- a/editor/src/inspector/handlers/node/particle_system.rs
+++ b/editor/src/inspector/handlers/node/particle_system.rs
@@ -123,7 +123,7 @@ impl ParticleSystemHandler {
         &self,
         args: &PropertyChanged,
         handle: Handle<Node>,
-        node: &Node,
+        node: &mut Node,
         ui: &UserInterface,
     ) -> Option<SceneCommand> {
         if let Some(particle_system) = node.cast::<ParticleSystem>() {

--- a/editor/src/inspector/handlers/node/pivot.rs
+++ b/editor/src/inspector/handlers/node/pivot.rs
@@ -8,7 +8,7 @@ use fyrox::{
 pub fn handle_pivot_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Inspectable(ref inner) => match args.name.as_ref() {

--- a/editor/src/inspector/handlers/node/rectangle.rs
+++ b/editor/src/inspector/handlers/node/rectangle.rs
@@ -11,7 +11,7 @@ use fyrox::{
 pub fn handle_rectangle_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if node.is_rectangle() {
         match args.value {

--- a/editor/src/inspector/handlers/node/rigid_body.rs
+++ b/editor/src/inspector/handlers/node/rigid_body.rs
@@ -11,7 +11,7 @@ use fyrox::{
 pub fn handle_rigid_body_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    rigid_body: &RigidBody,
+    rigid_body: &mut RigidBody,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Object(ref value) => {

--- a/editor/src/inspector/handlers/node/rigid_body2d.rs
+++ b/editor/src/inspector/handlers/node/rigid_body2d.rs
@@ -11,7 +11,7 @@ use fyrox::{
 pub fn handle_rigid_body2d_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    rigid_body: &RigidBody,
+    rigid_body: &mut RigidBody,
 ) -> Option<SceneCommand> {
     match args.value {
         FieldKind::Object(ref value) => {

--- a/editor/src/inspector/handlers/node/sprite.rs
+++ b/editor/src/inspector/handlers/node/sprite.rs
@@ -11,7 +11,7 @@ use fyrox::{
 pub fn handle_sprite_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
     if node.is_sprite() {
         match args.value {

--- a/editor/src/inspector/handlers/node/terrain.rs
+++ b/editor/src/inspector/handlers/node/terrain.rs
@@ -5,22 +5,21 @@ use crate::{
 use fyrox::{
     core::pool::Handle,
     gui::inspector::{CollectionChanged, FieldKind, PropertyChanged},
-    scene::{graph::Graph, node::Node, terrain::Layer, terrain::Terrain},
+    scene::{node::Node, terrain::Layer, terrain::Terrain},
 };
 use std::any::TypeId;
 
 pub fn handle_terrain_property_changed(
     args: &PropertyChanged,
     handle: Handle<Node>,
-    node: &Node,
-    graph: &Graph,
+    node: &mut Node,
 ) -> Option<SceneCommand> {
-    if node.is_terrain() {
+    if let Some(terrain) = node.cast::<Terrain>() {
         match args.value {
             FieldKind::Collection(ref collection_changed) => match args.name.as_ref() {
                 Terrain::LAYERS => match &**collection_changed {
                     CollectionChanged::Add => Some(SceneCommand::new(AddTerrainLayerCommand::new(
-                        handle, graph,
+                        handle, terrain,
                     ))),
                     CollectionChanged::Remove(index) => Some(SceneCommand::new(
                         DeleteTerrainLayerCommand::new(handle, *index),

--- a/editor/src/inspector/mod.rs
+++ b/editor/src/inspector/mod.rs
@@ -292,7 +292,7 @@ impl Inspector {
         engine: &mut GameEngine,
         sender: &Sender<Message>,
     ) {
-        let scene = &engine.scenes[editor_scene.scene];
+        let scene = &mut engine.scenes[editor_scene.scene];
 
         // Special case for particle systems.
         if let Selection::Graph(selection) = &editor_scene.selection {
@@ -322,9 +322,8 @@ impl Inspector {
                                 self.node_property_changed_handler.handle(
                                     args,
                                     node_handle,
-                                    &scene.graph[node_handle],
+                                    &mut scene.graph[node_handle],
                                     &engine.user_interface,
-                                    scene,
                                 )
                             } else {
                                 None

--- a/editor/src/inspector/mod.rs
+++ b/editor/src/inspector/mod.rs
@@ -278,6 +278,14 @@ impl Inspector {
                         &engine.plugins,
                     )
                 }
+            } else {
+                engine
+                    .user_interface
+                    .send_message(InspectorMessage::context(
+                        self.inspector,
+                        MessageDirection::ToWidget,
+                        Default::default(),
+                    ));
             }
         }
     }

--- a/editor/src/main.rs
+++ b/editor/src/main.rs
@@ -68,9 +68,6 @@ use crate::{
     utils::path_fixer::PathFixer,
     world::{graph::selection::GraphSelection, WorldViewer},
 };
-use fyrox::engine::resource_manager::ResourceManager;
-use fyrox::engine::{Engine, EngineInitParams};
-use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     core::{
         algebra::{Point3, Vector2},
@@ -84,6 +81,7 @@ use fyrox::{
         sstorage::ImmutableString,
     },
     dpi::LogicalSize,
+    engine::{resource_manager::ResourceManager, Engine, EngineInitParams, SerializationContext},
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     gui::{
@@ -685,7 +683,7 @@ impl Editor {
         self.path_fixer.handle_ui_message(
             message,
             &mut engine.user_interface,
-            engine.node_constructors.clone(),
+            engine.serialization_context.clone(),
             engine.resource_manager.clone(),
         );
         self.scene_viewer
@@ -1203,7 +1201,7 @@ impl Editor {
                     let result = {
                         block_on(SceneLoader::from_file(
                             &scene_path,
-                            engine.node_constructors.clone(),
+                            engine.serialization_context.clone(),
                         ))
                     };
                     match result {
@@ -1584,11 +1582,11 @@ fn main() {
         .with_title("rusty editor")
         .with_resizable(true);
 
-    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let serialization_context = Arc::new(SerializationContext::new());
     let mut engine = Engine::new(EngineInitParams {
         window_builder,
-        resource_manager: ResourceManager::new(node_constructors.clone()),
-        node_constructors,
+        resource_manager: ResourceManager::new(serialization_context.clone()),
+        serialization_context,
         events_loop: &event_loop,
         vsync: true,
     })

--- a/editor/src/main.rs
+++ b/editor/src/main.rs
@@ -99,7 +99,6 @@ use fyrox::{
         BuildContext, UiNode, UserInterface, VerticalAlignment,
     },
     material::{shader::Shader, Material, PropertyValue},
-    plugin::PluginContext,
     resource::texture::{CompressionOptions, Texture, TextureKind, TextureState},
     scene::{
         camera::Projection,

--- a/editor/src/main.rs
+++ b/editor/src/main.rs
@@ -1088,6 +1088,7 @@ impl Editor {
                     message_sender: self.message_sender.clone(),
                     editor_scene,
                     resource_manager: engine.resource_manager.clone(),
+                    serialization_context: engine.serialization_context.clone(),
                 },
                 &mut engine.user_interface,
             )
@@ -1127,6 +1128,7 @@ impl Editor {
                                 message_sender: self.message_sender.clone(),
                                 editor_scene,
                                 resource_manager: engine.resource_manager.clone(),
+                                serialization_context: engine.serialization_context.clone(),
                             },
                         );
                         needs_sync = true;
@@ -1139,6 +1141,7 @@ impl Editor {
                             message_sender: self.message_sender.clone(),
                             editor_scene,
                             resource_manager: engine.resource_manager.clone(),
+                            serialization_context: engine.serialization_context.clone(),
                         });
                         needs_sync = true;
                     }
@@ -1150,6 +1153,7 @@ impl Editor {
                             message_sender: self.message_sender.clone(),
                             editor_scene,
                             resource_manager: engine.resource_manager.clone(),
+                            serialization_context: engine.serialization_context.clone(),
                         });
                         needs_sync = true;
                     }
@@ -1161,6 +1165,7 @@ impl Editor {
                             message_sender: self.message_sender.clone(),
                             editor_scene,
                             resource_manager: engine.resource_manager.clone(),
+                            serialization_context: engine.serialization_context.clone(),
                         });
                         needs_sync = true;
                     }

--- a/editor/src/main.rs
+++ b/editor/src/main.rs
@@ -260,6 +260,8 @@ pub enum Message {
         handle: ErasedHandle,
     },
     SetEditorCameraProjection(Projection),
+    UnloadPlugins,
+    ReloadPlugins,
 }
 
 impl Message {
@@ -683,6 +685,8 @@ impl Editor {
             &mut engine.user_interface,
             engine.resource_manager.clone(),
         );
+        self.scene_viewer
+            .handle_ui_message(message, &engine.user_interface);
 
         if let Some(editor_scene) = self.scene.as_mut() {
             self.audio_panel
@@ -719,9 +723,6 @@ impl Editor {
 
             self.light_panel
                 .handle_ui_message(message, editor_scene, engine);
-
-            self.scene_viewer
-                .handle_ui_message(message, &engine.user_interface);
 
             self.material_editor
                 .handle_ui_message(message, engine, &self.message_sender);
@@ -1258,13 +1259,7 @@ impl Editor {
 
                     std::env::set_current_dir(working_directory.clone()).unwrap();
 
-                    engine.plugins.rescan(&mut PluginContext {
-                        scenes: &mut engine.scenes,
-                        ui: &mut engine.user_interface,
-                        resource_manager: &engine.resource_manager,
-                        renderer: &mut engine.renderer,
-                        dt,
-                    });
+                    engine.reload_plugins();
 
                     engine
                         .get_window()
@@ -1354,6 +1349,12 @@ impl Editor {
                             projection,
                         );
                     }
+                }
+                Message::UnloadPlugins => {
+                    engine.unload_plugins();
+                }
+                Message::ReloadPlugins => {
+                    engine.reload_plugins();
                 }
             }
         }

--- a/editor/src/scene/commands/graph.rs
+++ b/editor/src/scene/commands/graph.rs
@@ -2,6 +2,7 @@ use crate::{
     command::Command, define_node_command, define_swap_command, define_vec_add_remove_commands,
     scene::commands::SceneContext,
 };
+use fyrox::script::Script;
 use fyrox::{
     animation::Animation,
     core::{
@@ -468,6 +469,7 @@ define_swap_command! {
     SetMobilityCommand(Mobility): mobility, set_mobility, "Set Mobility";
     SetDepthOffsetCommand(f32): depth_offset_factor, set_depth_offset_factor, "Set Depth Offset";
     SetCastShadowsCommand(bool): cast_shadows, set_cast_shadows, "Set Cast Shadows";
+    SetScriptCommand(Option<Script>): script_cloned, set_script, "Set Script";
 }
 
 define_node_command! {

--- a/editor/src/scene/commands/graph.rs
+++ b/editor/src/scene/commands/graph.rs
@@ -510,3 +510,22 @@ define_node_command! {
         self.value = temp;
     }
 }
+
+#[derive(Debug)]
+pub struct ScriptDataBlobCommand {
+    handle: Handle<Node>,
+    old_value: Vec<u8>,
+    new_value: Vec<u8>,
+}
+
+impl Command for ScriptDataBlobCommand {
+    fn name(&mut self, context: &SceneContext) -> String {
+        "Change Script Property".to_string()
+    }
+
+    fn execute(&mut self, context: &mut SceneContext) {
+        todo!()
+    }
+
+    fn revert(&mut self, context: &mut SceneContext) {}
+}

--- a/editor/src/scene/commands/mod.rs
+++ b/editor/src/scene/commands/mod.rs
@@ -6,10 +6,12 @@ use crate::{
     },
     GameEngine, Message,
 };
+use fyrox::engine::SerializationContext;
 use fyrox::{
     engine::resource_manager::ResourceManager,
     scene::{graph::SubGraph, Scene},
 };
+use std::sync::Arc;
 use std::{
     ops::{Deref, DerefMut},
     sync::mpsc::Sender,
@@ -55,6 +57,7 @@ pub struct SceneContext<'a> {
     pub scene: &'a mut Scene,
     pub message_sender: Sender<Message>,
     pub resource_manager: ResourceManager,
+    pub serialization_context: Arc<SerializationContext>,
 }
 
 #[derive(Debug)]

--- a/editor/src/scene/commands/terrain.rs
+++ b/editor/src/scene/commands/terrain.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use fyrox::{
     core::pool::Handle,
-    scene::{graph::Graph, node::Node, terrain::Layer},
+    scene::{node::Node, terrain::Layer, terrain::Terrain},
 };
 
 #[derive(Debug)]
@@ -14,9 +14,7 @@ pub struct AddTerrainLayerCommand {
 }
 
 impl AddTerrainLayerCommand {
-    pub fn new(terrain_handle: Handle<Node>, graph: &Graph) -> Self {
-        let terrain = graph[terrain_handle].as_terrain();
-
+    pub fn new(terrain_handle: Handle<Node>, terrain: &Terrain) -> Self {
         Self {
             terrain: terrain_handle,
             layer: Some(terrain.create_layer(

--- a/editor/src/scene_viewer.rs
+++ b/editor/src/scene_viewer.rs
@@ -40,6 +40,8 @@ pub struct SceneViewer {
     navmesh_mode: Handle<UiNode>,
     terrain_mode: Handle<UiNode>,
     camera_projection: Handle<UiNode>,
+    unload_plugins: Handle<UiNode>,
+    reload_plugins: Handle<UiNode>,
     sender: Sender<Message>,
 }
 
@@ -120,6 +122,8 @@ impl SceneViewer {
         let terrain_mode;
         let selection_frame;
         let camera_projection;
+        let unload_plugins;
+        let reload_plugins;
         let window = WindowBuilder::new(WidgetBuilder::new())
             .can_close(false)
             .can_minimize(false)
@@ -132,6 +136,22 @@ impl SceneViewer {
                                 WidgetBuilder::new()
                                     .with_margin(Thickness::uniform(1.0))
                                     .with_horizontal_alignment(HorizontalAlignment::Right)
+                                    .with_child({
+                                        unload_plugins = ButtonBuilder::new(
+                                            WidgetBuilder::new().with_width(100.0),
+                                        )
+                                        .with_text("Unload Plugins")
+                                        .build(ctx);
+                                        unload_plugins
+                                    })
+                                    .with_child({
+                                        reload_plugins = ButtonBuilder::new(
+                                            WidgetBuilder::new().with_width(100.0),
+                                        )
+                                        .with_text("Reload Plugins")
+                                        .build(ctx);
+                                        reload_plugins
+                                    })
                                     .with_child({
                                         camera_projection = DropdownListBuilder::new(
                                             WidgetBuilder::new().with_width(150.0),
@@ -289,6 +309,8 @@ impl SceneViewer {
             terrain_mode,
             camera_projection,
             click_mouse_pos: None,
+            unload_plugins,
+            reload_plugins,
         }
     }
 }
@@ -332,6 +354,10 @@ impl SceneViewer {
                 self.sender
                     .send(Message::SetInteractionMode(InteractionModeKind::Terrain))
                     .unwrap();
+            } else if message.destination() == self.unload_plugins {
+                self.sender.send(Message::UnloadPlugins).unwrap()
+            } else if message.destination() == self.reload_plugins {
+                self.sender.send(Message::ReloadPlugins).unwrap()
             }
         } else if let Some(WidgetMessage::MouseDown { button, .. }) =
             message.data::<WidgetMessage>()

--- a/editor/src/utils/path_fixer.rs
+++ b/editor/src/utils/path_fixer.rs
@@ -2,21 +2,12 @@
 //! moved a resource in a file system, but a scene has old path.
 
 use crate::{make_scene_file_filter, Message};
-use fyrox::scene::camera::Camera;
-use fyrox::scene::decal::Decal;
-use fyrox::scene::dim2::rectangle::Rectangle;
-use fyrox::scene::light::spot::SpotLight;
-use fyrox::scene::mesh::Mesh;
-use fyrox::scene::node::constructor::NodeConstructorContainer;
-use fyrox::scene::particle_system::ParticleSystem;
-use fyrox::scene::sprite::Sprite;
-use fyrox::scene::terrain::Terrain;
 use fyrox::{
     asset::ResourceData,
     core::{
         color::Color, futures::executor::block_on, pool::Handle, replace_slashes, visitor::Visitor,
     },
-    engine::resource_manager::ResourceManager,
+    engine::{resource_manager::ResourceManager, SerializationContext},
     gui::{
         border::BorderBuilder,
         brush::Brush,
@@ -36,14 +27,17 @@ use fyrox::{
     },
     material::PropertyValue,
     resource::{model::Model, texture::Texture},
-    scene::{Scene, SceneLoader},
+    scene::{
+        camera::Camera, decal::Decal, dim2::rectangle::Rectangle, light::spot::SpotLight,
+        mesh::Mesh, particle_system::ParticleSystem, sprite::Sprite, terrain::Terrain, Scene,
+        SceneLoader,
+    },
 };
-use std::sync::Arc;
 use std::{
     collections::HashSet,
     hash::{Hash, Hasher},
-    path::Path,
-    path::PathBuf,
+    path::{Path, PathBuf},
+    sync::Arc,
 };
 
 pub struct PathFixer {
@@ -311,7 +305,7 @@ impl PathFixer {
         &mut self,
         message: &UiMessage,
         ui: &mut UserInterface,
-        node_constructors: Arc<NodeConstructorContainer>,
+        serialization_context: Arc<SerializationContext>,
         resource_manager: ResourceManager,
     ) {
         if let Some(FileSelectorMessage::Commit(path)) = message.data::<FileSelectorMessage>() {
@@ -319,7 +313,7 @@ impl PathFixer {
                 let message;
                 match block_on(Visitor::load_binary(path)) {
                     Ok(mut visitor) => {
-                        match SceneLoader::load("Scene", node_constructors, &mut visitor) {
+                        match SceneLoader::load("Scene", serialization_context, &mut visitor) {
                             Err(e) => {
                                 message = format!(
                                     "Failed to load a scene {}\nReason: {}",

--- a/editor/src/utils/path_fixer.rs
+++ b/editor/src/utils/path_fixer.rs
@@ -7,6 +7,7 @@ use fyrox::scene::decal::Decal;
 use fyrox::scene::dim2::rectangle::Rectangle;
 use fyrox::scene::light::spot::SpotLight;
 use fyrox::scene::mesh::Mesh;
+use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::scene::particle_system::ParticleSystem;
 use fyrox::scene::sprite::Sprite;
 use fyrox::scene::terrain::Terrain;
@@ -37,6 +38,7 @@ use fyrox::{
     resource::{model::Model, texture::Texture},
     scene::{Scene, SceneLoader},
 };
+use std::sync::Arc;
 use std::{
     collections::HashSet,
     hash::{Hash, Hasher},
@@ -309,6 +311,7 @@ impl PathFixer {
         &mut self,
         message: &UiMessage,
         ui: &mut UserInterface,
+        node_constructors: Arc<NodeConstructorContainer>,
         resource_manager: ResourceManager,
     ) {
         if let Some(FileSelectorMessage::Commit(path)) = message.data::<FileSelectorMessage>() {
@@ -316,7 +319,7 @@ impl PathFixer {
                 let message;
                 match block_on(Visitor::load_binary(path)) {
                     Ok(mut visitor) => {
-                        match SceneLoader::load("Scene", &mut visitor) {
+                        match SceneLoader::load("Scene", node_constructors, &mut visitor) {
                             Err(e) => {
                                 message = format!(
                                     "Failed to load a scene {}\nReason: {}",

--- a/examples/custom_loader.rs
+++ b/examples/custom_loader.rs
@@ -9,8 +9,6 @@
 pub mod shared;
 
 use crate::shared::create_camera;
-use fyrox::engine::EngineInitParams;
-use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     core::{
         algebra::{Matrix4, Vector3},
@@ -28,7 +26,7 @@ use fyrox::{
             },
             ResourceManager,
         },
-        Engine,
+        Engine, EngineInitParams, SerializationContext,
     },
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -201,8 +199,8 @@ fn main() {
         .with_title("Example 12 - Custom resource loader")
         .with_resizable(true);
 
-    let node_constructors = Arc::new(NodeConstructorContainer::new());
-    let resource_manager = ResourceManager::new(node_constructors.clone());
+    let serialization_context = Arc::new(SerializationContext::new());
+    let resource_manager = ResourceManager::new(serialization_context.clone());
 
     // Set up our custom loaders
     {
@@ -210,15 +208,15 @@ fn main() {
         let containers = state.containers_mut();
         containers.set_model_loader(CustomModelLoader(Arc::new(ModelLoader {
             resource_manager: resource_manager.clone(),
-            node_constructors: node_constructors.clone(),
+            serialization_context: serialization_context.clone(),
         })));
         containers.set_texture_loader(CustomTextureLoader(Arc::new(TextureLoader)));
     }
 
     let mut engine = Engine::new(EngineInitParams {
         window_builder,
-        resource_manager: ResourceManager::new(node_constructors.clone()),
-        node_constructors,
+        resource_manager: ResourceManager::new(serialization_context.clone()),
+        serialization_context,
         events_loop: &event_loop,
         vsync: false,
     })

--- a/examples/custom_loop.rs
+++ b/examples/custom_loop.rs
@@ -6,14 +6,16 @@
 
 use fyrox::{
     core::instant::Instant,
-    engine::Engine,
+    engine::{resource_manager::ResourceManager, Engine, EngineInitParams},
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
+    scene::node::constructor::NodeConstructorContainer,
     utils::{
         log::{Log, MessageKind},
         translate_event,
     },
 };
+use std::sync::Arc;
 
 fn main() {
     let event_loop = EventLoop::new();
@@ -23,10 +25,15 @@ fn main() {
         .with_title("Example - Custom Game Loop")
         .with_resizable(true);
 
-    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
-
-    // Then initialize the engine.
-    let mut engine = Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
+    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let mut engine = Engine::new(EngineInitParams {
+        window_builder,
+        resource_manager: ResourceManager::new(node_constructors.clone()),
+        node_constructors,
+        events_loop: &event_loop,
+        vsync: true,
+    })
+    .unwrap();
 
     // Define game loop variables.
     let clock = Instant::now();

--- a/examples/custom_loop.rs
+++ b/examples/custom_loop.rs
@@ -6,10 +6,9 @@
 
 use fyrox::{
     core::instant::Instant,
-    engine::{resource_manager::ResourceManager, Engine, EngineInitParams},
+    engine::{resource_manager::ResourceManager, Engine, EngineInitParams, SerializationContext},
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    scene::node::constructor::NodeConstructorContainer,
     utils::{
         log::{Log, MessageKind},
         translate_event,
@@ -25,11 +24,11 @@ fn main() {
         .with_title("Example - Custom Game Loop")
         .with_resizable(true);
 
-    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let serialization_context = Arc::new(SerializationContext::new());
     let mut engine = Engine::new(EngineInitParams {
         window_builder,
-        resource_manager: ResourceManager::new(node_constructors.clone()),
-        node_constructors,
+        resource_manager: ResourceManager::new(serialization_context.clone()),
+        serialization_context,
         events_loop: &event_loop,
         vsync: true,
     })

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -3,8 +3,6 @@
 pub mod shared;
 
 use crate::shared::create_camera;
-use fyrox::engine::EngineInitParams;
-use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     animation::Animation,
     core::{
@@ -12,7 +10,7 @@ use fyrox::{
         color::Color,
         pool::Handle,
     },
-    engine::{resource_manager::ResourceManager, Engine},
+    engine::{resource_manager::ResourceManager, Engine, EngineInitParams, SerializationContext},
     event::{ElementState, Event, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     gui::{
@@ -32,6 +30,7 @@ use fyrox::{
         translate_event,
     },
 };
+
 use std::sync::Arc;
 use std::{rc::Rc, time::Instant};
 
@@ -118,11 +117,11 @@ fn main() {
         .with_title("Example - User Interface")
         .with_resizable(true);
 
-    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let serialization_context = Arc::new(SerializationContext::new());
     let mut engine = Engine::new(EngineInitParams {
         window_builder,
-        resource_manager: ResourceManager::new(node_constructors.clone()),
-        node_constructors,
+        resource_manager: ResourceManager::new(serialization_context.clone()),
+        serialization_context,
         events_loop: &event_loop,
         vsync: false,
     })

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -3,6 +3,8 @@
 pub mod shared;
 
 use crate::shared::create_camera;
+use fyrox::engine::EngineInitParams;
+use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     animation::Animation,
     core::{
@@ -30,6 +32,7 @@ use fyrox::{
         translate_event,
     },
 };
+use std::sync::Arc;
 use std::{rc::Rc, time::Instant};
 
 struct Interface {
@@ -115,9 +118,15 @@ fn main() {
         .with_title("Example - User Interface")
         .with_resizable(true);
 
-    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
-
-    let mut engine = Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
+    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let mut engine = Engine::new(EngineInitParams {
+        window_builder,
+        resource_manager: ResourceManager::new(node_constructors.clone()),
+        node_constructors,
+        events_loop: &event_loop,
+        vsync: false,
+    })
+    .unwrap();
 
     // Create simple user interface that will show some useful info.
     let interface = create_ui(&mut engine);

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -7,8 +7,11 @@
 pub mod shared;
 
 use crate::shared::create_camera;
+use std::sync::Arc;
 
+use fyrox::engine::EngineInitParams;
 use fyrox::scene::base::LodControlledObject;
+use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     core::{
         algebra::{UnitQuaternion, Vector3},
@@ -136,9 +139,15 @@ fn main() {
         .with_title("Example 08 - Level of detail")
         .with_resizable(true);
 
-    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
-
-    let mut engine = Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
+    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let mut engine = Engine::new(EngineInitParams {
+        window_builder,
+        resource_manager: ResourceManager::new(node_constructors.clone()),
+        node_constructors,
+        events_loop: &event_loop,
+        vsync: true,
+    })
+    .unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -9,16 +9,13 @@ pub mod shared;
 use crate::shared::create_camera;
 use std::sync::Arc;
 
-use fyrox::engine::EngineInitParams;
-use fyrox::scene::base::LodControlledObject;
-use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     core::{
         algebra::{UnitQuaternion, Vector3},
         color::Color,
         pool::Handle,
     },
-    engine::{resource_manager::ResourceManager, Engine},
+    engine::{resource_manager::ResourceManager, Engine, EngineInitParams, SerializationContext},
     event::{ElementState, Event, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     gui::{
@@ -28,7 +25,7 @@ use fyrox::{
         BuildContext, UiNode,
     },
     scene::{
-        base::{LevelOfDetail, LodGroup},
+        base::{LevelOfDetail, LodControlledObject, LodGroup},
         node::Node,
         Scene,
     },
@@ -139,11 +136,11 @@ fn main() {
         .with_title("Example 08 - Level of detail")
         .with_resizable(true);
 
-    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let serialization_context = Arc::new(SerializationContext::new());
     let mut engine = Engine::new(EngineInitParams {
         window_builder,
-        resource_manager: ResourceManager::new(node_constructors.clone()),
-        node_constructors,
+        resource_manager: ResourceManager::new(serialization_context.clone()),
+        serialization_context,
         events_loop: &event_loop,
         vsync: true,
     })

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -7,8 +7,6 @@
 pub mod shared;
 
 use crate::shared::create_camera;
-use fyrox::engine::EngineInitParams;
-use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     core::{
         algebra::{Matrix4, Point3, UnitQuaternion, Vector2, Vector3},
@@ -20,7 +18,7 @@ use fyrox::{
         sstorage::ImmutableString,
     },
     dpi::LogicalPosition,
-    engine::{resource_manager::ResourceManager, Engine},
+    engine::{resource_manager::ResourceManager, Engine, EngineInitParams, SerializationContext},
     event::{ElementState, Event, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     gui::{
@@ -48,6 +46,7 @@ use fyrox::{
         translate_event,
     },
 };
+
 use std::{sync::Arc, time::Instant};
 
 fn create_ui(ctx: &mut BuildContext) -> Handle<UiNode> {
@@ -146,11 +145,11 @@ fn main() {
         .with_title("Example 12 - Navigation Mesh")
         .with_resizable(true);
 
-    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let serialization_context = Arc::new(SerializationContext::new());
     let mut engine = Engine::new(EngineInitParams {
         window_builder,
-        resource_manager: ResourceManager::new(node_constructors.clone()),
-        node_constructors,
+        resource_manager: ResourceManager::new(serialization_context.clone()),
+        serialization_context,
         events_loop: &event_loop,
         vsync: false,
     })

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -7,6 +7,8 @@
 pub mod shared;
 
 use crate::shared::create_camera;
+use fyrox::engine::EngineInitParams;
+use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     core::{
         algebra::{Matrix4, Point3, UnitQuaternion, Vector2, Vector3},
@@ -144,9 +146,15 @@ fn main() {
         .with_title("Example 12 - Navigation Mesh")
         .with_resizable(true);
 
-    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
-
-    let mut engine = Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
+    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let mut engine = Engine::new(EngineInitParams {
+        window_builder,
+        resource_manager: ResourceManager::new(node_constructors.clone()),
+        node_constructors,
+        events_loop: &event_loop,
+        vsync: false,
+    })
+    .unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/save_load.rs
+++ b/examples/save_load.rs
@@ -129,10 +129,14 @@ async fn load(game: &mut Game) {
 
         let mut visitor = Visitor::load_binary(SAVE_FILE).await.unwrap();
 
-        let scene = SceneLoader::load("Scene", game.engine.node_constructors.clone(), &mut visitor)
-            .unwrap()
-            .finish(game.engine.resource_manager.clone())
-            .await;
+        let scene = SceneLoader::load(
+            "Scene",
+            game.engine.serialization_context.clone(),
+            &mut visitor,
+        )
+        .unwrap()
+        .finish(game.engine.resource_manager.clone())
+        .await;
 
         let mut game_scene = GameScene::default();
         game_scene.visit("GameScene", &mut visitor).unwrap();

--- a/examples/save_load.rs
+++ b/examples/save_load.rs
@@ -129,7 +129,7 @@ async fn load(game: &mut Game) {
 
         let mut visitor = Visitor::load_binary(SAVE_FILE).await.unwrap();
 
-        let scene = SceneLoader::load("Scene", &mut visitor)
+        let scene = SceneLoader::load("Scene", game.engine.node_constructors.clone(), &mut visitor)
             .unwrap()
             .finish(game.engine.resource_manager.clone())
             .await;

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -9,16 +9,13 @@
 pub mod shared;
 
 use crate::shared::create_camera;
-use fyrox::engine::EngineInitParams;
-use fyrox::scene::node::constructor::NodeConstructorContainer;
-use fyrox::scene::pivot::PivotBuilder;
 use fyrox::{
     core::{
         algebra::{UnitQuaternion, Vector3},
         color::Color,
         pool::Handle,
     },
-    engine::{resource_manager::ResourceManager, Engine},
+    engine::{resource_manager::ResourceManager, Engine, EngineInitParams, SerializationContext},
     event::{ElementState, Event, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     gui::{
@@ -27,14 +24,13 @@ use fyrox::{
         widget::WidgetBuilder,
         BuildContext, UiNode,
     },
-    scene::{base::BaseBuilder, node::Node, Scene},
+    scene::{base::BaseBuilder, node::Node, pivot::PivotBuilder, Scene},
     utils::{
         log::{Log, MessageKind},
         translate_event,
     },
 };
-use std::sync::Arc;
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 
 fn create_ui(ctx: &mut BuildContext) -> Handle<UiNode> {
     TextBuilder::new(WidgetBuilder::new()).build(ctx)
@@ -85,11 +81,11 @@ fn main() {
         .with_title("Example - Scene")
         .with_resizable(true);
 
-    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let serialization_context = Arc::new(SerializationContext::new());
     let mut engine = Engine::new(EngineInitParams {
         window_builder,
-        resource_manager: ResourceManager::new(node_constructors.clone()),
-        node_constructors,
+        resource_manager: ResourceManager::new(serialization_context.clone()),
+        serialization_context,
         events_loop: &event_loop,
         vsync: true,
     })

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -9,6 +9,8 @@
 pub mod shared;
 
 use crate::shared::create_camera;
+use fyrox::engine::EngineInitParams;
+use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::scene::pivot::PivotBuilder;
 use fyrox::{
     core::{
@@ -31,6 +33,7 @@ use fyrox::{
         translate_event,
     },
 };
+use std::sync::Arc;
 use std::time::Instant;
 
 fn create_ui(ctx: &mut BuildContext) -> Handle<UiNode> {
@@ -82,9 +85,15 @@ fn main() {
         .with_title("Example - Scene")
         .with_resizable(true);
 
-    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
-
-    let mut engine = Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
+    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let mut engine = Engine::new(EngineInitParams {
+        window_builder,
+        resource_manager: ResourceManager::new(node_constructors.clone()),
+        node_constructors,
+        events_loop: &event_loop,
+        vsync: true,
+    })
+    .unwrap();
 
     // Create simple user interface that will show some useful info.
     let debug_text = create_ui(&mut engine.user_interface.build_ctx());

--- a/examples/scripting/.gitignore
+++ b/examples/scripting/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/examples/scripting/.idea/.gitignore
+++ b/examples/scripting/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/examples/scripting/.idea/modules.xml
+++ b/examples/scripting/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/test_scripting.iml" filepath="$PROJECT_DIR$/.idea/test_scripting.iml" />
+    </modules>
+  </component>
+</project>

--- a/examples/scripting/.idea/test_scripting.iml
+++ b/examples/scripting/.idea/test_scripting.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/examples/scripting/.idea/vcs.xml
+++ b/examples/scripting/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/examples/scripting/.idea/vcs.xml
+++ b/examples/scripting/.idea/vcs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/examples/scripting" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/examples/scripting/Cargo.toml
+++ b/examples/scripting/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test_scripting"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+name = "scripting"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+fyrox = { path = "../../" }

--- a/examples/scripting/plugins.ron
+++ b/examples/scripting/plugins.ron
@@ -1,0 +1,8 @@
+(
+    plugins: [
+        (
+            name: "Scripting Plugin",
+            path: "../../target/debug/scripting.dll"
+        )
+    ]
+)

--- a/examples/scripting/profiling.log
+++ b/examples/scripting/profiling.log
@@ -1,0 +1,1 @@
+Performance profiling results are not available, because feature 'enable_profiler' wasn't defined!

--- a/examples/scripting/src/lib.rs
+++ b/examples/scripting/src/lib.rs
@@ -1,0 +1,122 @@
+use fyrox::core::algebra::{UnitQuaternion, Vector3};
+use fyrox::core::sstorage::ImmutableString;
+use fyrox::material::PropertyValue;
+use fyrox::scene::mesh::Mesh;
+use fyrox::{
+    core::{
+        color::Hsv,
+        inspect::{Inspect, PropertyInfo},
+        uuid::Uuid,
+        visitor::prelude::*,
+    },
+    plugin::{Plugin, PluginContext},
+    script::{ScriptContext, ScriptDefinition, ScriptDefinitionStorage, ScriptTrait},
+};
+use std::any::TypeId;
+use std::{str::FromStr, sync::Arc};
+
+#[derive(Visit, Inspect, Default)]
+struct GamePlugin {
+    #[visit(skip)]
+    #[inspect(skip)]
+    script_storage: Arc<ScriptDefinitionStorage>,
+}
+
+impl GamePlugin {
+    fn type_uuid() -> Uuid {
+        Uuid::from_str("a9507fb2-0945-4fc1-91ce-115ae7c8a615").unwrap()
+    }
+
+    pub fn new() -> Self {
+        let mut script_storage = ScriptDefinitionStorage::new();
+
+        script_storage.add(ScriptDefinition {
+            name: "TestScript".to_string(),
+            type_uuid: TestScript::type_uuid(),
+            constructor: Box::new(|| Box::new(TestScript::default())),
+        });
+
+        Self {
+            script_storage: Arc::new(script_storage),
+        }
+    }
+}
+
+impl Plugin for GamePlugin {
+    fn on_init(&mut self, _engine: &mut PluginContext) {
+        println!("Hello, world!");
+    }
+
+    fn on_unload(&mut self, _context: &mut PluginContext) {}
+
+    fn update(&mut self, _context: &mut PluginContext) {}
+
+    fn script_definition_storage(&self) -> Arc<ScriptDefinitionStorage> {
+        self.script_storage.clone()
+    }
+
+    fn type_uuid(&self) -> Uuid {
+        Self::type_uuid()
+    }
+}
+
+#[derive(Visit, Inspect, Debug, Clone)]
+struct TestScript {
+    foo: String,
+
+    hue: f32,
+}
+
+impl Default for TestScript {
+    fn default() -> Self {
+        Self {
+            foo: "Test String".to_string(),
+            hue: 0.0,
+        }
+    }
+}
+
+impl TestScript {
+    fn type_uuid() -> Uuid {
+        Uuid::from_str("4aa165aa-011b-479f-bc10-b90b2c4b5060").unwrap()
+    }
+}
+
+impl ScriptTrait for TestScript {
+    fn on_init(&mut self, _context: &mut ScriptContext) {}
+
+    fn on_update(&mut self, context: &mut ScriptContext) {
+        let transform = context.node.local_transform_mut();
+        let new_rotation = **transform.rotation()
+            * UnitQuaternion::from_axis_angle(&Vector3::x_axis(), 1.0f32.to_radians());
+        transform.set_rotation(new_rotation);
+
+        if let Some(mesh) = context.node.cast_mut::<Mesh>() {
+            for surface in mesh.surfaces_mut() {
+                surface
+                    .material()
+                    .lock()
+                    .set_property(
+                        &ImmutableString::new("diffuseColor"),
+                        PropertyValue::Color(Hsv::new(self.hue, 100.0, 100.0).into()),
+                    )
+                    .unwrap();
+            }
+        }
+        self.hue = (self.hue + 0.2) % 360.0;
+    }
+
+    fn type_uuid(&self) -> Uuid {
+        Self::type_uuid()
+    }
+
+    fn plugin_uuid(&self) -> Uuid {
+        GamePlugin::type_uuid()
+    }
+}
+
+// Script entry point.
+#[no_mangle]
+pub extern "C" fn fyrox_main() -> Box<Box<dyn Plugin>> {
+    Box::new(Box::new(GamePlugin::new()))
+}

--- a/examples/scripting/src/lib.rs
+++ b/examples/scripting/src/lib.rs
@@ -1,18 +1,17 @@
-use fyrox::core::algebra::{UnitQuaternion, Vector3};
-use fyrox::core::sstorage::ImmutableString;
-use fyrox::material::PropertyValue;
-use fyrox::scene::mesh::Mesh;
 use fyrox::{
     core::{
+        algebra::{UnitQuaternion, Vector3},
         color::Hsv,
         inspect::{Inspect, PropertyInfo},
+        sstorage::ImmutableString,
         uuid::Uuid,
         visitor::prelude::*,
     },
+    material::PropertyValue,
     plugin::{Plugin, PluginContext},
+    scene::mesh::Mesh,
     script::{ScriptContext, ScriptDefinition, ScriptDefinitionStorage, ScriptTrait},
 };
-use std::any::TypeId;
 use std::{str::FromStr, sync::Arc};
 
 #[derive(Visit, Inspect, Default)]

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -4,13 +4,6 @@
 // some parts can be unused in some examples.
 #![allow(dead_code)]
 
-use fyrox::engine::EngineInitParams;
-use fyrox::scene::collider::Collider;
-use fyrox::scene::node::constructor::NodeConstructorContainer;
-use fyrox::scene::pivot::PivotBuilder;
-use fyrox::scene::rigidbody::RigidBody;
-use fyrox::scene::sound::effect::{BaseEffectBuilder, Effect, ReverbEffectBuilder};
-use fyrox::scene::sound::listener::ListenerBuilder;
 use fyrox::{
     animation::{
         machine::{Machine, Parameter, PoseNode, State, Transition},
@@ -22,7 +15,7 @@ use fyrox::{
         math::SmoothAngle,
         pool::Handle,
     },
-    engine::{resource_manager::ResourceManager, Engine},
+    engine::{resource_manager::ResourceManager, Engine, EngineInitParams, SerializationContext},
     event::{DeviceEvent, ElementState, VirtualKeyCode},
     event_loop::EventLoop,
     gui::{
@@ -39,10 +32,15 @@ use fyrox::{
     scene::{
         base::BaseBuilder,
         camera::{CameraBuilder, SkyBoxBuilder},
-        collider::{ColliderBuilder, ColliderShape},
+        collider::{Collider, ColliderBuilder, ColliderShape},
         graph::Graph,
         node::Node,
-        rigidbody::{RigidBodyBuilder, RigidBodyType},
+        pivot::PivotBuilder,
+        rigidbody::{RigidBody, RigidBodyBuilder, RigidBodyType},
+        sound::{
+            effect::{BaseEffectBuilder, Effect, ReverbEffectBuilder},
+            listener::ListenerBuilder,
+        },
         transform::TransformBuilder,
         Scene,
     },
@@ -124,11 +122,11 @@ impl Game {
             .with_title(title)
             .with_resizable(true);
 
-        let node_constructors = Arc::new(NodeConstructorContainer::new());
+        let serialization_context = Arc::new(SerializationContext::new());
         let mut engine = Engine::new(EngineInitParams {
             window_builder,
-            resource_manager: ResourceManager::new(node_constructors.clone()),
-            node_constructors,
+            resource_manager: ResourceManager::new(serialization_context.clone()),
+            serialization_context,
             events_loop: &event_loop,
             vsync: false,
         })

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -4,7 +4,9 @@
 // some parts can be unused in some examples.
 #![allow(dead_code)]
 
+use fyrox::engine::EngineInitParams;
 use fyrox::scene::collider::Collider;
+use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::scene::pivot::PivotBuilder;
 use fyrox::scene::rigidbody::RigidBody;
 use fyrox::scene::sound::effect::{BaseEffectBuilder, Effect, ReverbEffectBuilder};
@@ -122,9 +124,15 @@ impl Game {
             .with_title(title)
             .with_resizable(true);
 
-        let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
-
-        let mut engine = Engine::new(window_builder, resource_manager, &event_loop, false).unwrap();
+        let node_constructors = Arc::new(NodeConstructorContainer::new());
+        let mut engine = Engine::new(EngineInitParams {
+            window_builder,
+            resource_manager: ResourceManager::new(node_constructors.clone()),
+            node_constructors,
+            events_loop: &event_loop,
+            vsync: false,
+        })
+        .unwrap();
 
         engine
             .renderer

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -9,6 +9,8 @@
 pub mod shared;
 
 use crate::shared::create_camera;
+use fyrox::engine::EngineInitParams;
+use fyrox::scene::node::constructor::NodeConstructorContainer;
 use fyrox::{
     animation::Animation,
     core::{
@@ -42,6 +44,7 @@ use fyrox::{
     },
     window::Fullscreen,
 };
+use std::sync::Arc;
 use std::time::Instant;
 
 const DEFAULT_MODEL_ROTATION: f32 = 180.0;
@@ -333,9 +336,15 @@ fn main() {
         .with_title("Example - User Interface")
         .with_resizable(true);
 
-    let resource_manager = fyrox::engine::resource_manager::ResourceManager::new();
-
-    let mut engine = Engine::new(window_builder, resource_manager, &event_loop, true).unwrap();
+    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let mut engine = Engine::new(EngineInitParams {
+        window_builder,
+        resource_manager: ResourceManager::new(node_constructors.clone()),
+        node_constructors,
+        events_loop: &event_loop,
+        vsync: false,
+    })
+    .unwrap();
 
     // Create simple user interface that will show some useful info.
     let interface = create_ui(&mut engine);

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -9,8 +9,7 @@
 pub mod shared;
 
 use crate::shared::create_camera;
-use fyrox::engine::EngineInitParams;
-use fyrox::scene::node::constructor::NodeConstructorContainer;
+use fyrox::engine::{EngineInitParams, SerializationContext};
 use fyrox::{
     animation::Animation,
     core::{
@@ -336,11 +335,11 @@ fn main() {
         .with_title("Example - User Interface")
         .with_resizable(true);
 
-    let node_constructors = Arc::new(NodeConstructorContainer::new());
+    let serialization_context = Arc::new(SerializationContext::new());
     let mut engine = Engine::new(EngineInitParams {
         window_builder,
-        resource_manager: ResourceManager::new(node_constructors.clone()),
-        node_constructors,
+        resource_manager: ResourceManager::new(serialization_context.clone()),
+        serialization_context,
         events_loop: &event_loop,
         vsync: false,
     })

--- a/fyrox-core/src/visitor.rs
+++ b/fyrox-core/src/visitor.rs
@@ -844,8 +844,7 @@ impl Visitor {
         out_string
     }
 
-    pub fn save_binary<P: AsRef<Path>>(&self, path: P) -> VisitResult {
-        let mut writer = BufWriter::new(File::create(path)?);
+    pub fn save_binary_to_memory<W: Write>(&self, mut writer: W) -> VisitResult {
         writer.write_all(Self::MAGIC.as_bytes())?;
         let mut stack = vec![self.root];
         while let Some(node_handle) = stack.pop() {
@@ -863,6 +862,11 @@ impl Visitor {
             stack.extend_from_slice(&node.children);
         }
         Ok(())
+    }
+
+    pub fn save_binary<P: AsRef<Path>>(&self, path: P) -> VisitResult {
+        let writer = BufWriter::new(File::create(path)?);
+        self.save_binary_to_memory(writer)
     }
 
     fn load_node_binary(&mut self, file: &mut dyn Read) -> Result<Handle<Node>, VisitError> {

--- a/fyrox-core/src/visitor.rs
+++ b/fyrox-core/src/visitor.rs
@@ -716,6 +716,7 @@ pub struct Visitor {
     reading: bool,
     current_node: Handle<Node>,
     root: Handle<Node>,
+    pub environment: Option<Arc<dyn Any>>,
 }
 
 pub trait Visit {
@@ -741,6 +742,7 @@ impl Visitor {
             reading: false,
             current_node: root,
             root,
+            environment: None,
         }
     }
 
@@ -914,6 +916,7 @@ impl Visitor {
             reading: true,
             current_node: Handle::NONE,
             root: Handle::NONE,
+            environment: None,
         };
         visitor.root = visitor.load_node_binary(&mut reader)?;
         visitor.current_node = visitor.root;

--- a/fyrox-ui/src/inspector/editors/array.rs
+++ b/fyrox-ui/src/inspector/editors/array.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     border::BorderBuilder,
     brush::Brush,
@@ -307,17 +308,12 @@ where
         }
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
-            if let Some(collection_changed) = message.data::<CollectionChanged>() {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(collection_changed) = ctx.message.data::<CollectionChanged>() {
                 return Some(PropertyChanged {
-                    name: name.to_string(),
-                    owner_type_id,
+                    name: ctx.name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::Collection(Box::new(collection_changed.clone())),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/bool.rs
+++ b/fyrox-ui/src/inspector/editors/bool.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     check_box::{CheckBoxBuilder, CheckBoxMessage},
     inspector::{
@@ -49,17 +50,13 @@ impl PropertyEditorDefinition for BoolPropertyEditorDefinition {
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
-            if let Some(CheckBoxMessage::Check(Some(value))) = message.data::<CheckBoxMessage>() {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(CheckBoxMessage::Check(Some(value))) = ctx.message.data::<CheckBoxMessage>()
+            {
                 return Some(PropertyChanged {
-                    name: name.to_string(),
-                    owner_type_id,
+                    name: ctx.name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::object(*value),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/collection.rs
+++ b/fyrox-ui/src/inspector/editors/collection.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     button::{ButtonBuilder, ButtonMessage},
     core::{inspect::Inspect, pool::Handle},
@@ -432,17 +433,12 @@ where
         }
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
-            if let Some(collection_changed) = message.data::<CollectionChanged>() {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(collection_changed) = ctx.message.data::<CollectionChanged>() {
                 return Some(PropertyChanged {
-                    name: name.to_string(),
-                    owner_type_id,
+                    name: ctx.name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::Collection(Box::new(collection_changed.clone())),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/color.rs
+++ b/fyrox-ui/src/inspector/editors/color.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     color::{ColorFieldBuilder, ColorFieldMessage},
     core::color::Color,
@@ -48,17 +49,12 @@ impl PropertyEditorDefinition for ColorPropertyEditorDefinition {
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
-            if let Some(ColorFieldMessage::Color(value)) = message.data::<ColorFieldMessage>() {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(ColorFieldMessage::Color(value)) = ctx.message.data::<ColorFieldMessage>() {
                 return Some(PropertyChanged {
-                    name: name.to_string(),
-                    owner_type_id,
+                    name: ctx.name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::object(*value),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/enumeration.rs
+++ b/fyrox-ui/src/inspector/editors/enumeration.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     border::BorderBuilder,
     core::{inspect::Inspect, pool::Handle},
@@ -441,24 +442,19 @@ where
         }
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if let Some(msg) = message.data::<EnumPropertyEditorMessage>() {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if let Some(msg) = ctx.message.data::<EnumPropertyEditorMessage>() {
             return match msg {
                 EnumPropertyEditorMessage::PropertyChanged(property_changed) => {
                     Some(PropertyChanged {
-                        name: name.to_string(),
-                        owner_type_id,
+                        name: ctx.name.to_string(),
+                        owner_type_id: ctx.owner_type_id,
                         value: FieldKind::Inspectable(Box::new(property_changed.clone())),
                     })
                 }
                 EnumPropertyEditorMessage::Variant(index) => Some(PropertyChanged {
-                    name: name.to_string(),
-                    owner_type_id,
+                    name: ctx.name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::object((self.variant_generator)(*index)),
                 }),
             };

--- a/fyrox-ui/src/inspector/editors/inspectable.rs
+++ b/fyrox-ui/src/inspector/editors/inspectable.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     core::inspect::Inspect,
     inspector::{
@@ -111,17 +112,13 @@ where
         }
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if let Some(InspectorMessage::PropertyChanged(msg)) = message.data::<InspectorMessage>() {
-            if message.direction() == MessageDirection::FromWidget {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if let Some(InspectorMessage::PropertyChanged(msg)) = ctx.message.data::<InspectorMessage>()
+        {
+            if ctx.message.direction() == MessageDirection::FromWidget {
                 return Some(PropertyChanged {
-                    name: name.to_owned(),
-                    owner_type_id,
+                    name: ctx.name.to_owned(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::Inspectable(Box::new(msg.clone())),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/mod.rs
+++ b/fyrox-ui/src/inspector/editors/mod.rs
@@ -53,6 +53,13 @@ pub struct PropertyEditorMessageContext<'a, 'b> {
     pub layer_index: usize,
 }
 
+pub struct PropertyEditorTranslationContext<'b, 'c> {
+    pub environment: Option<Rc<dyn InspectorEnvironment>>,
+    pub name: &'b str,
+    pub owner_type_id: TypeId,
+    pub message: &'c UiMessage,
+}
+
 pub enum PropertyEditorInstance {
     Simple {
         /// A property editor. Could be any widget that capable of editing a property
@@ -81,12 +88,7 @@ pub trait PropertyEditorDefinition: Debug {
         ctx: PropertyEditorMessageContext,
     ) -> Result<Option<UiMessage>, InspectorError>;
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged>;
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged>;
 }
 
 #[derive(Clone, Default)]

--- a/fyrox-ui/src/inspector/editors/numeric.rs
+++ b/fyrox-ui/src/inspector/editors/numeric.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     core::num_traits::NumCast,
     inspector::{
@@ -86,19 +87,14 @@ where
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
             if let Some(NumericUpDownMessage::Value(value)) =
-                message.data::<NumericUpDownMessage<T>>()
+                ctx.message.data::<NumericUpDownMessage<T>>()
             {
                 return Some(PropertyChanged {
-                    name: name.to_string(),
-                    owner_type_id,
+                    name: ctx.name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::object(*value),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/quat.rs
+++ b/fyrox-ui/src/inspector/editors/quat.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     core::{
         algebra::{RealField, SimdRealField, SimdValue, UnitQuaternion, Vector3},
@@ -86,14 +87,11 @@ where
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
-            if let Some(Vec3EditorMessage::Value(value)) = message.data::<Vec3EditorMessage<T>>() {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(Vec3EditorMessage::Value(value)) =
+                ctx.message.data::<Vec3EditorMessage<T>>()
+            {
                 let euler = Vector3::new(
                     value.x.to_radians(),
                     value.y.to_radians(),
@@ -101,8 +99,8 @@ where
                 );
                 let rotation = quat_from_euler(euler, RotationOrder::XYZ);
                 return Some(PropertyChanged {
-                    owner_type_id,
-                    name: name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
+                    name: ctx.name.to_string(),
                     value: FieldKind::object(rotation),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/range.rs
+++ b/fyrox-ui/src/inspector/editors/range.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     inspector::{
         editors::{
@@ -57,18 +58,14 @@ impl<T: NumericType> PropertyEditorDefinition for RangePropertyEditorDefinition<
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
-            if let Some(RangeEditorMessage::Value(value)) = message.data::<RangeEditorMessage<T>>()
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(RangeEditorMessage::Value(value)) =
+                ctx.message.data::<RangeEditorMessage<T>>()
             {
                 return Some(PropertyChanged {
-                    name: name.to_string(),
-                    owner_type_id,
+                    name: ctx.name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::object(value.clone()),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/rect.rs
+++ b/fyrox-ui/src/inspector/editors/rect.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     core::math::Rect,
     inspector::{
@@ -75,17 +76,14 @@ where
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
-            if let Some(RectEditorMessage::Value(value)) = message.data::<RectEditorMessage<T>>() {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(RectEditorMessage::Value(value)) =
+                ctx.message.data::<RectEditorMessage<T>>()
+            {
                 return Some(PropertyChanged {
-                    name: name.to_string(),
-                    owner_type_id,
+                    name: ctx.name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
                     value: FieldKind::object(*value),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/string.rs
+++ b/fyrox-ui/src/inspector/editors/string.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     inspector::{
         editors::{
@@ -46,17 +47,12 @@ impl PropertyEditorDefinition for StringPropertyEditorDefinition {
         )))
     }
 
-    fn translate_message(
-        &self,
-        name: &str,
-        owner_type_id: TypeId,
-        message: &UiMessage,
-    ) -> Option<PropertyChanged> {
-        if message.direction() == MessageDirection::FromWidget {
-            if let Some(TextBoxMessage::Text(value)) = message.data::<TextBoxMessage>() {
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(TextBoxMessage::Text(value)) = ctx.message.data::<TextBoxMessage>() {
                 return Some(PropertyChanged {
-                    owner_type_id,
-                    name: name.to_string(),
+                    owner_type_id: ctx.owner_type_id,
+                    name: ctx.name.to_string(),
                     value: FieldKind::object(value.clone()),
                 });
             }

--- a/fyrox-ui/src/inspector/editors/vec.rs
+++ b/fyrox-ui/src/inspector/editors/vec.rs
@@ -3,7 +3,7 @@ use crate::{
     inspector::{
         editors::{
             PropertyEditorBuildContext, PropertyEditorDefinition, PropertyEditorInstance,
-            PropertyEditorMessageContext,
+            PropertyEditorMessageContext, PropertyEditorTranslationContext,
         },
         FieldKind, InspectorError, PropertyChanged,
     },
@@ -67,15 +67,13 @@ macro_rules! define_vector_editor {
 
             fn translate_message(
                 &self,
-                name: &str,
-                owner_type_id: TypeId,
-                message: &UiMessage,
+                ctx: PropertyEditorTranslationContext,
             ) -> Option<PropertyChanged> {
-                if message.direction() == MessageDirection::FromWidget {
-                    if let Some($message::Value(value)) = message.data::<$message<$t>>() {
+                if ctx.message.direction() == MessageDirection::FromWidget {
+                    if let Some($message::Value(value)) = ctx.message.data::<$message<$t>>() {
                         return Some(PropertyChanged {
-                            owner_type_id,
-                            name: name.to_string(),
+                            owner_type_id: ctx.owner_type_id,
+                            name: ctx.name.to_string(),
                             value: FieldKind::object(*value),
                         });
                     }

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -1,3 +1,4 @@
+use crate::inspector::editors::PropertyEditorTranslationContext;
 use crate::{
     border::BorderBuilder,
     check_box::CheckBoxBuilder,
@@ -529,12 +530,16 @@ impl Control for Inspector {
         // Check each message from descendant widget and try to translate it to
         // PropertyChanged message.
         if message.flags != self.context.sync_flag {
+            let env = self.context.environment.clone();
             for entry in self.context.entries.iter() {
                 if message.destination() == entry.property_editor {
                     if let Some(args) = entry.property_editor_definition.translate_message(
-                        &entry.property_name,
-                        entry.property_owner_type_id,
-                        message,
+                        PropertyEditorTranslationContext {
+                            environment: env.clone(),
+                            name: &entry.property_name,
+                            owner_type_id: entry.property_owner_type_id,
+                            message,
+                        },
                     ) {
                         ui.send_message(InspectorMessage::property_changed(
                             self.handle,

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -141,7 +141,7 @@ impl InspectorMessage {
     define_constructor!(InspectorMessage:PropertyChanged => fn property_changed(PropertyChanged), layout: false);
 }
 
-pub trait InspectorEnvironment: Any + Send + Sync {
+pub trait InspectorEnvironment: Any {
     fn as_any(&self) -> &dyn Any;
 }
 
@@ -206,9 +206,9 @@ impl PartialEq for ContextEntry {
 pub struct InspectorContext {
     stack_panel: Handle<UiNode>,
     entries: Vec<ContextEntry>,
-    property_definitions: Rc<PropertyEditorDefinitionContainer>,
-    environment: Option<Rc<dyn InspectorEnvironment>>,
-    sync_flag: u64,
+    pub property_definitions: Rc<PropertyEditorDefinitionContainer>,
+    pub environment: Option<Rc<dyn InspectorEnvironment>>,
+    pub sync_flag: u64,
 }
 
 impl PartialEq for InspectorContext {
@@ -563,6 +563,13 @@ impl InspectorBuilder {
 
     pub fn with_context(mut self, context: InspectorContext) -> Self {
         self.context = context;
+        self
+    }
+
+    pub fn with_opt_context(mut self, context: Option<InspectorContext>) -> Self {
+        if let Some(context) = context {
+            self.context = context;
+        }
         self
     }
 

--- a/src/engine/framework.rs
+++ b/src/engine/framework.rs
@@ -4,9 +4,8 @@
 //! Once you get familiar with the engine, you should **not** use the framework because it is too
 //! limiting and may slow you down.
 
-use crate::engine::EngineInitParams;
+use crate::engine::{EngineInitParams, SerializationContext};
 use crate::gui::message::UiMessage;
-use crate::scene::node::constructor::NodeConstructorContainer;
 use crate::utils::log::{Log, MessageKind};
 use crate::{
     core::instant::Instant,
@@ -64,12 +63,12 @@ impl<State: GameState> Framework<State> {
     pub fn new() -> Result<Self, EngineError> {
         let event_loop = EventLoop::new();
 
-        let node_constructors = Arc::new(NodeConstructorContainer::new());
+        let serialization_context = Arc::new(SerializationContext::new());
 
         let mut engine = Engine::new(EngineInitParams {
             window_builder: WindowBuilder::new().with_title("Game").with_resizable(true),
-            resource_manager: ResourceManager::new(node_constructors.clone()),
-            node_constructors,
+            resource_manager: ResourceManager::new(serialization_context.clone()),
+            serialization_context,
             events_loop: &event_loop,
             vsync: false,
         })?;

--- a/src/engine/framework.rs
+++ b/src/engine/framework.rs
@@ -4,7 +4,9 @@
 //! Once you get familiar with the engine, you should **not** use the framework because it is too
 //! limiting and may slow you down.
 
+use crate::engine::EngineInitParams;
 use crate::gui::message::UiMessage;
+use crate::scene::node::constructor::NodeConstructorContainer;
 use crate::utils::log::{Log, MessageKind};
 use crate::{
     core::instant::Instant,
@@ -14,6 +16,7 @@ use crate::{
     utils::translate_event,
     window::WindowBuilder,
 };
+use std::sync::Arc;
 
 #[doc(hidden)]
 pub mod prelude {
@@ -61,10 +64,15 @@ impl<State: GameState> Framework<State> {
     pub fn new() -> Result<Self, EngineError> {
         let event_loop = EventLoop::new();
 
-        let window_builder = WindowBuilder::new().with_title("Game").with_resizable(true);
-        let resource_manager = ResourceManager::new();
+        let node_constructors = Arc::new(NodeConstructorContainer::new());
 
-        let mut engine = Engine::new(window_builder, resource_manager, &event_loop, false)?;
+        let mut engine = Engine::new(EngineInitParams {
+            window_builder: WindowBuilder::new().with_title("Game").with_resizable(true),
+            resource_manager: ResourceManager::new(node_constructors.clone()),
+            node_constructors,
+            events_loop: &event_loop,
+            vsync: false,
+        })?;
 
         Ok(Self {
             title: "Game".to_owned(),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -388,4 +388,24 @@ impl Engine {
     pub fn sound_gain(&self) -> f32 {
         self.sound_engine.lock().unwrap().master_gain()
     }
+
+    pub fn unload_plugins(&mut self) {
+        self.plugins.clear(&mut PluginContext {
+            scenes: &mut self.scenes,
+            ui: &mut self.user_interface,
+            resource_manager: &self.resource_manager,
+            renderer: &mut self.renderer,
+            dt: 0.0,
+        });
+    }
+
+    pub fn reload_plugins(&mut self) {
+        self.plugins.rescan(&mut PluginContext {
+            scenes: &mut self.scenes,
+            ui: &mut self.user_interface,
+            resource_manager: &self.resource_manager,
+            renderer: &mut self.renderer,
+            dt: 0.0,
+        });
+    }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -332,7 +332,7 @@ impl Engine {
 
         for scene in self.scenes.iter_mut().filter(|s| s.enabled) {
             for node in scene.graph.linear_iter_mut() {
-                if let Some(script) = node.script.as_mut() {
+                if let Some(mut script) = node.script.take() {
                     if let Some(plugin) = self
                         .plugins
                         .plugins
@@ -341,7 +341,10 @@ impl Engine {
                     {
                         script.on_update(&mut ScriptContext {
                             plugin: &mut **plugin,
+                            node,
                         });
+
+                        node.script = Some(script);
                     }
                 }
             }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -25,7 +25,6 @@ use crate::{
     scene::{sound::SoundEngine, SceneContainer},
     window::{Window, WindowBuilder},
 };
-use std::any::Any;
 use std::{
     collections::HashSet,
     sync::{
@@ -408,6 +407,7 @@ impl Engine {
         self.sound_engine.lock().unwrap().master_gain()
     }
 
+    /// Unloads all currently loaded plugins.
     pub fn unload_plugins(&mut self) {
         self.plugins.clear(&mut PluginContext {
             scenes: &mut self.scenes,
@@ -418,6 +418,7 @@ impl Engine {
         });
     }
 
+    /// Re-loads all available plugins.
     pub fn reload_plugins(&mut self) {
         self.plugins.rescan(&mut PluginContext {
             scenes: &mut self.scenes,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -423,7 +423,7 @@ impl Engine {
 
     /// Re-loads all available plugins.
     pub fn reload_plugins(&mut self) {
-        self.plugins.rescan(&mut PluginContext {
+        self.plugins.reload(&mut PluginContext {
             scenes: &mut self.scenes,
             ui: &mut self.user_interface,
             resource_manager: &self.resource_manager,

--- a/src/engine/resource_manager/loader/model.rs
+++ b/src/engine/resource_manager/loader/model.rs
@@ -1,6 +1,6 @@
 //! Model loader.
 
-use crate::scene::node::constructor::NodeConstructorContainer;
+use crate::engine::SerializationContext;
 use crate::{
     engine::resource_manager::{
         container::event::ResourceEventBroadcaster,
@@ -19,7 +19,7 @@ pub struct ModelLoader {
     pub resource_manager: ResourceManager,
     /// Node constructors contains a set of constructors that allows to build a node using its
     /// type UUID.
-    pub node_constructors: Arc<NodeConstructorContainer>,
+    pub serialization_context: Arc<SerializationContext>,
 }
 
 impl ResourceLoader<Model, ModelImportOptions> for ModelLoader {
@@ -31,7 +31,7 @@ impl ResourceLoader<Model, ModelImportOptions> for ModelLoader {
         reload: bool,
     ) -> BoxedLoaderFuture {
         let resource_manager = self.resource_manager.clone();
-        let node_constructors = self.node_constructors.clone();
+        let node_constructors = self.serialization_context.clone();
 
         Box::pin(async move {
             let path = model.state().path().to_path_buf();

--- a/src/engine/resource_manager/mod.rs
+++ b/src/engine/resource_manager/mod.rs
@@ -1,6 +1,6 @@
 //! Resource manager controls loading and lifetime of resource in the engine.
 
-use crate::scene::node::constructor::NodeConstructorContainer;
+use crate::engine::SerializationContext;
 use crate::utils::log::Log;
 use crate::utils::watcher::FileSystemWatcher;
 use crate::{
@@ -131,7 +131,7 @@ impl From<TextureError> for TextureRegistrationError {
 
 impl ResourceManager {
     /// Creates a resource manager with default settings and loaders.
-    pub fn new(node_constructors: Arc<NodeConstructorContainer>) -> Self {
+    pub fn new(serialization_context: Arc<SerializationContext>) -> Self {
         let resource_manager = Self {
             state: Arc::new(Mutex::new(ResourceManagerState::new())),
         };
@@ -144,7 +144,7 @@ impl ResourceManager {
                 task_pool.clone(),
                 Box::new(ModelLoader {
                     resource_manager: resource_manager.clone(),
-                    node_constructors,
+                    serialization_context,
                 }),
             ),
             sound_buffers: ResourceContainer::new(task_pool.clone(), Box::new(SoundBufferLoader)),

--- a/src/engine/resource_manager/mod.rs
+++ b/src/engine/resource_manager/mod.rs
@@ -1,6 +1,7 @@
 //! Resource manager controls loading and lifetime of resource in the engine.
 
 use crate::utils::log::Log;
+use crate::utils::watcher::FileSystemWatcher;
 use crate::{
     core::{
         futures::future::join_all,
@@ -18,7 +19,6 @@ use crate::{
             ResourceLoader,
         },
         task::TaskPool,
-        watcher::ResourceWatcher,
     },
     material::shader::{Shader, ShaderImportOptions},
     resource::{
@@ -35,7 +35,6 @@ pub mod container;
 pub mod loader;
 pub mod options;
 mod task;
-pub mod watcher;
 
 /// Storage of resource containers.
 pub struct ContainersStorage {
@@ -100,7 +99,7 @@ impl ContainersStorage {
 /// See module docs.
 pub struct ResourceManagerState {
     containers_storage: Option<ContainersStorage>,
-    watcher: Option<ResourceWatcher>,
+    watcher: Option<FileSystemWatcher>,
 }
 
 /// See module docs.
@@ -349,7 +348,7 @@ impl ResourceManagerState {
     /// the manager to reload changed resources. By default there is no watcher, since it
     /// may be an undesired effect to reload resources at runtime. This is very useful thing
     /// for fast iterative development.
-    pub fn set_watcher(&mut self, watcher: Option<ResourceWatcher>) {
+    pub fn set_watcher(&mut self, watcher: Option<FileSystemWatcher>) {
         self.watcher = watcher;
     }
 

--- a/src/engine/resource_manager/mod.rs
+++ b/src/engine/resource_manager/mod.rs
@@ -1,5 +1,6 @@
 //! Resource manager controls loading and lifetime of resource in the engine.
 
+use crate::scene::node::constructor::NodeConstructorContainer;
 use crate::utils::log::Log;
 use crate::utils::watcher::FileSystemWatcher;
 use crate::{
@@ -128,15 +129,9 @@ impl From<TextureError> for TextureRegistrationError {
     }
 }
 
-impl Default for ResourceManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ResourceManager {
     /// Creates a resource manager with default settings and loaders.
-    pub fn new() -> Self {
+    pub fn new(node_constructors: Arc<NodeConstructorContainer>) -> Self {
         let resource_manager = Self {
             state: Arc::new(Mutex::new(ResourceManagerState::new())),
         };
@@ -149,6 +144,7 @@ impl ResourceManager {
                 task_pool.clone(),
                 Box::new(ModelLoader {
                     resource_manager: resource_manager.clone(),
+                    node_constructors,
                 }),
             ),
             sound_buffers: ResourceContainer::new(task_pool.clone(), Box::new(SoundBufferLoader)),

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,0 +1,88 @@
+use crate::{
+    core::{inspect::Inspect, uuid::Uuid, visitor::Visit},
+    engine::Engine,
+};
+use fxhash::FxHashMap;
+use libloading::{Library, Symbol};
+use std::{
+    ffi::{OsStr, OsString},
+    ops::{Deref, DerefMut},
+    path::Path,
+};
+
+pub trait GameTrait: Visit + Inspect {
+    fn on_init(&mut self, engine: &mut Engine);
+
+    fn script_definition_storage(&self) -> &ScriptDefinitionStorage;
+}
+
+pub type EntryPoint = extern "C" fn() -> Box<Box<dyn GameTrait>>;
+
+pub struct Game {
+    entry: Box<dyn GameTrait>,
+
+    lib_path: OsString,
+
+    // Must be last to be dropped last!
+    #[allow(dead_code)]
+    library: Library,
+}
+
+impl Deref for Game {
+    type Target = dyn GameTrait;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.entry
+    }
+}
+
+impl DerefMut for Game {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.entry
+    }
+}
+
+impl Game {
+    pub fn try_load<P: AsRef<OsStr>>(path: P) -> Result<Self, libloading::Error> {
+        unsafe {
+            let library = libloading::Library::new(path)?;
+
+            let fyrox_main: Symbol<EntryPoint> = library.get(b"fyrox_main\0")?;
+
+            let entry: Box<Box<dyn GameTrait>> = fyrox_main();
+
+            Ok(Self {
+                library,
+                lib_path: path.as_ref().to_os_string(),
+                entry: *entry,
+            })
+        }
+    }
+
+    pub fn lib_path(&self) -> &OsStr {
+        &self.lib_path
+    }
+}
+
+pub trait Script: Visit + Inspect {
+    fn on_init(&mut self);
+
+    fn type_uuid(&self) -> Uuid;
+}
+
+pub struct ScriptDefinition {
+    pub name: String,
+    pub type_uuid: Uuid,
+    pub constructor: Box<dyn FnMut() -> Box<dyn Script>>,
+}
+
+#[derive(Default)]
+pub struct ScriptDefinitionStorage {
+    map: FxHashMap<Uuid, ScriptDefinition>,
+}
+
+impl ScriptDefinitionStorage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod plugin;
 pub mod renderer;
 pub mod resource;
 pub mod scene;
+pub mod script;
 pub mod utils;
 
 pub use crate::core::rand;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod animation;
 pub mod engine;
+pub mod game;
 pub mod material;
 pub mod renderer;
 pub mod resource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@
 
 pub mod animation;
 pub mod engine;
-pub mod game;
 pub mod material;
+pub mod plugin;
 pub mod renderer;
 pub mod resource;
 pub mod scene;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::approx_constant)]
 
 pub mod animation;
+pub mod editor;
 pub mod engine;
 pub mod material;
 pub mod plugin;

--- a/src/plugin/container.rs
+++ b/src/plugin/container.rs
@@ -1,0 +1,150 @@
+use crate::{
+    core::pool::{Handle, Pool},
+    plugin::{DynamicPlugin, PluginContext},
+    utils::{log::Log, watcher::FileSystemWatcher},
+};
+use notify::DebouncedEvent;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub struct PluginContainer {
+    pub(crate) plugins: Pool<DynamicPlugin>,
+    watcher: Option<FileSystemWatcher>,
+}
+
+fn unload_plugin(mut plugin: DynamicPlugin, context: &mut PluginContext) {
+    plugin.on_unload(context);
+}
+
+impl PluginContainer {
+    pub fn new() -> Self {
+        Self {
+            plugins: Default::default(),
+            watcher: None,
+        }
+    }
+
+    pub fn rescan(&mut self, context: &mut PluginContext) {
+        self.clear(context);
+
+        Log::info("Looking for plugins recursively from working directory...".to_owned());
+
+        let mut libs = HashMap::<OsString, PathBuf>::new();
+        for dir in walkdir::WalkDir::new(".").into_iter().flatten() {
+            let path = dir.path();
+            if let (Some(file_name), Some(extension)) = (path.file_name(), path.extension()) {
+                if let Some(file_name_str) = path.file_stem().and_then(|s| s.to_str()) {
+                    if !file_name_str.ends_with("_plugin") {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+
+                if extension == "dll" || extension == "dylib" || extension == "so" {
+                    if let Some(prev_candidate) = libs.get_mut(file_name) {
+                        if let (Ok(new_candidate_modified_time), Ok(prev_candidate_modified_time)) = (
+                            prev_candidate.metadata().and_then(|m| m.modified()),
+                            path.metadata().and_then(|m| m.modified()),
+                        ) {
+                            if new_candidate_modified_time > prev_candidate_modified_time {
+                                *prev_candidate = path.to_path_buf();
+                            }
+                        }
+                    } else {
+                        libs.insert(file_name.to_os_string(), path.to_path_buf());
+                    }
+                }
+            }
+        }
+
+        for path in libs.values() {
+            match DynamicPlugin::try_load(path) {
+                Ok(mut plugin) => {
+                    plugin.on_init(context);
+                    let _ = self.plugins.spawn(plugin);
+
+                    Log::info(format!(
+                        "Plugin {} was loaded successfully!",
+                        path.display()
+                    ))
+                }
+                Err(e) => Log::err(format!(
+                    "Unable to load plugin from {}. Reason: {:?}",
+                    path.display(),
+                    e
+                )),
+            }
+        }
+
+        Log::info(format!(
+            "{} plugins were loaded successfully!",
+            self.plugins.alive_count()
+        ));
+    }
+
+    pub fn add(&mut self, wrapper: DynamicPlugin) -> Handle<DynamicPlugin> {
+        self.plugins.spawn(wrapper)
+    }
+
+    pub fn free(&mut self, handle: Handle<DynamicPlugin>, context: &mut PluginContext) {
+        unload_plugin(self.plugins.free(handle), context);
+    }
+
+    pub fn clear(&mut self, context: &mut PluginContext) {
+        let plugin_count = self.plugins.alive_count();
+
+        Log::info(format!("Unloading {} plugins...", plugin_count));
+
+        for i in 0..self.plugins.get_capacity() {
+            if self.plugins.at(i).is_some() {
+                let handle = self.plugins.handle_from_index(i);
+                unload_plugin(self.plugins.free(handle), context);
+            }
+        }
+
+        Log::info(format!(
+            "{} plugins were unloaded successfully!",
+            plugin_count
+        ));
+    }
+
+    pub fn set_watcher(&mut self, watcher: Option<FileSystemWatcher>) {
+        self.watcher = watcher;
+    }
+
+    pub fn handle_fs_events(&mut self, context: &mut PluginContext) {
+        if let Some(watcher) = self.watcher.as_ref() {
+            while let Some(DebouncedEvent::Write(path)) = watcher.try_get_event() {
+                'plugin_loop: for i in 0..self.plugins.get_capacity() {
+                    if self.plugins.at(i).map_or(false, |p| p.lib_path == path) {
+                        let handle = self.plugins.handle_from_index(i);
+
+                        // Unload old plugin first.
+                        unload_plugin(self.plugins.free(handle), context);
+
+                        // Try to load new plugin.
+                        match DynamicPlugin::try_load(path.as_os_str()) {
+                            Ok(mut dynamic_plugin) => {
+                                dynamic_plugin.on_init(context);
+                                // Put plugin at its previous position to keep update order deterministic
+                                // This must never fail, because index is guaranteed to be free.
+                                if self.plugins.spawn_at(i, dynamic_plugin).is_err() {
+                                    panic!("Unable to preserve plugin location at {}!", i)
+                                }
+                            }
+                            Err(e) => Log::err(format!(
+                                "Failed to re-load plugin {}! Reason: {:?}",
+                                path.display(),
+                                e
+                            )),
+                        }
+
+                        break 'plugin_loop;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/plugin/container.rs
+++ b/src/plugin/container.rs
@@ -147,4 +147,8 @@ impl PluginContainer {
             }
         }
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &DynamicPlugin> {
+        self.plugins.iter()
+    }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,16 +1,16 @@
 use crate::{
-    core::{inspect::Inspect, visitor::Visit},
+    core::{inspect::Inspect, uuid::Uuid, visitor::Visit},
     engine::resource_manager::ResourceManager,
     gui::UserInterface,
     renderer::Renderer,
     scene::SceneContainer,
     script::ScriptDefinitionStorage,
 };
-use fyrox_core::uuid::Uuid;
 use libloading::{Library, Symbol};
 use std::{
     ffi::{OsStr, OsString},
     ops::{Deref, DerefMut},
+    sync::Arc,
 };
 
 pub mod container;
@@ -30,7 +30,7 @@ pub trait Plugin: Visit + Inspect {
 
     fn update(&mut self, context: &mut PluginContext);
 
-    fn script_definition_storage(&self) -> &ScriptDefinitionStorage;
+    fn script_definition_storage(&self) -> Arc<ScriptDefinitionStorage>;
 
     fn type_uuid(&self) -> Uuid;
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,10 +1,10 @@
+use crate::engine::SerializationContext;
 use crate::{
     core::{inspect::Inspect, uuid::Uuid, visitor::Visit},
     engine::resource_manager::ResourceManager,
     gui::UserInterface,
     renderer::Renderer,
     scene::SceneContainer,
-    script::ScriptDefinitionStorage,
 };
 use libloading::{Library, Symbol};
 use serde::Deserialize;
@@ -12,7 +12,6 @@ use std::{
     ffi::{OsStr, OsString},
     ops::{Deref, DerefMut},
     path::PathBuf,
-    sync::Arc,
 };
 
 pub mod container;
@@ -23,6 +22,7 @@ pub struct PluginContext<'a> {
     pub resource_manager: &'a ResourceManager,
     pub renderer: &'a mut Renderer,
     pub dt: f32,
+    pub serialization_context: &'a SerializationContext,
 }
 
 pub trait Plugin: Visit + Inspect {
@@ -31,8 +31,6 @@ pub trait Plugin: Visit + Inspect {
     fn on_unload(&mut self, context: &mut PluginContext);
 
     fn update(&mut self, context: &mut PluginContext);
-
-    fn script_definition_storage(&self) -> Arc<ScriptDefinitionStorage>;
 
     fn type_uuid(&self) -> Uuid;
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     scene::SceneContainer,
     script::ScriptDefinitionStorage,
 };
+use fyrox_core::uuid::Uuid;
 use libloading::{Library, Symbol};
 use std::{
     ffi::{OsStr, OsString},
@@ -30,6 +31,8 @@ pub trait Plugin: Visit + Inspect {
     fn update(&mut self, context: &mut PluginContext);
 
     fn script_definition_storage(&self) -> &ScriptDefinitionStorage;
+
+    fn type_uuid(&self) -> Uuid;
 }
 
 pub type EntryPoint = extern "C" fn() -> Box<Box<dyn Plugin>>;

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -7,9 +7,11 @@ use crate::{
     script::ScriptDefinitionStorage,
 };
 use libloading::{Library, Symbol};
+use serde::Deserialize;
 use std::{
     ffi::{OsStr, OsString},
     ops::{Deref, DerefMut},
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -36,6 +38,12 @@ pub trait Plugin: Visit + Inspect {
 }
 
 pub type EntryPoint = extern "C" fn() -> Box<Box<dyn Plugin>>;
+
+#[derive(Deserialize)]
+pub struct PluginDefinition {
+    name: String,
+    path: PathBuf,
+}
 
 pub struct DynamicPlugin {
     entry: Box<dyn Plugin>,

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,11 +1,11 @@
 use crate::{
-    core::{inspect::Inspect, uuid::Uuid, visitor::Visit},
+    core::{inspect::Inspect, visitor::Visit},
     engine::resource_manager::ResourceManager,
     gui::UserInterface,
     renderer::Renderer,
     scene::SceneContainer,
+    script::ScriptDefinitionStorage,
 };
-use fxhash::FxHashMap;
 use libloading::{Library, Symbol};
 use std::{
     ffi::{OsStr, OsString},
@@ -77,28 +77,5 @@ impl DynamicPlugin {
 
     pub fn lib_path(&self) -> &OsStr {
         &self.lib_path
-    }
-}
-
-pub trait Script: Visit + Inspect {
-    fn on_init(&mut self);
-
-    fn type_uuid(&self) -> Uuid;
-}
-
-pub struct ScriptDefinition {
-    pub name: String,
-    pub type_uuid: Uuid,
-    pub constructor: Box<dyn FnMut() -> Box<dyn Script>>,
-}
-
-#[derive(Default)]
-pub struct ScriptDefinitionStorage {
-    map: FxHashMap<Uuid, ScriptDefinition>,
-}
-
-impl ScriptDefinitionStorage {
-    pub fn new() -> Self {
-        Self::default()
     }
 }

--- a/src/resource/model.rs
+++ b/src/resource/model.rs
@@ -18,6 +18,7 @@
 //! Currently only FBX (common format in game industry for storing complex 3d models)
 //! and RGS (native Fyroxed format) formats are supported.
 use crate::scene::graph::Graph;
+use crate::scene::node::constructor::NodeConstructorContainer;
 use crate::{
     animation::Animation,
     asset::{define_new_resource, Resource, ResourceData},
@@ -33,6 +34,7 @@ use crate::{
 };
 use fxhash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::{
     borrow::Cow,
     path::{Path, PathBuf},
@@ -364,6 +366,7 @@ impl From<VisitError> for ModelLoadError {
 impl ModelData {
     pub(in crate) async fn load<P: AsRef<Path>>(
         path: P,
+        node_constructors: Arc<NodeConstructorContainer>,
         resource_manager: ResourceManager,
         model_import_options: ModelImportOptions,
     ) -> Result<Self, ModelLoadError> {
@@ -395,7 +398,7 @@ impl ModelData {
             // Scene can be used directly as model resource. Such scenes can be created in
             // Fyroxed.
             "rgs" => (
-                SceneLoader::from_file(path.as_ref())
+                SceneLoader::from_file(path.as_ref(), node_constructors)
                     .await?
                     .finish(resource_manager)
                     .await,

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -2,6 +2,7 @@
 //!
 //! For more info see [`Base`]
 
+use crate::script::Script;
 use crate::{
     core::{
         algebra::{Matrix4, Vector3},
@@ -20,6 +21,7 @@ use crate::{
         variable::{InheritError, TemplateVariable},
         DirectlyInheritableEntity,
     },
+    script::ScriptTrait,
     utils::log::Log,
 };
 use fxhash::FxHashMap;
@@ -352,6 +354,8 @@ pub struct Base {
     // was instantiated from.
     #[inspect(read_only)]
     pub(in crate) original_handle_in_resource: Handle<Node>,
+
+    pub script: Option<Script>,
 }
 
 impl_directly_inheritable_entity_trait!(Base;
@@ -386,6 +390,7 @@ impl Clone for Base {
             frustum_culling: self.frustum_culling.clone(),
             depth_offset: self.depth_offset.clone(),
             cast_shadows: self.cast_shadows.clone(),
+            script: self.script.clone(),
 
             // Rest of data is *not* copied!
             parent: Default::default(),
@@ -759,6 +764,7 @@ pub struct BaseBuilder {
     tag: String,
     frustum_culling: bool,
     cast_shadows: bool,
+    script: Option<Script>,
 }
 
 impl Default for BaseBuilder {
@@ -783,6 +789,7 @@ impl BaseBuilder {
             tag: Default::default(),
             frustum_culling: true,
             cast_shadows: true,
+            script: None,
         }
     }
 
@@ -865,6 +872,11 @@ impl BaseBuilder {
         self
     }
 
+    pub fn with_script(mut self, script: Script) -> Self {
+        self.script = Some(script);
+        self
+    }
+
     /// Creates an instance of [`Base`].
     pub fn build_base(self) -> Base {
         Base {
@@ -888,6 +900,7 @@ impl BaseBuilder {
             transform_modified: Cell::new(false),
             frustum_culling: self.frustum_culling.into(),
             cast_shadows: self.cast_shadows.into(),
+            script: self.script,
         }
     }
 }

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -734,7 +734,11 @@ impl Default for Base {
     }
 }
 
-fn visit_script(name: &str, script: &mut Option<Script>, visitor: &mut Visitor) -> VisitResult {
+pub fn visit_opt_script(
+    name: &str,
+    script: &mut Option<Script>,
+    visitor: &mut Visitor,
+) -> VisitResult {
     visitor.enter_region(name)?;
 
     let mut script_type_uuid = script.as_ref().map(|s| s.id()).unwrap_or_default();
@@ -794,7 +798,7 @@ impl Visit for Base {
         let _ = self.frustum_culling.visit("FrustumCulling", visitor);
         let _ = self.cast_shadows.visit("CastShadows", visitor);
 
-        visit_script("Script", &mut self.script, visitor)?;
+        visit_opt_script("Script", &mut self.script, visitor)?;
 
         visitor.leave_region()
     }

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -21,7 +21,6 @@ use crate::{
         variable::{InheritError, TemplateVariable},
         DirectlyInheritableEntity,
     },
-    script::ScriptTrait,
     utils::log::Log,
 };
 use fxhash::FxHashMap;
@@ -355,6 +354,7 @@ pub struct Base {
     #[inspect(read_only)]
     pub(in crate) original_handle_in_resource: Handle<Node>,
 
+    /// Current script of the scene node.
     pub script: Option<Script>,
 }
 
@@ -653,6 +653,16 @@ impl Base {
         self.cast_shadows.set(cast_shadows);
     }
 
+    /// Sets new script for the scene node.
+    pub fn set_script(&mut self, script: Option<Script>) {
+        self.script = script;
+    }
+
+    /// Returns a copy of the current script.
+    pub fn script_cloned(&self) -> Option<Script> {
+        self.script.clone()
+    }
+
     /// Updates node lifetime and returns true if the node is still alive, false - otherwise.
     pub(crate) fn update_lifetime(&mut self, dt: f32) -> bool {
         if let Some(lifetime) = self.lifetime.get_mut_silent().as_mut() {
@@ -872,6 +882,7 @@ impl BaseBuilder {
         self
     }
 
+    /// Sets desired script of the node.
     pub fn with_script(mut self, script: Script) -> Self {
         self.script = Some(script);
         self

--- a/src/scene/node/constructor.rs
+++ b/src/scene/node/constructor.rs
@@ -18,7 +18,6 @@ use crate::{
     },
 };
 use fxhash::FxHashMap;
-use lazy_static::lazy_static;
 
 /// A simple type alias for boxed node constructor.
 pub type NodeConstructor = Box<dyn FnMut() -> Node + Send>;
@@ -29,12 +28,9 @@ pub struct NodeConstructorContainer {
     map: Mutex<FxHashMap<Uuid, NodeConstructor>>,
 }
 
-lazy_static! {
-    static ref NODE_CONSTRUCTORS: NodeConstructorContainer = NodeConstructorContainer::new();
-}
-
 impl NodeConstructorContainer {
-    fn new() -> Self {
+    /// Creates default node constructor container with constructors for built-in engine nodes.
+    pub fn new() -> Self {
         let container = NodeConstructorContainer::default();
 
         container.add::<dim2::collider::Collider>();
@@ -58,11 +54,6 @@ impl NodeConstructorContainer {
         container.add::<Terrain>();
 
         container
-    }
-
-    /// Returns a reference to global node constructor container.
-    pub fn instance() -> &'static Self {
-        &NODE_CONSTRUCTORS
     }
 
     /// Adds new type constructor for a given type and return previous constructor for the type

--- a/src/scene/node/container.rs
+++ b/src/scene/node/container.rs
@@ -92,7 +92,13 @@ fn read_node(name: &str, visitor: &mut Visitor) -> Result<Node, VisitError> {
             let mut id = Uuid::default();
             id.visit("TypeUuid", visitor)?;
 
-            let mut node = NodeConstructorContainer::instance()
+            let constructor_container = visitor
+                .environment
+                .as_ref()
+                .and_then(|e| e.downcast_ref::<NodeConstructorContainer>())
+                .expect("Visitor environment must contain node constructor container!");
+
+            let mut node = constructor_container
                 .try_create(&id)
                 .ok_or_else(|| VisitError::User(format!("Unknown node type uuid {}!", id)))?;
 

--- a/src/scene/node/container.rs
+++ b/src/scene/node/container.rs
@@ -7,6 +7,7 @@ use crate::{
         uuid::Uuid,
         visitor::{Visit, VisitError, VisitResult, Visitor},
     },
+    engine::SerializationContext,
     scene::{
         self,
         camera::Camera,
@@ -14,7 +15,7 @@ use crate::{
         dim2::{self, rectangle::Rectangle},
         light::{directional::DirectionalLight, point::PointLight, spot::SpotLight},
         mesh::Mesh,
-        node::{constructor::NodeConstructorContainer, Node},
+        node::Node,
         particle_system::ParticleSystem,
         pivot::Pivot,
         sound::{listener::Listener, Sound},
@@ -92,13 +93,14 @@ fn read_node(name: &str, visitor: &mut Visitor) -> Result<Node, VisitError> {
             let mut id = Uuid::default();
             id.visit("TypeUuid", visitor)?;
 
-            let constructor_container = visitor
+            let serialization_context = visitor
                 .environment
                 .as_ref()
-                .and_then(|e| e.downcast_ref::<NodeConstructorContainer>())
-                .expect("Visitor environment must contain node constructor container!");
+                .and_then(|e| e.downcast_ref::<SerializationContext>())
+                .expect("Visitor environment must contain serialization context!");
 
-            let mut node = constructor_container
+            let mut node = serialization_context
+                .node_constructors
                 .try_create(&id)
                 .ok_or_else(|| VisitError::User(format!("Unknown node type uuid {}!", id)))?;
 

--- a/src/scene/node/mod.rs
+++ b/src/scene/node/mod.rs
@@ -309,8 +309,12 @@ impl Node {
     ///     node.cast::<Mesh>().expect("Expected to be an instance of Mesh")
     /// }
     /// ```
-    pub fn cast<T: NodeTrait>(&self) -> Option<&T> {
-        self.0.as_any().downcast_ref::<T>()
+    pub fn cast<T: NodeTrait + TypeUuidProvider>(&self) -> Option<&T> {
+        if self.id() == T::type_uuid() {
+            unsafe { Some(&*(&*self.0 as *const dyn NodeTrait as *const T)) }
+        } else {
+            None
+        }
     }
 
     /// Performs downcasting to a particular type.
@@ -325,8 +329,12 @@ impl Node {
     ///     node.cast_mut::<Mesh>().expect("Expected to be an instance of Mesh")
     /// }
     /// ```
-    pub fn cast_mut<T: NodeTrait>(&mut self) -> Option<&mut T> {
-        self.0.as_any_mut().downcast_mut::<T>()
+    pub fn cast_mut<T: NodeTrait + TypeUuidProvider>(&mut self) -> Option<&mut T> {
+        if self.id() == T::type_uuid() {
+            unsafe { Some(&mut *(&mut *self.0 as *mut dyn NodeTrait as *mut T)) }
+        } else {
+            None
+        }
     }
 
     /// Allows a node to provide access to a component of specified type.

--- a/src/script/constructor.rs
+++ b/src/script/constructor.rs
@@ -1,0 +1,73 @@
+//! A special container that is able to create nodes by their type UUID.
+
+use crate::{
+    core::{
+        parking_lot::{Mutex, MutexGuard},
+        uuid::Uuid,
+    },
+    scene::node::TypeUuidProvider,
+    script::{Script, ScriptTrait},
+};
+use std::collections::BTreeMap;
+
+pub struct ScriptConstructor {
+    /// A simple type alias for boxed node constructor.
+    pub constructor: Box<dyn FnMut() -> Script + Send>,
+
+    /// Script name.
+    pub name: String,
+}
+
+/// A special container that is able to create nodes by their type UUID.
+#[derive(Default)]
+pub struct ScriptConstructorContainer {
+    // BTreeMap allows to have sorted list of constructors.
+    map: Mutex<BTreeMap<Uuid, ScriptConstructor>>,
+}
+
+impl ScriptConstructorContainer {
+    /// Creates default node constructor container with constructors for built-in engine nodes.
+    pub fn new() -> Self {
+        ScriptConstructorContainer::default()
+    }
+
+    /// Adds new type constructor for a given type and return previous constructor for the type
+    /// (if any).
+    pub fn add<T, N>(&self, name: N) -> Option<ScriptConstructor>
+    where
+        T: TypeUuidProvider + ScriptTrait + Default,
+        N: AsRef<str>,
+    {
+        self.map.lock().insert(
+            T::type_uuid(),
+            ScriptConstructor {
+                constructor: Box::new(|| Script::new(T::default())),
+                name: name.as_ref().to_string(),
+            },
+        )
+    }
+
+    /// Adds custom type constructor.
+    pub fn add_custom(&self, type_uuid: Uuid, constructor: ScriptConstructor) {
+        self.map.lock().insert(type_uuid, constructor);
+    }
+
+    /// Unregisters type constructor.
+    pub fn remove(&self, type_uuid: Uuid) {
+        self.map.lock().remove(&type_uuid);
+    }
+
+    /// Makes an attempt to create a script using provided type UUID. It may fail if there is no
+    /// script constructor for specified type UUID.
+    pub fn try_create(&self, type_uuid: &Uuid) -> Option<Script> {
+        self.map
+            .lock()
+            .get_mut(type_uuid)
+            .map(|c| (c.constructor)())
+    }
+
+    /// Returns inner map of script constructors.
+    pub fn map(&self) -> MutexGuard<BTreeMap<Uuid, ScriptConstructor>> {
+        self.map.lock()
+    }
+}

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1,0 +1,75 @@
+use crate::core::{
+    inspect::{Inspect, PropertyInfo},
+    uuid::Uuid,
+    visitor::{Visit, VisitResult, Visitor},
+};
+use fxhash::FxHashMap;
+use std::fmt::Debug;
+
+pub trait BaseScript: Visit + Inspect + Send + Debug + 'static {
+    fn clone_box(&self) -> Box<dyn ScriptTrait>;
+}
+
+impl<T> BaseScript for T
+where
+    T: Clone + ScriptTrait,
+{
+    fn clone_box(&self) -> Box<dyn ScriptTrait> {
+        Box::new(self.clone())
+    }
+}
+
+pub trait ScriptTrait: BaseScript {
+    fn on_init(&mut self);
+
+    fn type_uuid(&self) -> Uuid;
+}
+
+pub struct ScriptDefinition {
+    pub name: String,
+    pub type_uuid: Uuid,
+    pub constructor: Box<dyn FnMut() -> Box<dyn ScriptTrait>>,
+}
+
+#[derive(Debug)]
+pub struct Script(pub Box<dyn ScriptTrait>);
+
+impl Inspect for Script {
+    fn properties(&self) -> Vec<PropertyInfo<'_>> {
+        self.0.properties()
+    }
+}
+
+impl Visit for Script {
+    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
+        self.0.visit(name, visitor)
+    }
+}
+
+impl Clone for Script {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+impl Script {
+    pub fn new<T: ScriptTrait>(script_object: T) -> Self {
+        Self(Box::new(script_object))
+    }
+}
+
+#[derive(Default)]
+pub struct ScriptDefinitionStorage {
+    map: FxHashMap<Uuid, ScriptDefinition>,
+}
+
+impl ScriptDefinitionStorage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, script_definition: ScriptDefinition) {
+        self.map
+            .insert(script_definition.type_uuid, script_definition);
+    }
+}

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1,3 +1,4 @@
+use crate::scene::node::Node;
 use crate::{
     core::{
         inspect::{Inspect, PropertyInfo},
@@ -24,8 +25,9 @@ where
     }
 }
 
-pub struct ScriptContext<'a> {
+pub struct ScriptContext<'a, 'b> {
     pub plugin: &'a mut dyn Plugin,
+    pub node: &'b mut Node,
 }
 
 pub trait ScriptTrait: BaseScript {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod log;
 pub mod navmesh;
 pub mod raw_mesh;
 pub mod uvgen;
+pub mod watcher;
 
 use crate::core::algebra::Vector2;
 use crate::{

--- a/src/utils/watcher.rs
+++ b/src/utils/watcher.rs
@@ -10,13 +10,13 @@ use std::{
 
 /// Resource watcher allows you to track changed resources and "tell" resource manager to reload
 /// them.
-pub struct ResourceWatcher {
+pub struct FileSystemWatcher {
     #[allow(dead_code)] // We must keep watcher alive, but compiler isn't smart enough.
     watcher: RecommendedWatcher,
     receiver: Receiver<DebouncedEvent>,
 }
 
-impl ResourceWatcher {
+impl FileSystemWatcher {
     /// Creates new resource watcher with a path to watch and notification delay.
     pub fn new<P: AsRef<Path>>(path: P, delay: Duration) -> Result<Self, notify::Error> {
         let (tx, rx) = channel();


### PR DESCRIPTION
The PR implements plugin system with user scripts. A user script can be assigned to a scene node to do custom gameplay logic.

- [x] Basic plugin interface
- [x] Basic script interface
- [x] Script serialization
- [x] Undo/redo for scripts
- [ ] Play mode for the editor
- [ ] Proof-of-concept game based on plugin/scripts
- [ ] Other stuff (to be decided)