### PR TITLE
Change package to scripting

### DIFF
--- a/examples/scripting/Cargo.toml
+++ b/examples/scripting/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test_scripting"
+name = "scripting"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Change makes it so you do:

`cargo build --package scripting`

instead of:

`cargo build --package test_scripting`