### PR TITLE
Add layout + render transform support

### DIFF
--- a/editor/src/absm/canvas.rs
+++ b/editor/src/absm/canvas.rs
@@ -75,13 +75,13 @@ impl Control for AbsmCanvas {
     }
 
     fn draw(&self, ctx: &mut DrawingContext) {
-        let visual_transform = self
-            .widget
-            .visual_transform()
-            .try_inverse()
-            .unwrap_or_default();
+        let size = 9999.0;
 
-        let local_bounds = self.widget.bounding_rect().transform(&visual_transform);
+        let local_bounds = self
+            .widget
+            .bounding_rect()
+            .inflate(size, size)
+            .translate(Vector2::new(size * 0.5, size * 0.5));
         DrawingContext::push_rect_filled(ctx, &local_bounds, None);
         ctx.commit(
             self.clip_bounds(),
@@ -89,9 +89,6 @@ impl Control for AbsmCanvas {
             CommandTexture::None,
             None,
         );
-
-        let local_bounds = self.widget.bounding_rect();
-
         let step_size = 50.0;
 
         let mut local_left_bottom = local_bounds.left_top_corner();
@@ -114,7 +111,7 @@ impl Control for AbsmCanvas {
             ctx.push_line(
                 Vector2::new(local_left_bottom.x - step_size, y),
                 Vector2::new(local_right_top.x + step_size, y),
-                1.0,
+                1.0 / self.zoom,
             );
         }
 
@@ -124,7 +121,7 @@ impl Control for AbsmCanvas {
             ctx.push_line(
                 Vector2::new(x, local_left_bottom.y + step_size),
                 Vector2::new(x, local_right_top.y - step_size),
-                1.0,
+                1.0 / self.zoom,
             );
         }
 
@@ -229,7 +226,7 @@ impl Control for AbsmCanvas {
         } else if let Some(WidgetMessage::MouseWheel { amount, pos }) = message.data() {
             let cursor_pos = (*pos - self.screen_position()).scale(self.zoom);
 
-            self.zoom += 0.1 * amount;
+            self.zoom = (self.zoom + 0.1 * amount).clamp(0.2, 2.0);
 
             let new_cursor_pos = (*pos - self.screen_position()).scale(self.zoom);
 

--- a/editor/src/asset/item.rs
+++ b/editor/src/asset/item.rs
@@ -59,7 +59,7 @@ impl Control for AssetItem {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.screen_bounds();
+        let bounds = self.bounding_rect();
         drawing_context.push_rect_filled(&bounds, None);
         drawing_context.commit(bounds, self.background(), CommandTexture::None, None);
         drawing_context.push_rect(&bounds, 1.0);

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -43,8 +43,6 @@ use fyrox::{
     },
     window::Fullscreen,
 };
-use fyrox_core::algebra::{Matrix3, Rotation2, Rotation3, UnitComplex};
-use fyrox_ui::widget::WidgetMessage;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -58,8 +56,6 @@ struct Interface {
     reset: Handle<UiNode>,
     video_modes: Vec<VideoMode>,
     resolutions: Handle<UiNode>,
-    window: Handle<UiNode>,
-    angle: f32,
 }
 
 // User interface in the engine build up on graph data structure, on tree to be
@@ -96,7 +92,7 @@ fn create_ui(engine: &mut Engine) -> Interface {
     let yaw;
     let scale;
     let reset;
-    let window = WindowBuilder::new(
+    WindowBuilder::new(
         WidgetBuilder::new()
             // We want the window to be anchored at right top corner at the beginning
             .with_desired_position(Vector2::new(window_width - 300.0, 0.0))
@@ -196,7 +192,6 @@ fn create_ui(engine: &mut Engine) -> Interface {
         .add_column(Column::strict(100.0))
         .add_column(Column::stretch())
         .add_row(Row::strict(30.0))
-        .add_row(Row::strict(30.0))
         .add_row(Row::stretch())
         .add_row(Row::strict(30.0))
         .build(ctx),
@@ -271,8 +266,6 @@ fn create_ui(engine: &mut Engine) -> Interface {
         reset,
         resolutions,
         video_modes,
-        angle: 0.0,
-        window,
     }
 }
 
@@ -353,7 +346,7 @@ fn main() {
     .unwrap();
 
     // Create simple user interface that will show some useful info.
-    let mut interface = create_ui(&mut engine);
+    let interface = create_ui(&mut engine);
 
     // Create test scene.
     let GameScene {
@@ -419,17 +412,6 @@ fn main() {
                         MessageDirection::ToWidget,
                         format!("Example 04 - User Interface\nFPS: {}", fps),
                     ));
-
-                    engine
-                        .user_interface
-                        .send_message(WidgetMessage::layout_transform(
-                            interface.yaw,
-                            MessageDirection::ToWidget,
-                            Rotation2::from(UnitComplex::from_angle(interface.angle))
-                                .to_homogeneous(),
-                        ));
-                    interface.angle += 10.0 * dt;
-
                     engine.update(fixed_timestep);
                 }
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -43,6 +43,8 @@ use fyrox::{
     },
     window::Fullscreen,
 };
+use fyrox_core::algebra::{Matrix3, Rotation2, Rotation3, UnitComplex};
+use fyrox_ui::widget::WidgetMessage;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -56,6 +58,8 @@ struct Interface {
     reset: Handle<UiNode>,
     video_modes: Vec<VideoMode>,
     resolutions: Handle<UiNode>,
+    window: Handle<UiNode>,
+    angle: f32,
 }
 
 // User interface in the engine build up on graph data structure, on tree to be
@@ -92,7 +96,7 @@ fn create_ui(engine: &mut Engine) -> Interface {
     let yaw;
     let scale;
     let reset;
-    WindowBuilder::new(
+    let window = WindowBuilder::new(
         WidgetBuilder::new()
             // We want the window to be anchored at right top corner at the beginning
             .with_desired_position(Vector2::new(window_width - 300.0, 0.0))
@@ -192,6 +196,7 @@ fn create_ui(engine: &mut Engine) -> Interface {
         .add_column(Column::strict(100.0))
         .add_column(Column::stretch())
         .add_row(Row::strict(30.0))
+        .add_row(Row::strict(30.0))
         .add_row(Row::stretch())
         .add_row(Row::strict(30.0))
         .build(ctx),
@@ -266,6 +271,8 @@ fn create_ui(engine: &mut Engine) -> Interface {
         reset,
         resolutions,
         video_modes,
+        angle: 0.0,
+        window,
     }
 }
 
@@ -346,7 +353,7 @@ fn main() {
     .unwrap();
 
     // Create simple user interface that will show some useful info.
-    let interface = create_ui(&mut engine);
+    let mut interface = create_ui(&mut engine);
 
     // Create test scene.
     let GameScene {
@@ -412,6 +419,17 @@ fn main() {
                         MessageDirection::ToWidget,
                         format!("Example 04 - User Interface\nFPS: {}", fps),
                     ));
+
+                    engine
+                        .user_interface
+                        .send_message(WidgetMessage::layout_transform(
+                            interface.yaw,
+                            MessageDirection::ToWidget,
+                            Rotation2::from(UnitComplex::from_angle(interface.angle))
+                                .to_homogeneous(),
+                        ));
+                    interface.angle += 10.0 * dt;
+
                     engine.update(fixed_timestep);
                 }
 

--- a/fyrox-core/src/math/mod.rs
+++ b/fyrox-core/src/math/mod.rs
@@ -114,12 +114,13 @@ where
         let mut clipped = *self;
 
         if clipped.position.x < other.position.x {
-            clipped.position.x = other.position.x;
             clipped.size.x -= other.position.x - clipped.position.x;
+            clipped.position.x = other.position.x;
         }
+
         if clipped.position.y < other.position.y {
-            clipped.position.y = other.position.y;
             clipped.size.y -= other.position.y - clipped.position.y;
+            clipped.position.y = other.position.y;
         }
 
         let clipped_right_bottom = clipped.right_bottom_corner();
@@ -242,17 +243,19 @@ where
 
     #[inline]
     #[must_use]
-    pub fn transform(&self, basis: &Matrix3<T>) -> Self {
+    pub fn transform(&self, matrix: &Matrix3<T>) -> Self {
         let min = self.position;
         let max = self.right_bottom_corner();
 
-        let mut transformed_min = Vector2::new(basis[6], basis[7]);
-        let mut transformed_max = Vector2::new(basis[6], basis[7]);
+        let translation = Vector2::new(matrix[6], matrix[7]);
+
+        let mut transformed_min = translation;
+        let mut transformed_max = translation;
 
         for i in 0..2 {
             for j in 0..2 {
-                let a = basis[(i, j)] * min[j];
-                let b = basis[(i, j)] * max[j];
+                let a = matrix[(i, j)] * min[j];
+                let b = matrix[(i, j)] * max[j];
                 if a < b {
                     transformed_min[i] += a;
                     transformed_max[i] += b;

--- a/fyrox-core/src/math/mod.rs
+++ b/fyrox-core/src/math/mod.rs
@@ -239,6 +239,35 @@ where
     pub fn y(&self) -> T {
         self.position.y
     }
+
+    #[inline]
+    #[must_use]
+    pub fn transform(&self, basis: &Matrix3<T>) -> Self {
+        let min = self.position;
+        let max = self.right_bottom_corner();
+
+        let mut transformed_min = Vector2::new(basis[6], basis[7]);
+        let mut transformed_max = Vector2::new(basis[6], basis[7]);
+
+        for i in 0..2 {
+            for j in 0..2 {
+                let a = basis[(i, j)] * min[j];
+                let b = basis[(i, j)] * max[j];
+                if a < b {
+                    transformed_min[i] += a;
+                    transformed_max[i] += b;
+                } else {
+                    transformed_min[i] += b;
+                    transformed_max[i] += a;
+                }
+            }
+        }
+
+        Self {
+            position: transformed_min,
+            size: transformed_max - transformed_min,
+        }
+    }
 }
 
 impl<T> Visit for Rect<T>

--- a/fyrox-ui/src/border.rs
+++ b/fyrox-ui/src/border.rs
@@ -70,7 +70,7 @@ impl Control for Border {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.widget.screen_bounds();
+        let bounds = self.widget.bounding_rect();
         DrawingContext::push_rect_filled(drawing_context, &bounds, None);
         drawing_context.commit(
             self.clip_bounds(),

--- a/fyrox-ui/src/color.rs
+++ b/fyrox-ui/src/color.rs
@@ -109,7 +109,7 @@ crate::define_widget_deref!(AlphaBar);
 
 impl AlphaBar {
     fn alpha_at(&self, mouse_pos: Vector2<f32>) -> f32 {
-        let relative_pos = mouse_pos - self.screen_position;
+        let relative_pos = mouse_pos - self.screen_position();
         let k = match self.orientation {
             Orientation::Vertical => relative_pos.y / self.actual_size().y,
             Orientation::Horizontal => relative_pos.x / self.actual_size().x,
@@ -203,7 +203,7 @@ impl Control for AlphaBar {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.screen_bounds();
+        let bounds = self.bounding_rect();
 
         // Draw checker board first.
         let h_amount = (bounds.w() / CHECKERBOARD_SIZE).ceil() as usize;
@@ -364,7 +364,7 @@ crate::define_widget_deref!(HueBar);
 
 impl HueBar {
     fn hue_at(&self, mouse_pos: Vector2<f32>) -> f32 {
-        let relative_pos = mouse_pos - self.screen_position;
+        let relative_pos = mouse_pos - self.screen_position();
         let k = match self.orientation {
             Orientation::Vertical => relative_pos.y / self.actual_size().y,
             Orientation::Horizontal => relative_pos.x / self.actual_size().x,
@@ -383,7 +383,7 @@ impl Control for HueBar {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.screen_bounds();
+        let bounds = self.bounding_rect();
         for hue in 1..360 {
             let prev_color = Color::from(Hsv::new((hue - 1) as f32, 100.0, 100.0));
             let curr_color = Color::from(Hsv::new(hue as f32, 100.0, 100.0));
@@ -522,7 +522,7 @@ crate::define_widget_deref!(SaturationBrightnessField);
 
 impl SaturationBrightnessField {
     fn saturation_at(&self, mouse_pos: Vector2<f32>) -> f32 {
-        ((mouse_pos.x - self.screen_position.x) / self.screen_bounds().w())
+        ((mouse_pos.x - self.screen_position().x) / self.screen_bounds().w())
             .min(1.0)
             .max(0.0)
             * 100.0
@@ -530,7 +530,7 @@ impl SaturationBrightnessField {
 
     fn brightness_at(&self, mouse_pos: Vector2<f32>) -> f32 {
         100.0
-            - ((mouse_pos.y - self.screen_position.y) / self.screen_bounds().h())
+            - ((mouse_pos.y - self.screen_position().y) / self.screen_bounds().h())
                 .min(1.0)
                 .max(0.0)
                 * 100.0
@@ -558,7 +558,7 @@ impl Control for SaturationBrightnessField {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.screen_bounds();
+        let bounds = self.bounding_rect();
 
         drawing_context.push_rect_multicolor(
             &bounds,
@@ -1185,7 +1185,7 @@ impl Control for ColorField {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.screen_bounds();
+        let bounds = self.bounding_rect();
 
         drawing_context.push_rect_filled(&bounds, None);
         drawing_context.commit(

--- a/fyrox-ui/src/grid.rs
+++ b/fyrox-ui/src/grid.rs
@@ -361,7 +361,7 @@ impl Control for Grid {
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
         if self.draw_border {
-            let bounds = self.widget.screen_bounds();
+            let bounds = self.widget.bounding_rect();
 
             let left_top = Vector2::new(bounds.x(), bounds.y());
             let right_top = Vector2::new(bounds.x() + bounds.w(), bounds.y());

--- a/fyrox-ui/src/image.rs
+++ b/fyrox-ui/src/image.rs
@@ -60,7 +60,7 @@ impl Control for Image {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.widget.screen_bounds();
+        let bounds = self.widget.bounding_rect();
         let tex_coords = if self.flip {
             Some([
                 Vector2::new(0.0, 0.0),

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -2302,7 +2302,7 @@ mod test {
         widget::{WidgetBuilder, WidgetMessage},
         UserInterface,
     };
-    use fyrox_core::algebra::{Matrix3, Rotation2, UnitComplex};
+    use fyrox_core::algebra::{Rotation2, UnitComplex};
 
     #[test]
     fn test_transform_size() {

--- a/fyrox-ui/src/list_view.rs
+++ b/fyrox-ui/src/list_view.rs
@@ -139,7 +139,7 @@ impl Control for ListViewItem {
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
         // Emit transparent geometry so item container can be picked by hit test.
-        drawing_context.push_rect_filled(&self.widget.screen_bounds(), None);
+        drawing_context.push_rect_filled(&self.widget.bounding_rect(), None);
         drawing_context.commit(
             self.clip_bounds(),
             Brush::Solid(Color::TRANSPARENT),

--- a/fyrox-ui/src/scroll_bar.rs
+++ b/fyrox-ui/src/scroll_bar.rs
@@ -249,7 +249,7 @@ impl Control for ScrollBar {
                 match msg {
                     WidgetMessage::MouseDown { pos, .. } => {
                         if self.indicator.is_some() {
-                            let indicator_pos = ui.nodes.borrow(self.indicator).screen_position;
+                            let indicator_pos = ui.nodes.borrow(self.indicator).screen_position();
                             self.is_dragging = true;
                             self.offset = indicator_pos - *pos;
                             ui.capture_mouse(self.indicator);
@@ -270,8 +270,8 @@ impl Control for ScrollBar {
                                 let percent = match self.orientation {
                                     Orientation::Horizontal => {
                                         let span = canvas.actual_size().x - indicator_size.x;
-                                        let offset =
-                                            mouse_pos.x - canvas.screen_position.x + self.offset.x;
+                                        let offset = mouse_pos.x - canvas.screen_position().x
+                                            + self.offset.x;
                                         if span > 0.0 {
                                             math::clampf(offset / span, 0.0, 1.0)
                                         } else {
@@ -280,8 +280,8 @@ impl Control for ScrollBar {
                                     }
                                     Orientation::Vertical => {
                                         let span = canvas.actual_size().y - indicator_size.y;
-                                        let offset =
-                                            mouse_pos.y - canvas.screen_position.y + self.offset.y;
+                                        let offset = mouse_pos.y - canvas.screen_position().y
+                                            + self.offset.y;
                                         if span > 0.0 {
                                             math::clampf(offset / span, 0.0, 1.0)
                                         } else {

--- a/fyrox-ui/src/scroll_panel.rs
+++ b/fyrox-ui/src/scroll_panel.rs
@@ -115,7 +115,7 @@ impl Control for ScrollPanel {
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
         // Emit transparent geometry so panel will receive mouse events.
-        drawing_context.push_rect_filled(&self.widget.screen_bounds(), None);
+        drawing_context.push_rect_filled(&self.widget.bounding_rect(), None);
         drawing_context.commit(
             self.clip_bounds(),
             Brush::Solid(Color::TRANSPARENT),

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -58,7 +58,7 @@ impl Control for Text {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.widget.screen_bounds();
+        let bounds = self.widget.bounding_rect();
         drawing_context.draw_text(
             self.clip_bounds(),
             bounds.position,

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -334,7 +334,7 @@ impl TextBox {
     }
 
     pub fn screen_pos_to_text_pos(&self, screen_pos: Vector2<f32>) -> Option<Position> {
-        let caret_pos = self.widget.screen_position;
+        let caret_pos = self.widget.screen_position();
         let font = self.formatted_text.borrow().get_font();
         let font = font.0.lock();
         for (line_index, line) in self.formatted_text.borrow().get_lines().iter().enumerate() {
@@ -437,7 +437,7 @@ impl Control for TextBox {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.widget.screen_bounds();
+        let bounds = self.widget.bounding_rect();
         drawing_context.push_rect_filled(&bounds, None);
         drawing_context.commit(
             self.clip_bounds(),

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -520,14 +520,18 @@ impl Control for TextBox {
             None,
         );
 
-        let screen_position = bounds.position;
-        drawing_context.draw_text(bounds, screen_position, &self.formatted_text.borrow());
+        let local_position = bounds.position;
+        drawing_context.draw_text(
+            self.clip_bounds(),
+            local_position,
+            &self.formatted_text.borrow(),
+        );
 
         if self.caret_visible {
             let text = self.formatted_text.borrow();
 
             let font = text.get_font();
-            let mut caret_pos = screen_position;
+            let mut caret_pos = local_position;
 
             let font = font.0.lock();
             if let Some(line) = text.get_lines().get(self.caret_position.line) {

--- a/fyrox-ui/src/vector_image.rs
+++ b/fyrox-ui/src/vector_image.rs
@@ -104,7 +104,7 @@ impl Control for VectorImage {
     }
 
     fn draw(&self, drawing_context: &mut DrawingContext) {
-        let bounds = self.widget.screen_bounds();
+        let bounds = self.widget.bounding_rect();
 
         for primitive in self.primitives.iter() {
             match primitive {

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -358,6 +358,7 @@ pub struct Widget {
     tooltip: Handle<UiNode>,
     tooltip_time: f32,
     context_menu: Handle<UiNode>,
+    pub(in crate) clip_to_bounds: bool,
     pub(in crate) layout_transform: Matrix3<f32>,
     pub(in crate) render_transform: Matrix3<f32>,
     pub(in crate) visual_transform: Matrix3<f32>,
@@ -1052,6 +1053,7 @@ pub struct WidgetBuilder {
     pub handle_os_events: bool,
     pub layout_transform: Matrix3<f32>,
     pub render_transform: Matrix3<f32>,
+    pub clip_to_bounds: bool,
 }
 
 impl Default for WidgetBuilder {
@@ -1094,6 +1096,7 @@ impl WidgetBuilder {
             handle_os_events: false,
             layout_transform: Matrix3::identity(),
             render_transform: Matrix3::identity(),
+            clip_to_bounds: true,
         }
     }
 
@@ -1114,6 +1117,11 @@ impl WidgetBuilder {
 
     pub fn with_height(mut self, height: f32) -> Self {
         self.height = height;
+        self
+    }
+
+    pub fn with_clip_to_bounds(mut self, clip_to_bounds: bool) -> Self {
+        self.clip_to_bounds = clip_to_bounds;
         self
     }
 
@@ -1325,6 +1333,7 @@ impl WidgetBuilder {
             layout_transform: self.layout_transform,
             render_transform: self.render_transform,
             visual_transform: Matrix3::identity(),
+            clip_to_bounds: self.clip_to_bounds,
         }
     }
 }

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -6,6 +6,7 @@ use crate::{
     HorizontalAlignment, LayoutEvent, MouseButton, MouseState, Thickness, UiNode, UserInterface,
     VerticalAlignment, BRUSH_FOREGROUND, BRUSH_PRIMARY,
 };
+use fyrox_core::algebra::Matrix3;
 use std::{
     any::Any,
     cell::{Cell, RefCell},
@@ -260,6 +261,9 @@ pub enum WidgetMessage {
     ///
     /// Direction: **From/To UI**
     Opacity(Option<f32>),
+
+    LayoutTransform(Matrix3<f32>),
+    RenderTransform(Matrix3<f32>),
 }
 
 impl WidgetMessage {
@@ -288,6 +292,8 @@ impl WidgetMessage {
     define_constructor!(WidgetMessage:HorizontalAlignment => fn horizontal_alignment(HorizontalAlignment), layout: false);
     define_constructor!(WidgetMessage:VerticalAlignment => fn vertical_alignment(VerticalAlignment), layout: false);
     define_constructor!(WidgetMessage:Opacity => fn opacity(Option<f32>), layout: false);
+    define_constructor!(WidgetMessage:LayoutTransform => fn layout_transform(Matrix3<f32>), layout: false);
+    define_constructor!(WidgetMessage:RenderTransform => fn render_transform(Matrix3<f32>), layout: false);
 
     // Internal messages. Do not use.
     define_constructor!(WidgetMessage:GotFocus => fn got_focus(), layout: false);
@@ -316,8 +322,6 @@ pub struct Widget {
     width: f32,
     /// Explicit height for node or automatic if NaN (means value is undefined). Default is NaN
     height: f32,
-    /// Screen position of the node
-    pub(in crate) screen_position: Vector2<f32>,
     /// Minimum width and height
     min_size: Vector2<f32>,
     /// Maximum width and height
@@ -354,6 +358,9 @@ pub struct Widget {
     tooltip: Handle<UiNode>,
     tooltip_time: f32,
     context_menu: Handle<UiNode>,
+    pub(in crate) layout_transform: Matrix3<f32>,
+    pub(in crate) render_transform: Matrix3<f32>,
+    pub(in crate) visual_transform: Matrix3<f32>,
     pub(in crate) preview_messages: bool,
     pub(in crate) handle_os_events: bool,
     pub(in crate) layout_events_sender: Option<Sender<LayoutEvent>>,
@@ -366,10 +373,10 @@ pub struct Widget {
     pub(in crate) prev_arrange: Cell<Rect<f32>>,
     /// Desired size of the node after Measure pass.
     pub(in crate) desired_size: Cell<Vector2<f32>>,
-    /// Actual node local position after Arrange pass.
+    /// Actual local position of the widget after Arrange pass.
     pub(in crate) actual_local_position: Cell<Vector2<f32>>,
-    /// Actual size of the node after Arrange pass.
-    pub(in crate) actual_size: Cell<Vector2<f32>>,
+    /// Actual local size of the widget after Arrange pass.
+    pub(in crate) actual_local_size: Cell<Vector2<f32>>,
     pub(in crate) prev_global_visibility: bool,
     pub(in crate) clip_bounds: Cell<Rect<f32>>,
 }
@@ -393,7 +400,7 @@ impl Widget {
 
     #[inline]
     pub fn actual_size(&self) -> Vector2<f32> {
-        self.actual_size.get()
+        self.actual_local_size.get()
     }
 
     #[inline]
@@ -556,7 +563,7 @@ impl Widget {
 
     #[inline]
     pub fn screen_position(&self) -> Vector2<f32> {
-        self.screen_position
+        Vector2::new(self.visual_transform[6], self.visual_transform[7])
     }
 
     #[inline]
@@ -626,12 +633,32 @@ impl Widget {
 
     #[inline]
     pub fn screen_bounds(&self) -> Rect<f32> {
+        self.bounding_rect().transform(&self.visual_transform)
+    }
+
+    #[inline]
+    pub fn bounding_rect(&self) -> Rect<f32> {
         Rect::new(
-            self.screen_position.x,
-            self.screen_position.y,
-            self.actual_size.get().x,
-            self.actual_size.get().y,
+            0.0,
+            0.0,
+            self.actual_local_size.get().x,
+            self.actual_local_size.get().y,
         )
+    }
+
+    #[inline]
+    pub fn visual_transform(&self) -> &Matrix3<f32> {
+        &self.visual_transform
+    }
+
+    #[inline]
+    pub fn render_transform(&self) -> &Matrix3<f32> {
+        &self.render_transform
+    }
+
+    #[inline]
+    pub fn layout_transform(&self) -> &Matrix3<f32> {
+        &self.layout_transform
     }
 
     pub fn has_descendant(&self, node_handle: Handle<UiNode>, ui: &UserInterface) -> bool {
@@ -749,6 +776,15 @@ impl Widget {
                     &WidgetMessage::Cursor(icon) => {
                         self.cursor = icon;
                     }
+                    WidgetMessage::LayoutTransform(transform) => {
+                        if &self.layout_transform != transform {
+                            self.layout_transform = *transform;
+                            self.invalidate_layout();
+                        }
+                    }
+                    WidgetMessage::RenderTransform(transform) => {
+                        self.render_transform = *transform;
+                    }
                     _ => (),
                 }
             }
@@ -828,7 +864,7 @@ impl Widget {
 
     #[inline]
     pub(in crate) fn commit_arrange(&self, position: Vector2<f32>, size: Vector2<f32>) {
-        self.actual_size.set(size);
+        self.actual_local_size.set(size);
         self.actual_local_position.set(position);
         self.arrange_valid.set(true);
     }
@@ -1014,6 +1050,8 @@ pub struct WidgetBuilder {
     pub context_menu: Handle<UiNode>,
     pub preview_messages: bool,
     pub handle_os_events: bool,
+    pub layout_transform: Matrix3<f32>,
+    pub render_transform: Matrix3<f32>,
 }
 
 impl Default for WidgetBuilder {
@@ -1054,6 +1092,8 @@ impl WidgetBuilder {
             context_menu: Handle::default(),
             preview_messages: false,
             handle_os_events: false,
+            layout_transform: Matrix3::identity(),
+            render_transform: Matrix3::identity(),
         }
     }
 
@@ -1129,6 +1169,16 @@ impl WidgetBuilder {
 
     pub fn with_desired_position(mut self, desired_position: Vector2<f32>) -> Self {
         self.desired_position = desired_position;
+        self
+    }
+
+    pub fn with_layout_transform(mut self, layout_transform: Matrix3<f32>) -> Self {
+        self.layout_transform = layout_transform;
+        self
+    }
+
+    pub fn with_render_transform(mut self, render_transform: Matrix3<f32>) -> Self {
+        self.render_transform = render_transform;
         self
     }
 
@@ -1231,10 +1281,9 @@ impl WidgetBuilder {
             desired_local_position: self.desired_position,
             width: self.width,
             height: self.height,
-            screen_position: Vector2::default(),
             desired_size: Cell::new(Vector2::default()),
             actual_local_position: Cell::new(Vector2::default()),
-            actual_size: Cell::new(Vector2::default()),
+            actual_local_size: Cell::new(Vector2::default()),
             min_size: self.min_size.unwrap_or_default(),
             max_size: self
                 .max_size
@@ -1273,6 +1322,9 @@ impl WidgetBuilder {
             preview_messages: self.preview_messages,
             handle_os_events: self.handle_os_events,
             layout_events_sender: None,
+            layout_transform: self.layout_transform,
+            render_transform: self.render_transform,
+            visual_transform: Matrix3::identity(),
         }
     }
 }

--- a/fyrox-ui/src/window.rs
+++ b/fyrox-ui/src/window.rs
@@ -214,7 +214,7 @@ impl Control for Window {
 
                         // Check grips.
                         for grip in self.grips.borrow_mut().iter_mut() {
-                            let offset = self.screen_position;
+                            let offset = self.screen_position();
                             let screen_bounds = grip.bounds.translate(offset);
                             if screen_bounds.contains(pos) {
                                 grip.is_dragging = true;
@@ -239,7 +239,7 @@ impl Control for Window {
                         let mut new_cursor = None;
 
                         for grip in self.grips.borrow().iter() {
-                            let offset = self.screen_position;
+                            let offset = self.screen_position();
                             let screen_bounds = grip.bounds.translate(offset);
                             if screen_bounds.contains(pos) {
                                 new_cursor = Some(grip.cursor);
@@ -335,7 +335,7 @@ impl Control for Window {
             }
             if let WidgetMessage::Unlink = msg {
                 if message.destination() == self.handle() {
-                    self.initial_position = self.screen_position;
+                    self.initial_position = self.screen_position();
                 }
             }
         } else if let Some(ButtonMessage::Click) = message.data::<ButtonMessage>() {


### PR DESCRIPTION
The PR adds support for custom layout and render transform, it could be used to rotate/scale/translate/shear widgets. It is especially useful for things like canvases with zoom/drag features and so on.