### PR TITLE
Remove `#[inspect(expand)]` and `#[inspect(expand_subtree)]`

### DIFF
--- a/fyrox-core-derive/src/inspect/args.rs
+++ b/fyrox-core-derive/src/inspect/args.rs
@@ -44,18 +44,6 @@ pub struct FieldArgs {
     #[darling(default)]
     pub display_name: Option<String>,
 
-    /// `#[inspect(expand)]`
-    ///
-    /// Include the fields of the field, exclude the marked field itself.
-    #[darling(default)]
-    pub expand: bool,
-
-    /// `#[inspect(expand_subtree)]`
-    ///
-    /// Include the field and the fields of the field.
-    #[darling(default)]
-    pub expand_subtree: bool,
-
     /// `#[inspect(getter = "<path>")]`
     ///
     /// Convert the field reference to another reference

--- a/fyrox-core-derive/src/inspect/utils.rs
+++ b/fyrox-core-derive/src/inspect/utils.rs
@@ -156,42 +156,17 @@ pub fn gen_inspect_fn_body(
     // `inspect` function body, consisting of a sequence of quotes
     let mut quotes = Vec::new();
 
-    // 1. collect non-expanible field properties
     let props = field_args
         .fields
         .iter()
         .enumerate()
-        .filter(|(_i, f)| !(f.skip || f.expand || f.expand_subtree))
+        .filter(|(_i, f)| !f.skip)
         .map(|(i, field)| self::quote_field_prop(field_prefix, i, field, field_args.style));
 
     quotes.push(quote! {
         let mut props = Vec::new();
         #(props.push(#props);)*
     });
-
-    // 2. visit expansible fields
-    for (i, field) in field_args
-        .fields
-        .iter()
-        .enumerate()
-        .filter(|(_i, f)| !f.skip && (f.expand || f.expand_subtree))
-    {
-        // parent (the field)
-        if field.expand_subtree {
-            let prop = self::quote_field_prop(field_prefix, i, field, field_args.style);
-
-            quotes.push(quote! {
-                props.push(#prop);
-            });
-        }
-
-        // children (fields of the field)
-        let field_ref = field_prefix.quote_field_ref(i, field, field_args.style);
-
-        quotes.push(quote! {
-            props.extend(#field_ref.properties());
-        });
-    }
 
     // concatenate the quotes
     quote! {

--- a/fyrox-core-derive/src/inspect/utils/prop_keys.rs
+++ b/fyrox-core-derive/src/inspect/utils/prop_keys.rs
@@ -16,8 +16,7 @@ pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
     match &ty_args.data {
         ast::Data::Struct(field_args) => {
             for (nth, field) in field_args.fields.iter().enumerate() {
-                // don't expose uninspectable fields' properties
-                if field.expand || field.skip {
+                if field.skip {
                     continue;
                 }
 
@@ -31,12 +30,9 @@ pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
         ast::Data::Enum(variants) => {
             for v in variants {
                 for (nth, field) in v.fields.iter().enumerate() {
-                    // don't expose uninspectable fields' properties
-                    if field.expand || field.skip {
+                    if field.skip {
                         continue;
                     }
-
-                    // REMARK: We can't refer to expanded fields
 
                     let prop_ident = self::enum_field_prop(v, nth, field);
                     let prop_name = utils::prop_name(nth, field);

--- a/fyrox-core-derive/tests/it/inspect.rs
+++ b/fyrox-core-derive/tests/it/inspect.rs
@@ -65,10 +65,6 @@ fn inspect_attributes() {
         _skipped: u32,
         #[inspect(name = "the_x", display_name = "Super X")]
         x: f32,
-        // Expand properties are added to the end of the list.
-        // NOTE: Even though this field inspection is postponed, this field is given index `2`
-        #[inspect(expand)]
-        aar_gee: AarGee,
         #[inspect(
             read_only,
             min_value = 0.1,
@@ -106,21 +102,6 @@ fn inspect_attributes() {
     ];
 
     assert_eq!(data.properties()[0..2], expected);
-    assert_eq!(data.properties().len(), 2 + data.aar_gee.properties().len());
-
-    #[derive(Debug, Default, Inspect)]
-    pub struct X {
-        #[inspect(expand_subtree)]
-        y: Y,
-    }
-
-    #[derive(Debug, Default, Inspect)]
-    pub struct Y {
-        a: u32,
-    }
-
-    let x = X::default();
-    assert_eq!(x.properties().len(), 1 + x.y.properties().len());
 }
 
 #[test]
@@ -247,27 +228,19 @@ fn inspect_enum() {
 
 #[test]
 fn inspect_prop_key_constants() {
-    #[derive(Debug, Inspect)]
-    pub struct X;
-
     #[allow(dead_code)]
     #[derive(Inspect)]
     pub struct SStruct {
         field: usize,
         #[inspect(skip)]
         hidden: usize,
-        #[inspect(expand)]
-        expand: X,
-        #[inspect(expand_subtree)]
-        expand_subtree: X,
     }
 
     // NOTE: property names are in snake_case (not Title Case)
     assert_eq!(SStruct::FIELD, "field");
-    // property keys for uninspectable fields are NOT emitted
+
+    // hidden properties
     // assert_eq!(SStruct::HIDDEN, "hidden");
-    // assert_eq!(SStruct::EXPAND, "expand");
-    assert_eq!(SStruct::EXPAND_SUBTREE, "expand_subtree");
 
     #[derive(Inspect)]
     pub struct STuple(usize);


### PR DESCRIPTION
Because the hack is not in use today.

Reverting this change is easy.
