### PR TITLE
Internal: change property key name to consider enum variant's name

### DIFF
--- a/fyrox-core-derive/Cargo.toml
+++ b/fyrox-core-derive/Cargo.toml
@@ -19,7 +19,7 @@ convert_case = "0.5.0"
 proc-macro2 = "1.0.33"
 quote = "1.0.10"
 syn = "1.0.82"
-darling = "0.13.1"
+darling = "0.14.0"
 fxhash = "0.2.1"
 
 [dev-dependencies]

--- a/fyrox-core-derive/src/inspect/args.rs
+++ b/fyrox-core-derive/src/inspect/args.rs
@@ -93,7 +93,7 @@ pub struct FieldArgs {
     pub is_modified: Option<String>,
 }
 
-#[derive(FromVariant)]
+#[derive(FromVariant, Clone)]
 #[darling(attributes(inspect))]
 pub struct VariantArgs {
     pub ident: Ident,

--- a/fyrox-core-derive/src/inspect/utils/prop_keys.rs
+++ b/fyrox-core-derive/src/inspect/utils/prop_keys.rs
@@ -6,12 +6,36 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::*;
 
-use crate::inspect::{args, utils};
+use crate::inspect::args;
 
-/// Returns a list of `pub const [VARIANT_]FIELD: &'static str = "key_value"`;
+/// `pub const [VARIANT_]FIELD: &'static str = "key";`
+pub fn prop_keys_impl(ty_args: &args::TypeArgs) -> TokenStream2 {
+    let ty_ident = &ty_args.ident;
+    let (impl_generics, ty_generics, where_clause) = ty_args.generics.split_for_impl();
+
+    let prop_keys = self::quote_prop_keys(ty_args);
+
+    quote! {
+        /// Property key constants
+        impl #impl_generics #ty_ident #ty_generics #where_clause {
+            #prop_keys
+        }
+    }
+}
+
+/// List of `pub const <ident> = <name>;`
+///
+/// # Definition format
+///
+/// | Type         | Identifier                | Name                     |
+/// |--------------|---------------------------|--------------------------|
+/// | Struct       | `FIELD_NAME`              | `field_name`             |
+/// | Unit struct  | `F_<number>`              | `<number>`               |
+/// | Tuple struct | `VARIANT_NAME_FIELD_NAME  | `VariantName.field_name` |
+/// | Enum         | `VARIANT_NAME_F_<number>` | `VariantName.<number>`   |
 pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
     let mut prop_idents = Vec::new();
-    let mut prop_names = Vec::new();
+    let mut prop_key_names = Vec::new();
 
     match &ty_args.data {
         ast::Data::Struct(field_args) => {
@@ -20,11 +44,11 @@ pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
                     continue;
                 }
 
-                let prop_ident = self::struct_field_prop(ty_args, nth, field);
-                let prop_name = utils::prop_name(nth, field);
+                let prop_ident = self::struct_prop_ident(ty_args, nth, field);
+                let prop_key_name = self::struct_prop_key_name(nth, field);
 
                 prop_idents.push(prop_ident);
-                prop_names.push(prop_name);
+                prop_key_names.push(prop_key_name);
             }
         }
         ast::Data::Enum(variants) => {
@@ -34,11 +58,11 @@ pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
                         continue;
                     }
 
-                    let prop_ident = self::enum_field_prop(v, nth, field);
-                    let prop_name = utils::prop_name(nth, field);
+                    let prop_ident = self::enum_prop_ident(v, nth, field);
+                    let prop_key_name = self::enum_prop_key_name(nth, field, v);
 
                     prop_idents.push(prop_ident);
-                    prop_names.push(prop_name);
+                    prop_key_names.push(prop_key_name);
                 }
             }
         }
@@ -47,12 +71,40 @@ pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
     quote! {
         #(
             #[allow(missing_docs)]
-            pub const #prop_idents: &'static str = #prop_names;
+            pub const #prop_idents: &'static str = #prop_key_names;
         )*
     }
 }
 
-fn struct_field_prop(ty_args: &args::TypeArgs, nth: usize, field: &args::FieldArgs) -> Ident {
+pub fn struct_prop_key_name(nth: usize, field: &args::FieldArgs) -> String {
+    field.name.clone().unwrap_or_else(|| {
+        let field_ident = match &field.ident {
+            Some(ident) => quote!(#ident),
+            None => {
+                let nth_field = Index::from(nth);
+                quote!(#nth_field)
+            }
+        };
+
+        field_ident.to_string()
+    })
+}
+
+pub fn enum_prop_key_name(nth: usize, field: &args::FieldArgs, v: &args::VariantArgs) -> String {
+    field.name.clone().unwrap_or_else(|| {
+        let field_ident = match &field.ident {
+            Some(ident) => quote!(#ident),
+            None => {
+                let nth_field = Index::from(nth);
+                quote!(#nth_field)
+            }
+        };
+
+        format!("{}.{}", v.ident, field_ident)
+    })
+}
+
+pub fn struct_prop_ident(ty_args: &args::TypeArgs, nth: usize, field: &args::FieldArgs) -> Ident {
     let fields = match &ty_args.data {
         ast::Data::Struct(xs) => xs,
         _ => unreachable!(),
@@ -63,7 +115,11 @@ fn struct_field_prop(ty_args: &args::TypeArgs, nth: usize, field: &args::FieldAr
     syn::parse_str(&ident).unwrap()
 }
 
-fn enum_field_prop(variant_args: &args::VariantArgs, nth: usize, field: &args::FieldArgs) -> Ident {
+pub fn enum_prop_ident(
+    variant_args: &args::VariantArgs,
+    nth: usize,
+    field: &args::FieldArgs,
+) -> Ident {
     let variant_ident = &variant_args.ident;
     let field_ident = self::field_ident(&variant_args.fields, nth, field);
 

--- a/fyrox-core-derive/src/inspect/utils/prop_keys.rs
+++ b/fyrox-core-derive/src/inspect/utils/prop_keys.rs
@@ -27,12 +27,12 @@ pub fn prop_keys_impl(ty_args: &args::TypeArgs) -> TokenStream2 {
 ///
 /// # Definition format
 ///
-/// | Type         | Identifier                | Name                     |
-/// |--------------|---------------------------|--------------------------|
-/// | Struct       | `FIELD_NAME`              | `field_name`             |
-/// | Unit struct  | `F_<number>`              | `<number>`               |
-/// | Tuple struct | `VARIANT_NAME_FIELD_NAME  | `VariantName.field_name` |
-/// | Enum         | `VARIANT_NAME_F_<number>` | `VariantName.<number>`   |
+/// | Type           | Identifier                | Name                     |
+/// |----------------|---------------------------|--------------------------|
+/// | Struct         | `FIELD_NAME`              | `field_name`             |
+/// | Struct (tuple) | `F_<number>`              | `<number>`               |
+/// | Enum (struct)  | `VARIANT_NAME_FIELD_NAME  | `VariantName.field_name` |
+/// | Enum (tuple)   | `VARIANT_NAME_F_<number>` | `VariantName.<number>`   |
 pub fn quote_prop_keys(ty_args: &args::TypeArgs) -> TokenStream2 {
     let mut prop_idents = Vec::new();
     let mut prop_key_names = Vec::new();

--- a/fyrox-core-derive/tests/it/inspect.rs
+++ b/fyrox-core-derive/tests/it/inspect.rs
@@ -162,7 +162,7 @@ fn inspect_enum() {
         vec![
             PropertyInfo {
                 owner_type_id: TypeId::of::<Data>(),
-                name: "x",
+                name: "Named.x",
                 display_name: "X",
                 value: match data {
                     Data::Named { ref x, .. } => x,
@@ -172,7 +172,7 @@ fn inspect_enum() {
             },
             PropertyInfo {
                 owner_type_id: TypeId::of::<Data>(),
-                name: "y",
+                name: "Named.y",
                 display_name: "Y",
                 value: match data {
                     Data::Named { ref y, .. } => y,
@@ -182,7 +182,7 @@ fn inspect_enum() {
             },
             PropertyInfo {
                 owner_type_id: TypeId::of::<Data>(),
-                name: "z",
+                name: "Named.z",
                 display_name: "Z",
                 value: match data {
                     Data::Named { ref z, .. } => z,
@@ -200,7 +200,7 @@ fn inspect_enum() {
         vec![
             PropertyInfo {
                 owner_type_id: TypeId::of::<Data>(),
-                name: "0",
+                name: "Tuple.0",
                 display_name: "0",
                 value: match data {
                     Data::Tuple(ref f0, ref _f1) => f0,
@@ -210,7 +210,7 @@ fn inspect_enum() {
             },
             PropertyInfo {
                 owner_type_id: TypeId::of::<Data>(),
-                name: "1",
+                name: "Tuple.1",
                 display_name: "1",
                 value: match data {
                     Data::Tuple(ref _f0, ref f1) => f1,
@@ -254,11 +254,11 @@ fn inspect_prop_key_constants() {
         Unit,
     }
 
-    assert_eq!(E::TUPLE_F_0, "0");
-    assert_eq!(E::STRUCT_FIELD, "field");
+    assert_eq!(E::TUPLE_F_0, "Tuple.0");
+    assert_eq!(E::TUPLE_F_0, E::Tuple(0).properties()[0].name);
 
-    // variant itself it not a property
-    // assert_eq!(E::UNIT, "unit");
+    assert_eq!(E::STRUCT_FIELD, "Struct.field");
+    assert_eq!(E::STRUCT_FIELD, E::Struct { field: 0 }.properties()[0].name);
 }
 
 #[test]


### PR DESCRIPTION
This PR changes the property key constants for enums generated with `#[derive(Inspect)]`.

# Example

Let's consider this code:

```rust
#[derive(Inspect)]
enum E {
    A { field: usize },
    B { field: usize },
}
```

Before this PR, it generates:
```rust
impl E {
    pub const A: &'static str = "field";
    pub const B: &'static str = "field";
}
```

After this PR, it generates:
```rust
impl E {
    pub const A: &'static str = "A.field";
    pub const B: &'static str = "B.field";
}
```

# Future use

With runtime reflection, we might refer to enum fields like `joint.BallJoint.local_anchor1`.
