### PR TITLE
Isolate running game in separate process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ fxhash = "0.2.1"
 strum = "0.24.0"
 strum_macros = "0.24.0"
 notify = "4.0"
+clap = { version = "3.1.18", features = ["derive"] }
 
 [features]
 enable_profiler = ["fyrox-core/enable_profiler"]

--- a/editor/src/build.rs
+++ b/editor/src/build.rs
@@ -92,11 +92,9 @@ impl BuildWindow {
         let log_changed = self.changed.clone();
         std::thread::spawn(move || {
             while reader_active.load(Ordering::SeqCst) {
-                for line in BufReader::new(&mut stdout).lines().take(10) {
-                    if let Ok(line) = line {
-                        log.lock().push_str(&line);
-                        log_changed.store(true, Ordering::SeqCst);
-                    }
+                for line in BufReader::new(&mut stdout).lines().take(10).flatten() {
+                    log.lock().push_str(&line);
+                    log_changed.store(true, Ordering::SeqCst);
                 }
             }
         });

--- a/editor/src/build.rs
+++ b/editor/src/build.rs
@@ -12,7 +12,7 @@ use fyrox::{
     },
 };
 use std::{
-    io::{BufRead, BufReader, Read},
+    io::{BufRead, BufReader},
     process::ChildStdout,
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/editor/src/build.rs
+++ b/editor/src/build.rs
@@ -1,0 +1,124 @@
+use fyrox::{
+    core::{parking_lot::Mutex, pool::Handle},
+    gui::{
+        grid::{Column, GridBuilder, Row},
+        message::MessageDirection,
+        scroll_viewer::ScrollViewerBuilder,
+        text::{TextBuilder, TextMessage},
+        widget::WidgetBuilder,
+        window::{WindowBuilder, WindowMessage, WindowTitle},
+        BuildContext, UiNode, UserInterface,
+    },
+};
+use std::{
+    io::Read,
+    process::ChildStdout,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+pub struct BuildWindow {
+    window: Handle<UiNode>,
+    active: Arc<AtomicBool>,
+    changed: Arc<AtomicBool>,
+    log: Arc<Mutex<String>>,
+    log_text: Handle<UiNode>,
+}
+
+impl BuildWindow {
+    pub fn new(ctx: &mut BuildContext) -> Self {
+        let log_text;
+        let window = WindowBuilder::new(WidgetBuilder::new().with_width(300.0).with_height(400.0))
+            .can_minimize(false)
+            .can_close(false)
+            .open(false)
+            .with_content(
+                GridBuilder::new(
+                    WidgetBuilder::new()
+                        .with_child(
+                            TextBuilder::new(WidgetBuilder::new())
+                                .with_text("Please wait while your game is building...")
+                                .build(ctx),
+                        )
+                        .with_child(
+                            ScrollViewerBuilder::new(WidgetBuilder::new().on_row(1))
+                                .with_content({
+                                    log_text = TextBuilder::new(WidgetBuilder::new()).build(ctx);
+                                    log_text
+                                })
+                                .build(ctx),
+                        ),
+                )
+                .add_row(Row::auto())
+                .add_row(Row::stretch())
+                .add_column(Column::stretch())
+                .build(ctx),
+            )
+            .with_title(WindowTitle::text("Building the Game..."))
+            .build(ctx);
+
+        Self {
+            window,
+            log_text,
+            log: Arc::new(Default::default()),
+            active: Arc::new(AtomicBool::new(false)),
+            changed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn listen(&mut self, mut stdout: ChildStdout, ui: &UserInterface) {
+        ui.send_message(WindowMessage::open_modal(
+            self.window,
+            MessageDirection::ToWidget,
+            true,
+        ));
+
+        let log = self.log.clone();
+        self.active.store(true, Ordering::SeqCst);
+        let reader_active = self.active.clone();
+        let log_changed = self.changed.clone();
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            while reader_active.load(Ordering::SeqCst) {
+                let mut slice = [0u8; 64];
+                if let Ok(size) = stdout.read(&mut slice) {
+                    buf.extend_from_slice(&slice[..size]);
+                    if let Ok(string) = std::str::from_utf8(&buf) {
+                        *log.lock() += string;
+                        buf.clear();
+                        log_changed.store(true, Ordering::SeqCst);
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn reset(&mut self, ui: &UserInterface) {
+        self.active.store(false, Ordering::SeqCst);
+        self.changed.store(false, Ordering::SeqCst);
+        self.log.lock().clear();
+        ui.send_message(TextMessage::text(
+            self.log_text,
+            MessageDirection::ToWidget,
+            Default::default(),
+        ));
+        ui.send_message(WindowMessage::close(
+            self.window,
+            MessageDirection::ToWidget,
+        ));
+    }
+
+    pub fn update(&mut self, ui: &UserInterface) {
+        if self.changed.load(Ordering::SeqCst) {
+            ui.send_message(TextMessage::text(
+                self.log_text,
+                MessageDirection::ToWidget,
+                self.log.lock().clone(),
+            ));
+
+            self.changed.store(false, Ordering::SeqCst);
+        }
+    }
+}

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1138,30 +1138,46 @@ impl Editor {
                     }
                     Err(e) => Log::err(format!("Failed to enter play mode: {:?}", e)),
                 }
+            } else {
+                Log::err("Save you scene first!".to_owned());
             }
+        } else {
+            Log::err("Cannot enter build mode when there is no scene!".to_owned());
         }
     }
 
     fn set_build_mode(&mut self) {
         if let Mode::Edit = self.mode {
-            match std::process::Command::new("cargo")
-                .stdout(Stdio::piped())
-                .arg("build")
-                .arg("--package")
-                .arg("executor")
-                .arg("--release")
-                .spawn()
-            {
-                Ok(mut process) => {
-                    self.build_window
-                        .listen(process.stdout.take().unwrap(), &self.engine.user_interface);
+            if let Some(scene) = self.scene.as_ref() {
+                if let Some(path) = scene.path.as_ref().cloned() {
+                    match std::process::Command::new("cargo")
+                        .stdout(Stdio::piped())
+                        .arg("build")
+                        .arg("--package")
+                        .arg("executor")
+                        .arg("--release")
+                        .spawn()
+                    {
+                        Ok(mut process) => {
+                            self.build_window.listen(
+                                process.stdout.take().unwrap(),
+                                &self.engine.user_interface,
+                            );
 
-                    self.mode = Mode::Build { process };
+                            self.mode = Mode::Build { process };
 
-                    self.on_mode_changed();
+                            self.on_mode_changed();
+                        }
+                        Err(e) => Log::err(format!("Failed to enter build mode: {:?}", e)),
+                    }
+                } else {
+                    Log::err("Save you scene first!".to_owned());
                 }
-                Err(e) => Log::err(format!("Failed to enter build mode: {:?}", e)),
+            } else {
+                Log::err("Cannot enter build mode when there is no scene!".to_owned());
             }
+        } else {
+            Log::err("Cannot enter build mode when from non-Edit mode!".to_owned());
         }
     }
 

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1099,6 +1099,9 @@ impl Editor {
                     .arg("--package")
                     .arg("executor")
                     .arg("--release")
+                    .arg("--")
+                    .arg("--override-scene")
+                    .arg(path.clone())
                     .spawn()
                 {
                     Ok(process) => {

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1594,11 +1594,11 @@ impl Editor {
         self.asset_browser.update(&mut self.engine);
     }
 
-    pub fn add_game_plugin<P>(&mut self) -> bool
+    pub fn add_game_plugin<P>(&mut self, plugin: P) -> bool
     where
-        P: Plugin + Default + TypeUuidProvider,
+        P: Plugin + TypeUuidProvider,
     {
-        self.engine.add_plugin::<P>()
+        self.engine.add_plugin(plugin)
     }
 
     pub fn run(mut self, event_loop: EventLoop<()>) -> ! {

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -270,11 +270,7 @@ pub enum Mode {
 
 impl Mode {
     pub fn is_edit(&self) -> bool {
-        !self.is_play()
-    }
-
-    pub fn is_play(&self) -> bool {
-        matches!(self, Mode::Play { .. })
+        matches!(self, Mode::Edit { .. })
     }
 }
 
@@ -1110,7 +1106,6 @@ impl Editor {
                 self.save_current_scene(path.clone());
 
                 match std::process::Command::new("cargo")
-                    .stdin(Stdio::piped())
                     .stdout(Stdio::piped())
                     .arg("run")
                     .arg("--package")
@@ -1150,7 +1145,6 @@ impl Editor {
     fn set_build_mode(&mut self) {
         if let Mode::Edit = self.mode {
             match std::process::Command::new("cargo")
-                .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .arg("build")
                 .arg("--package")

--- a/editor/src/scene_viewer.rs
+++ b/editor/src/scene_viewer.rs
@@ -1,19 +1,18 @@
-use crate::scene::commands::graph::ScaleNodeCommand;
 use crate::{
     camera::PickingOptions, gui::make_dropdown_list_option_with_height, load_image,
-    utils::enable_widget, AddModelCommand, AssetItem, AssetKind, ChangeSelectionCommand,
-    CommandGroup, DropdownListBuilder, EditorScene, GameEngine, GraphSelection, InteractionMode,
-    InteractionModeKind, Message, Mode, SceneCommand, Selection, SetMeshTextureCommand,
-    SetParticleSystemTextureCommand, SetSpriteTextureCommand, Settings,
+    scene::commands::graph::ScaleNodeCommand, utils::enable_widget, AddModelCommand, AssetItem,
+    AssetKind, ChangeSelectionCommand, CommandGroup, DropdownListBuilder, EditorScene, GameEngine,
+    GraphSelection, InteractionMode, InteractionModeKind, Message, Mode, SceneCommand, Selection,
+    SetMeshTextureCommand, SetParticleSystemTextureCommand, SetSpriteTextureCommand, Settings,
 };
-use fyrox::core::algebra::Vector3;
 use fyrox::{
+    core::algebra::Vector3,
     core::{algebra::Vector2, color::Color, make_relative_path, math::Rect, pool::Handle},
     engine::Engine,
     gui::{
         border::BorderBuilder,
         brush::Brush,
-        button::{ButtonBuilder, ButtonMessage},
+        button::{ButtonBuilder, ButtonContent, ButtonMessage},
         canvas::CanvasBuilder,
         dropdown_list::DropdownListMessage,
         formatted_text::WrapMode,
@@ -219,7 +218,7 @@ impl SceneViewer {
                             .with_margin(Thickness::uniform(1.0))
                             .with_width(100.0),
                     )
-                    .with_text("Play/Stop")
+                    .with_text("Play")
                     .build(ctx);
                     switch_mode
                 })
@@ -440,6 +439,11 @@ impl SceneViewer {
 
     pub fn on_mode_changed(&self, ui: &UserInterface, mode: &Mode) {
         let enabled = mode.is_edit();
+        ui.send_message(ButtonMessage::content(
+            self.switch_mode,
+            MessageDirection::ToWidget,
+            ButtonContent::text(if enabled { "Play" } else { "Stop" }),
+        ));
         for widget in [self.interaction_mode_panel, self.contextual_actions] {
             enable_widget(widget, enabled, ui);
         }

--- a/editor/src/utils/mod.rs
+++ b/editor/src/utils/mod.rs
@@ -1,7 +1,5 @@
-use crate::WindowEvent;
 use fyrox::{
     core::{algebra::Vector2, pool::Handle},
-    event::Event,
     gui::{
         file_browser::{FileBrowserMode, FileSelectorBuilder, FileSelectorMessage, Filter},
         message::MessageDirection,
@@ -49,38 +47,6 @@ pub fn enable_widget(handle: Handle<UiNode>, state: bool, ui: &UserInterface) {
         MessageDirection::ToWidget,
         state,
     ));
-}
-
-pub fn normalize_os_event(
-    result: &mut Event<()>,
-    frame_position: Vector2<f32>,
-    frame_size: Vector2<f32>,
-) {
-    if let Event::WindowEvent { event, .. } = result {
-        match event {
-            WindowEvent::Resized(size) => {
-                size.width = frame_size.x as u32;
-                size.height = frame_size.y as u32;
-            }
-            WindowEvent::Moved(position) => {
-                position.x -= frame_position.x as i32;
-                position.y -= frame_position.y as i32;
-            }
-            WindowEvent::CursorMoved { position, .. } => {
-                position.x -= frame_position.x as f64;
-                position.y -= frame_position.y as f64;
-            }
-            WindowEvent::Touch(touch) => {
-                touch.location.x -= frame_position.x as f64;
-                touch.location.y -= frame_position.y as f64;
-            }
-            WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                new_inner_size.width = frame_size.x as u32;
-                new_inner_size.height = frame_size.y as u32;
-            }
-            _ => (),
-        }
-    }
 }
 
 pub fn create_file_selector(

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -64,11 +64,11 @@ impl Executor {
         Self { event_loop, engine }
     }
 
-    pub fn add_plugin<P>(&mut self) -> bool
+    pub fn add_plugin<P>(&mut self, plugin: P) -> bool
     where
-        P: Plugin + Default + TypeUuidProvider,
+        P: Plugin + TypeUuidProvider,
     {
-        self.engine.add_plugin::<P>()
+        self.engine.add_plugin(plugin)
     }
 
     pub fn run(self) -> ! {

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -1,22 +1,30 @@
 #![allow(missing_docs)]
 
-use crate::scene::node::TypeUuidProvider;
 use crate::{
-    core::instant::Instant,
+    core::{futures::executor::block_on, instant::Instant, pool::Handle},
     engine::{resource_manager::ResourceManager, Engine, EngineInitParams, SerializationContext},
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     plugin::Plugin,
+    scene::{node::TypeUuidProvider, SceneLoader},
     utils::{
         log::{Log, MessageKind},
         translate_event,
     },
     window::WindowBuilder,
 };
+use clap::Parser;
 use std::{
     ops::{Deref, DerefMut},
     sync::Arc,
 };
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(short, long, default_value = "")]
+    override_scene: String,
+}
 
 pub struct Executor {
     event_loop: EventLoop<()>,
@@ -79,7 +87,27 @@ impl Executor {
         let fixed_timestep = 1.0 / 60.0;
         let mut elapsed_time = 0.0;
 
-        engine.enable_plugins(Default::default(), true);
+        let args = Args::parse();
+
+        let mut override_scene = Handle::NONE;
+        if !args.override_scene.is_empty() {
+            match block_on(SceneLoader::from_file(
+                &args.override_scene,
+                engine.serialization_context.clone(),
+            )) {
+                Ok(loader) => {
+                    override_scene = engine
+                        .scenes
+                        .add(block_on(loader.finish(engine.resource_manager.clone())));
+                }
+                Err(e) => Log::warn(format!(
+                    "Unable to load {} override scene! Reason: {:?}",
+                    args.override_scene, e
+                )),
+            }
+        }
+
+        engine.enable_plugins(override_scene, true);
 
         event_loop.run(move |event, _, control_flow| {
             engine.handle_os_event_by_plugins(&event, fixed_timestep);

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -621,7 +621,12 @@ impl Engine {
     /// This method is intended to be used by the editor and game runner. If you're using the
     /// engine as a framework, then you should not call this method because you'll most likely
     /// do something wrong.
-    pub fn handle_os_event_by_scripts(&mut self, event: &Event<()>, scene: Handle<Scene>, dt: f32) {
+    pub(crate) fn handle_os_event_by_scripts(
+        &mut self,
+        event: &Event<()>,
+        scene: Handle<Scene>,
+        dt: f32,
+    ) {
         process_scripts(
             &mut self.scenes[scene],
             &mut self.plugins,
@@ -639,7 +644,7 @@ impl Engine {
     /// This method is intended to be used by the editor and game runner. If you're using the
     /// engine as a framework, then you should not call this method because you'll most likely
     /// do something wrong.
-    pub fn initialize_scene_scripts(&mut self, scene: Handle<Scene>, dt: f32) {
+    pub(crate) fn initialize_scene_scripts(&mut self, scene: Handle<Scene>, dt: f32) {
         // Wait until all resources are fully loaded (or failed to load). It is needed
         // because some scripts may use resources and any attempt to use non loaded resource
         // will result in panic.
@@ -748,7 +753,7 @@ impl Engine {
     }
 
     /// Enables or disables registered plugins.
-    pub fn enable_plugins(&mut self, override_scene: Handle<Scene>, enabled: bool) {
+    pub(crate) fn enable_plugins(&mut self, override_scene: Handle<Scene>, enabled: bool) {
         if self.plugins_enabled != enabled {
             self.plugins_enabled = enabled;
 
@@ -790,20 +795,19 @@ impl Engine {
     }
 
     /// Adds new plugin.
-    pub fn add_plugin<P>(&mut self) -> bool
+    pub fn add_plugin<P>(&mut self, mut plugin: P) -> bool
     where
-        P: Plugin + Default + TypeUuidProvider,
+        P: Plugin + TypeUuidProvider,
     {
         if self.plugins.iter().any(|p| p.id() == P::type_uuid()) {
             false
         } else {
-            let mut plugin = P::default();
-
             plugin.on_register(PluginRegistrationContext {
                 serialization_context: self.serialization_context.clone(),
             });
 
             self.plugins.push(Box::new(plugin));
+
             true
         }
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -488,6 +488,7 @@ impl Engine {
                 resource_manager: &self.resource_manager,
                 renderer: &mut self.renderer,
                 dt,
+                user_interface: &mut self.user_interface,
                 serialization_context: self.serialization_context.clone(),
                 window: get_window!(self),
             };
@@ -509,6 +510,7 @@ impl Engine {
                         resource_manager: &self.resource_manager,
                         renderer: &mut self.renderer,
                         dt,
+                        user_interface: &mut self.user_interface,
                         serialization_context: self.serialization_context.clone(),
                         window: get_window!(self),
                     },
@@ -760,6 +762,7 @@ impl Engine {
                             resource_manager: &self.resource_manager,
                             renderer: &mut self.renderer,
                             dt: 0.0,
+                            user_interface: &mut self.user_interface,
                             serialization_context: self.serialization_context.clone(),
                             window: get_window!(self),
                         },
@@ -775,6 +778,7 @@ impl Engine {
                         resource_manager: &self.resource_manager,
                         renderer: &mut self.renderer,
                         dt: 0.0,
+                        user_interface: &mut self.user_interface,
                         serialization_context: self.serialization_context.clone(),
                         window: get_window!(self),
                     });

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     renderer::Renderer,
     scene::{Scene, SceneContainer},
 };
+use fyrox_ui::UserInterface;
 use std::{any::Any, sync::Arc};
 
 /// Contains plugin environment for the registration stage.
@@ -23,17 +24,14 @@ pub struct PluginRegistrationContext {
 pub struct PluginContext<'a> {
     /// A reference to scene container of the engine. You can add new scenes from [`Plugin`] methods
     /// by using [`SceneContainer::add`].
-    ///
-    /// # Important notes
-    ///
-    /// Do not clear this container when running your plugin in the editor, otherwise you'll get
-    /// panic. Every scene that was added in the container while "play mode" in the editor was
-    /// active will be removed when you leave play mode.
     pub scenes: &'a mut SceneContainer,
 
     /// A reference to the resource manager, it can be used to load various resources and manage
     /// them. See [`ResourceManager`] docs for more info.
     pub resource_manager: &'a ResourceManager,
+
+    /// A reference to user interface instance.
+    pub user_interface: &'a mut UserInterface,
 
     /// A reference to the renderer, it can be used to add custom render passes (for example to
     /// render custom effects and so on).
@@ -101,32 +99,6 @@ impl dyn Plugin {
 /// high-level structure of your game and forces you to implement game logic inside plugins and
 /// scripts. The framework mode provides low-level access to engine details and leaves implementation
 /// details to you.
-///
-/// By default the engine, if used alone, **completely ignores** every plugin, it calls a few methods
-/// ([`Plugin::on_register`], [`Plugin::on_standalone_init`]) and does not call any other methods.
-/// The plugins are meant to be used only in "true" engine mode. If you're using the engine alone
-/// (without the editor, executor, and required project structure), it means that you're using the
-/// engine in **framework** mode and you're able to setup your project as you want.
-///
-/// The plugins managed either by `Executor` or the editor (`Fyroxed`). The first one is a small
-/// framework that calls all methods of the plugin as it needs to be, `Executor` is used to build
-/// final binary of your game. The editor is also able to use plugins, it manages them in special
-/// way that guarantees some invariants.
-///
-/// # Interface details
-///
-/// There is one confusing part in the plugin interface: two methods that looks like they're doing
-/// the same thing - [`Plugin::on_standalone_init`] and [`Plugin::on_enter_play_mode`]. However
-/// there is one major difference in the two. The first method is called when the plugin is running
-/// in a standalone mode (in game executor, which is final binary of your game). The second is used
-/// in the editor and called when the editor enters "play mode".
-///
-/// The "play mode" is special and should be described a bit more. The editor is able to edit
-/// scenes, there could be only one scene opened at a time. However your game could use multiple
-/// scenes (for example one for game menu and one per game level). This fact leads to a problem:
-/// how the game will know which scene is currently edited and requested for "play mode"?
-/// [`Plugin::on_enter_play_mode`] solves the problem by providing you the handle to the active
-/// scene, in this method you should force your game to use provided scene.
 ///
 /// # Static vs dynamic plugins
 ///


### PR DESCRIPTION
This PR implements full isolation of a game code, instead of running the game in the editor directly the editor now spawns separate process. The PR fixes lots of issues related to shared engine instance between editor and the game and removes some APIs (i.e. `SceneUserInterface`).