### PR TITLE
Use simple `#[inspect(deref)]`

### DIFF
--- a/fyrox-core-derive/README.md
+++ b/fyrox-core-derive/README.md
@@ -1,3 +1,7 @@
 # fyrox-core-derive
 
-Provides the `#[derive(Visit)]` macro, which implements `fyrox::core::visitor::Visit`.
+This crate provides with some derive macros:
+
+- `#[derive(Visit)]`
+- `#[derive(Inspect)]`
+- `#[derive(Reflect)]`

--- a/fyrox-core-derive/src/inspect.rs
+++ b/fyrox-core-derive/src/inspect.rs
@@ -9,7 +9,9 @@ use quote::quote;
 use syn::*;
 
 pub fn impl_inspect(ast: DeriveInput) -> TokenStream2 {
-    let ty_args = args::TypeArgs::from_derive_input(&ast).unwrap();
+    let mut ty_args = args::TypeArgs::from_derive_input(&ast).unwrap();
+    ty_args.validate();
+
     match &ty_args.data {
         ast::Data::Struct(ref field_args) => self::impl_inspect_struct(&ty_args, field_args),
         ast::Data::Enum(ref variant_args) => self::impl_inspect_enum(&ty_args, variant_args),

--- a/fyrox-core-derive/src/inspect/args.rs
+++ b/fyrox-core-derive/src/inspect/args.rs
@@ -100,11 +100,11 @@ pub struct FieldArgs {
     #[darling(default)]
     pub description: Option<String>,
 
-    /// `#[inspect(getter = "<method_name>")]`
+    /// `#[inspect(is_modified = <expr>)]`
     ///
-    /// True if the value has been modified.
+    /// Method call syntax. It returns true if the value has been modified.
     #[darling(default)]
-    pub is_modified: Option<String>,
+    pub is_modified: Option<Expr>,
 }
 
 impl FieldArgs {

--- a/fyrox-core-derive/src/inspect/utils.rs
+++ b/fyrox-core-derive/src/inspect/utils.rs
@@ -206,7 +206,7 @@ fn quote_field_prop(
     let getter = match &field.getter {
         // use custom getter function to retrieve the target reference
         Some(getter) => {
-            quote! { (#field_ref).#getter }
+            quote! { #field_ref.#getter }
         }
         // default: get reference of the field
         None => field_ref.clone(),
@@ -247,8 +247,7 @@ fn quote_field_prop(
 
     let is_modified = match field.is_modified.as_ref() {
         Some(getter) => {
-            let getter: Path = parse_str(getter).expect("can't parse `is_modified` as a path");
-            quote! { #field_ref.#getter() }
+            quote! { #field_ref.#getter }
         }
         None => quote! { false },
     };

--- a/fyrox-core-derive/src/inspect/utils.rs
+++ b/fyrox-core-derive/src/inspect/utils.rs
@@ -206,8 +206,7 @@ fn quote_field_prop(
     let getter = match &field.getter {
         // use custom getter function to retrieve the target reference
         Some(getter) => {
-            let getter: Path = parse_str(getter).expect("can't parse `getter` as a path");
-            quote! { #getter(#field_ref) }
+            quote! { (#field_ref).#getter }
         }
         // default: get reference of the field
         None => field_ref.clone(),

--- a/fyrox-core-derive/src/reflect/args.rs
+++ b/fyrox-core-derive/src/reflect/args.rs
@@ -108,7 +108,7 @@ pub struct FieldArgs {
 
     /// `#[reflect(deref)]`
     ///
-    /// Delegates most of the `Reflect` implementations to the deref type.
+    /// Sets `field` and `field_mut` attributes with `deref()` and `deref_mut()`
     #[darling(default)]
     pub deref: bool,
 
@@ -130,7 +130,7 @@ impl FieldArgs {
         if self.deref {
             assert!(
                 self.field.is_none() || self.field_mut.is_none(),
-                "use either `deref` or `field` + `field_mut`"
+                "can't use both `deref` and `field` + `field_mut`"
             );
         }
 

--- a/fyrox-core-derive/tests/it/inspect.rs
+++ b/fyrox-core-derive/tests/it/inspect.rs
@@ -279,19 +279,31 @@ fn inspect_with_custom_getter() {
     }
 
     #[derive(Inspect, Reflect)]
-    struct A(#[inspect(getter = "Deref::deref")] D<u32>);
+    struct A(
+        #[inspect(getter = "deref()")] D<u32>,
+        #[inspect(deref)] D<u32>,
+    );
 
-    let a = A(D(10));
+    let a = A(D(10), D(11));
 
     assert_eq!(
         a.properties(),
-        vec![PropertyInfo {
-            owner_type_id: TypeId::of::<A>(),
-            name: "0",
-            display_name: "0",
-            value: &*a.0,
-            ..default_prop()
-        }]
+        vec![
+            PropertyInfo {
+                owner_type_id: TypeId::of::<A>(),
+                name: "0",
+                display_name: "0",
+                value: &*a.0,
+                ..default_prop()
+            },
+            PropertyInfo {
+                owner_type_id: TypeId::of::<A>(),
+                name: "1",
+                display_name: "1",
+                value: &*a.1,
+                ..default_prop()
+            }
+        ]
     );
 }
 

--- a/fyrox-core-derive/tests/it/inspect.rs
+++ b/fyrox-core-derive/tests/it/inspect.rs
@@ -310,7 +310,7 @@ fn inspect_with_custom_getter() {
 #[test]
 fn inspect_modified() {
     #[derive(Inspect, Reflect)]
-    struct S(#[inspect(is_modified = "clone")] bool);
+    struct S(#[inspect(is_modified = "clone()")] bool);
 
     let s = S(true);
     assert_eq!(

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -311,13 +311,13 @@ pub struct Base {
     #[reflect(hidden)]
     pub(crate) script_message_sender: Option<Sender<ScriptMessage>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) name: TemplateVariable<String>,
 
     pub(crate) local_transform: Transform,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     visibility: TemplateVariable<bool>,
 
@@ -327,33 +327,33 @@ pub struct Base {
     #[reflect(hidden)]
     pub(crate) lifetime: TemplateVariable<Option<f32>>,
 
-    #[inspect(min_value = 0.0, max_value = 1.0, step = 0.1, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, max_value = 1.0, step = 0.1, deref)]
     #[reflect(deref)]
     depth_offset: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     lod_group: TemplateVariable<Option<LodGroup>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     mobility: TemplateVariable<Mobility>,
 
     #[reflect(deref)]
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     tag: TemplateVariable<String>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     cast_shadows: TemplateVariable<bool>,
 
     /// A set of custom properties that can hold almost any data. It can be used to set additional
     /// properties to scene nodes.
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub properties: TemplateVariable<Vec<Property>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     frustum_culling: TemplateVariable<bool>,
 

--- a/src/scene/camera.rs
+++ b/src/scene/camera.rs
@@ -260,35 +260,35 @@ impl Default for Exposure {
 pub struct Camera {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     projection: TemplateVariable<Projection>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     viewport: TemplateVariable<Rect<f32>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     enabled: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(field = "as_ref()?.deref()", field_mut = "as_mut()?.deref_mut()")]
     sky_box: TemplateVariable<Option<Box<SkyBox>>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     environment: TemplateVariable<Option<Texture>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     exposure: TemplateVariable<Exposure>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     color_grading_lut: TemplateVariable<Option<ColorGradingLut>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     color_grading_enabled: TemplateVariable<bool>,
 

--- a/src/scene/collider.rs
+++ b/src/scene/collider.rs
@@ -475,39 +475,39 @@ impl ColliderShape {
 pub struct Collider {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) shape: TemplateVariable<ColliderShape>,
 
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     pub(crate) friction: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) density: TemplateVariable<Option<f32>>,
 
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     pub(crate) restitution: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) is_sensor: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) collision_groups: TemplateVariable<InteractionGroups>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) solver_groups: TemplateVariable<InteractionGroups>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) friction_combine_rule: TemplateVariable<CoefficientCombineRule>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) restitution_combine_rule: TemplateVariable<CoefficientCombineRule>,
 

--- a/src/scene/decal.rs
+++ b/src/scene/decal.rs
@@ -90,19 +90,19 @@ use std::ops::{Deref, DerefMut};
 pub struct Decal {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     diffuse_texture: TemplateVariable<Option<Texture>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     normal_texture: TemplateVariable<Option<Texture>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     color: TemplateVariable<Color>,
 
-    #[inspect(min_value = 0.0, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, deref)]
     #[reflect(deref)]
     layer: TemplateVariable<u8>,
 }

--- a/src/scene/dim2/collider.rs
+++ b/src/scene/dim2/collider.rs
@@ -245,39 +245,39 @@ impl ColliderShape {
 pub struct Collider {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) shape: TemplateVariable<ColliderShape>,
 
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     pub(crate) friction: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) density: TemplateVariable<Option<f32>>,
 
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     pub(crate) restitution: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) is_sensor: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) collision_groups: TemplateVariable<InteractionGroups>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) solver_groups: TemplateVariable<InteractionGroups>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) friction_combine_rule: TemplateVariable<CoefficientCombineRule>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) restitution_combine_rule: TemplateVariable<CoefficientCombineRule>,
 

--- a/src/scene/dim2/joint.rs
+++ b/src/scene/dim2/joint.rs
@@ -118,19 +118,19 @@ impl Default for JointParams {
 pub struct Joint {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) params: TemplateVariable<JointParams>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) body1: TemplateVariable<Handle<Node>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) body2: TemplateVariable<Handle<Node>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[visit(optional)] // Backward compatibility
     #[reflect(deref)]
     pub(crate) contacts_enabled: TemplateVariable<bool>,

--- a/src/scene/dim2/rectangle.rs
+++ b/src/scene/dim2/rectangle.rs
@@ -104,15 +104,15 @@ use std::ops::{Deref, DerefMut};
 pub struct Rectangle {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     texture: TemplateVariable<Option<Texture>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     color: TemplateVariable<Color>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     uv_rect: TemplateVariable<Rect<f32>>,
 }

--- a/src/scene/dim2/rigidbody.rs
+++ b/src/scene/dim2/rigidbody.rs
@@ -68,51 +68,51 @@ pub(crate) enum ApplyAction {
 pub struct RigidBody {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) lin_vel: TemplateVariable<Vector2<f32>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) ang_vel: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) lin_damping: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) ang_damping: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) body_type: TemplateVariable<RigidBodyType>,
 
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     pub(crate) mass: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) rotation_locked: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) translation_locked: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) ccd_enabled: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) can_sleep: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) dominance: TemplateVariable<i8>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) gravity_scale: TemplateVariable<f32>,
 

--- a/src/scene/joint.rs
+++ b/src/scene/joint.rs
@@ -170,19 +170,19 @@ impl Default for JointParams {
 pub struct Joint {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) params: TemplateVariable<JointParams>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) body1: TemplateVariable<Handle<Node>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) body2: TemplateVariable<Handle<Node>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     #[visit(optional)] // Backward compatibility
     pub(crate) contacts_enabled: TemplateVariable<bool>,

--- a/src/scene/light/directional.rs
+++ b/src/scene/light/directional.rs
@@ -109,7 +109,7 @@ impl CsmOptions {
 pub struct DirectionalLight {
     base_light: BaseLight,
     /// See [`CsmOptions`].
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub csm_options: TemplateVariable<CsmOptions>,
 }

--- a/src/scene/light/mod.rs
+++ b/src/scene/light/mod.rs
@@ -58,24 +58,24 @@ pub const DEFAULT_SCATTER_B: f32 = 0.03;
 pub struct BaseLight {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     color: TemplateVariable<Color>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     cast_shadows: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[visit(rename = "ScatterFactor")]
     #[reflect(deref)]
     scatter: TemplateVariable<Vector3<f32>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     scatter_enabled: TemplateVariable<bool>,
 
-    #[inspect(min_value = 0.0, step = 0.1, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.1, deref)]
     #[reflect(deref)]
     intensity: TemplateVariable<f32>,
 }

--- a/src/scene/light/point.rs
+++ b/src/scene/light/point.rs
@@ -45,11 +45,11 @@ use std::ops::{Deref, DerefMut};
 pub struct PointLight {
     base_light: BaseLight,
 
-    #[inspect(min_value = 0.0, step = 0.001, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.001, deref)]
     #[reflect(deref)]
     shadow_bias: TemplateVariable<f32>,
 
-    #[inspect(min_value = 0.0, step = 0.1, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.1, deref)]
     #[reflect(deref)]
     radius: TemplateVariable<f32>,
 }

--- a/src/scene/light/spot.rs
+++ b/src/scene/light/spot.rs
@@ -51,28 +51,23 @@ use std::ops::{Deref, DerefMut};
 pub struct SpotLight {
     base_light: BaseLight,
 
-    #[inspect(
-        min_value = 0.0,
-        max_value = 3.14159,
-        step = 0.1,
-        getter = "Deref::deref"
-    )]
+    #[inspect(min_value = 0.0, max_value = 3.14159, step = 0.1, deref)]
     #[reflect(deref)]
     hotspot_cone_angle: TemplateVariable<f32>,
 
-    #[inspect(min_value = 0.0, step = 0.1, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.1, deref)]
     #[reflect(deref)]
     falloff_angle_delta: TemplateVariable<f32>,
 
-    #[inspect(min_value = 0.0, step = 0.001, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.001, deref)]
     #[reflect(deref)]
     shadow_bias: TemplateVariable<f32>,
 
-    #[inspect(min_value = 0.0, step = 0.1, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.1, deref)]
     #[reflect(deref)]
     distance: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     cookie_texture: TemplateVariable<Option<Texture>>,
 }

--- a/src/scene/mesh/mod.rs
+++ b/src/scene/mesh/mod.rs
@@ -94,15 +94,15 @@ pub struct Mesh {
     #[visit(rename = "Common")]
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     surfaces: TemplateVariable<Vec<Surface>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     render_path: TemplateVariable<RenderPath>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     decal_layer_index: TemplateVariable<u8>,
 

--- a/src/scene/particle_system/mod.rs
+++ b/src/scene/particle_system/mod.rs
@@ -149,28 +149,28 @@ pub struct ParticleSystem {
     base: Base,
 
     /// List of emitters of the particle system.
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub emitters: TemplateVariable<Vec<Emitter>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     texture: TemplateVariable<Option<Texture>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     acceleration: TemplateVariable<Vector3<f32>>,
 
     #[visit(rename = "ColorGradient")]
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     color_over_lifetime: TemplateVariable<Option<ColorGradient>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     soft_boundary_sharpness_factor: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     enabled: TemplateVariable<bool>,
 

--- a/src/scene/rigidbody.rs
+++ b/src/scene/rigidbody.rs
@@ -144,59 +144,59 @@ pub(crate) enum ApplyAction {
 pub struct RigidBody {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) lin_vel: TemplateVariable<Vector3<f32>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) ang_vel: TemplateVariable<Vector3<f32>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) lin_damping: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) ang_damping: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) body_type: TemplateVariable<RigidBodyType>,
 
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     pub(crate) mass: TemplateVariable<f32>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) x_rotation_locked: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) y_rotation_locked: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) z_rotation_locked: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) translation_locked: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) ccd_enabled: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) can_sleep: TemplateVariable<bool>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) dominance: TemplateVariable<i8>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) gravity_scale: TemplateVariable<f32>,
 

--- a/src/scene/sound/effect.rs
+++ b/src/scene/sound/effect.rs
@@ -32,13 +32,13 @@ pub struct EffectInput {
 /// Base effect contains common properties for every effect (gain, inputs, etc.)
 #[derive(Visit, Inspect, Reflect, Debug)]
 pub struct BaseEffect {
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) name: TemplateVariable<String>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) gain: TemplateVariable<f32>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) inputs: TemplateVariable<Vec<EffectInput>>,
     #[visit(skip)]
@@ -191,16 +191,16 @@ impl BaseEffectBuilder {
 #[derive(Visit, Inspect, Reflect, Debug)]
 pub struct ReverbEffect {
     pub(crate) base: BaseEffect,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) dry: TemplateVariable<f32>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) wet: TemplateVariable<f32>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) fc: TemplateVariable<f32>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) decay_time: TemplateVariable<f32>,
 }

--- a/src/scene/sound/mod.rs
+++ b/src/scene/sound/mod.rs
@@ -51,40 +51,40 @@ pub mod listener;
 #[derive(Visit, Inspect, Reflect, Debug)]
 pub struct Sound {
     base: Base,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     buffer: TemplateVariable<Option<SoundBufferResource>>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     play_once: TemplateVariable<bool>,
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     gain: TemplateVariable<f32>,
-    #[inspect(min_value = -1.0, max_value = 1.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = -1.0, max_value = 1.0, step = 0.05, deref)]
     #[reflect(deref)]
     panning: TemplateVariable<f32>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     pub(crate) status: TemplateVariable<Status>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     looping: TemplateVariable<bool>,
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     pitch: TemplateVariable<f64>,
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     radius: TemplateVariable<f32>,
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     max_distance: TemplateVariable<f32>,
-    #[inspect(min_value = 0.0, step = 0.05, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.05, deref)]
     #[reflect(deref)]
     rolloff_factor: TemplateVariable<f32>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     playback_time: TemplateVariable<Duration>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     spatial_blend: TemplateVariable<f32>,
     #[inspect(skip)]

--- a/src/scene/sprite.rs
+++ b/src/scene/sprite.rs
@@ -67,16 +67,16 @@ use std::ops::{Deref, DerefMut};
 #[derive(Debug, Inspect, Reflect, Clone, Visit)]
 pub struct Sprite {
     base: Base,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     texture: TemplateVariable<Option<Texture>>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     color: TemplateVariable<Color>,
-    #[inspect(min_value = 0.0, step = 0.1, getter = "Deref::deref")]
+    #[inspect(min_value = 0.0, step = 0.1, deref)]
     #[reflect(deref)]
     size: TemplateVariable<f32>,
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     rotation: TemplateVariable<f32>,
 }

--- a/src/scene/terrain.rs
+++ b/src/scene/terrain.rs
@@ -259,11 +259,11 @@ pub struct TerrainRayCastResult {
 pub struct Terrain {
     base: Base,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     layers: TemplateVariable<Vec<Layer>>,
 
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     decal_layer_index: TemplateVariable<u8>,
 

--- a/src/scene/transform.rs
+++ b/src/scene/transform.rs
@@ -73,7 +73,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Local scale of the transform",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     local_scale: TemplateVariable<Vector3<f32>>,
@@ -81,7 +81,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Local position of the transform",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     local_position: TemplateVariable<Vector3<f32>>,
@@ -89,7 +89,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Local rotation of the transform",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     local_rotation: TemplateVariable<UnitQuaternion<f32>>,
@@ -97,7 +97,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Pre rotation of the transform. Applied before local rotation.",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     pre_rotation: TemplateVariable<UnitQuaternion<f32>>,
@@ -105,7 +105,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Post rotation of the transform. Applied after local rotation.",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     post_rotation: TemplateVariable<UnitQuaternion<f32>>,
@@ -113,7 +113,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Rotation offset of the transform.",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     rotation_offset: TemplateVariable<Vector3<f32>>,
@@ -121,7 +121,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Rotation pivot of the transform.",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     rotation_pivot: TemplateVariable<Vector3<f32>>,
@@ -129,7 +129,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Scale offset of the transform.",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     scaling_offset: TemplateVariable<Vector3<f32>>,
@@ -137,7 +137,7 @@ pub struct Transform {
     #[inspect(
         deref,
         description = "Scale pivot of the transform.",
-        is_modified = "is_modified"
+        is_modified = "is_modified()"
     )]
     #[reflect(deref)]
     scaling_pivot: TemplateVariable<Vector3<f32>>,

--- a/src/scene/transform.rs
+++ b/src/scene/transform.rs
@@ -71,7 +71,7 @@ pub struct Transform {
     dirty: Cell<bool>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Local scale of the transform",
         is_modified = "is_modified"
     )]
@@ -79,7 +79,7 @@ pub struct Transform {
     local_scale: TemplateVariable<Vector3<f32>>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Local position of the transform",
         is_modified = "is_modified"
     )]
@@ -87,7 +87,7 @@ pub struct Transform {
     local_position: TemplateVariable<Vector3<f32>>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Local rotation of the transform",
         is_modified = "is_modified"
     )]
@@ -95,7 +95,7 @@ pub struct Transform {
     local_rotation: TemplateVariable<UnitQuaternion<f32>>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Pre rotation of the transform. Applied before local rotation.",
         is_modified = "is_modified"
     )]
@@ -103,7 +103,7 @@ pub struct Transform {
     pre_rotation: TemplateVariable<UnitQuaternion<f32>>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Post rotation of the transform. Applied after local rotation.",
         is_modified = "is_modified"
     )]
@@ -111,7 +111,7 @@ pub struct Transform {
     post_rotation: TemplateVariable<UnitQuaternion<f32>>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Rotation offset of the transform.",
         is_modified = "is_modified"
     )]
@@ -119,7 +119,7 @@ pub struct Transform {
     rotation_offset: TemplateVariable<Vector3<f32>>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Rotation pivot of the transform.",
         is_modified = "is_modified"
     )]
@@ -127,7 +127,7 @@ pub struct Transform {
     rotation_pivot: TemplateVariable<Vector3<f32>>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Scale offset of the transform.",
         is_modified = "is_modified"
     )]
@@ -135,7 +135,7 @@ pub struct Transform {
     scaling_offset: TemplateVariable<Vector3<f32>>,
 
     #[inspect(
-        getter = "Deref::deref",
+        deref,
         description = "Scale pivot of the transform.",
         is_modified = "is_modified"
     )]


### PR DESCRIPTION
This PR results in lots of:

```diff
-    #[inspect(getter = "Deref::deref")]
+    #[inspect(deref)]
     #[reflect(deref)]
     visibility: TemplateVariable<bool>,
```

Changes:

- Add `#[inspect(deref)]`, a shorthand for `#[inspect(getter = "deref()")]`
- `#[inspect(getter = ..)]` now accepts method call syntax, not path
- `#[inspect(is_modified = ..)]` now accepts method call syntax, not path
