### PR TITLE
Add `Reflect::set_field`

### DIFF
--- a/fyrox-core-derive/src/reflect/args.rs
+++ b/fyrox-core-derive/src/reflect/args.rs
@@ -14,7 +14,7 @@ pub struct TypeArgs {
     pub generics: Generics,
     pub data: ast::Data<VariantArgs, FieldArgs>,
 
-    /// Hides all fields
+    /// Hides all fields and creates an empty impl
     #[darling(default)]
     pub hide_all: bool,
 
@@ -112,17 +112,26 @@ pub struct FieldArgs {
     #[darling(default)]
     pub deref: bool,
 
-    /// `#[reflect(field = <method call>)]
+    /// `#[reflect(field = "<method call>")]
     ///
-    /// Implement `Reflect` by delegating the impl to an internal field
+    /// Implement `Reflect::field` with the method call
     #[darling(default)]
     pub field: Option<Expr>,
 
-    /// `#[reflect(field_mut = <method call>)]
+    /// `#[reflect(field_mut = "<method call>")]
     ///
-    /// Implement `Reflect` by delegating the impl to an internal field
+    /// Implement `Reflect::field_mut` with the method call
     #[darling(default)]
     pub field_mut: Option<Expr>,
+
+    /// `#[reflect(setter = "<method name>")]
+    ///
+    /// **STRUCT-ONLY (for now)**
+    ///
+    /// Setter method name used in `Reflect::set_field`.
+    /// Expected signature: `fn(&mut self, value: T)`
+    #[darling(default)]
+    pub setter: Option<Path>,
 }
 
 impl FieldArgs {

--- a/fyrox-core-derive/src/reflect/prop.rs
+++ b/fyrox-core-derive/src/reflect/prop.rs
@@ -97,25 +97,23 @@ pub fn struct_prop<'a>(
     }
 }
 
-pub fn props(ty_args: &args::TypeArgs) -> Vec<Property<'_>> {
+pub fn props(ty_args: &args::TypeArgs) -> Box<dyn Iterator<Item = Property<'_>> + '_> {
     match &ty_args.data {
-        ast::Data::Struct(field_args) => field_args
-            .fields
-            .iter()
-            .enumerate()
-            .filter(|(_, f)| !f.hidden)
-            .map(|(nth, field)| self::struct_prop(ty_args, nth, field))
-            .collect::<Vec<_>>(),
-        ast::Data::Enum(variants) => variants
-            .iter()
-            .flat_map(|v| {
-                v.fields
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, f)| !f.hidden)
-                    .map(|(nth, field)| self::enum_prop(v, nth, field))
-            })
-            .collect::<Vec<_>>(),
+        ast::Data::Struct(field_args) => Box::new(
+            field_args
+                .fields
+                .iter()
+                .enumerate()
+                .filter(|(_, f)| !f.hidden)
+                .map(|(nth, field)| self::struct_prop(ty_args, nth, field)),
+        ),
+        ast::Data::Enum(variants) => Box::new(variants.iter().flat_map(|v| {
+            v.fields
+                .iter()
+                .enumerate()
+                .filter(|(_, f)| !f.hidden)
+                .map(|(nth, field)| self::enum_prop(v, nth, field))
+        })),
     }
 }
 

--- a/fyrox-core-derive/tests/it/reflect.rs
+++ b/fyrox-core-derive/tests/it/reflect.rs
@@ -218,9 +218,11 @@ fn reflect_custom_setter() {
     };
 
     let value = 10.0f32;
-    assert!(wrapper.set_field(Wrapper::<()>::VALUE, Box::new(value)).is_ok());
+    assert!(wrapper
+        .set_field(Wrapper::<()>::VALUE, Box::new(value))
+        .is_ok());
     assert!(wrapper.is_dirty);
 
-    // raw field access is allowed, but should be forbidden
-    assert!(wrapper.field_mut(Wrapper::<()>::VALUE).is_some())
+    // raw field access to the `#[reflect(setter = ..)]` field is forbidden
+    assert!(wrapper.field_mut(Wrapper::<()>::VALUE).is_none());
 }

--- a/fyrox-core-derive/tests/it/reflect.rs
+++ b/fyrox-core-derive/tests/it/reflect.rs
@@ -12,11 +12,9 @@ pub struct Struct {
     hidden: usize,
 }
 
-#[allow(dead_code)]
 #[derive(Reflect)]
 pub struct Tuple(usize, usize);
 
-#[allow(dead_code)]
 #[derive(Reflect)]
 pub enum Enum {
     Named { field: usize },
@@ -196,4 +194,33 @@ fn reflect_list_path() {
     };
 
     assert_eq!(a.get_resolve_path("xs[0].data[1]"), Ok(&1usize));
+}
+
+#[test]
+fn reflect_custom_setter() {
+    #[derive(Reflect)]
+    pub struct Wrapper<T> {
+        #[reflect(setter = "set_value")]
+        value: T,
+        is_dirty: bool,
+    }
+
+    impl<T> Wrapper<T> {
+        pub fn set_value(&mut self, value: T) {
+            self.value = value;
+            self.is_dirty = true;
+        }
+    }
+
+    let mut wrapper = Wrapper {
+        value: 0.0f32,
+        is_dirty: false,
+    };
+
+    let value = 10.0f32;
+    assert!(wrapper.set_field(Wrapper::<()>::VALUE, Box::new(value)).is_ok());
+    assert!(wrapper.is_dirty);
+
+    // raw field access is allowed, but should be forbidden
+    assert!(wrapper.field_mut(Wrapper::<()>::VALUE).is_some())
 }

--- a/fyrox-core/src/reflect.rs
+++ b/fyrox-core/src/reflect.rs
@@ -38,11 +38,7 @@ pub trait Reflect: Any {
 
     /// Calls user method specified with `#[reflect(setter = ..)]` or falls back to
     /// [`Reflect::field_mut`]
-    fn set_field(
-        &mut self,
-        field: &str,
-        value: Box<dyn Reflect>,
-    ) -> Result<(), Box<dyn Reflect>> {
+    fn set_field(&mut self, field: &str, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         let field = match self.field_mut(field) {
             Some(f) => f,
             None => return Err(value),

--- a/fyrox-core/src/reflect.rs
+++ b/fyrox-core/src/reflect.rs
@@ -36,6 +36,22 @@ pub trait Reflect: Any {
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>>;
 
+    /// Calls user method specified with `#[reflect(setter = ..)]` or falls back to
+    /// [`Reflect::field_mut`]
+    fn set_field(
+        &mut self,
+        field: &str,
+        value: Box<dyn Reflect>,
+    ) -> Result<(), Box<dyn Reflect>> {
+        let field = match self.field_mut(field) {
+            Some(f) => f,
+            None => return Err(value),
+        };
+
+        field.set(value)?;
+        Ok(())
+    }
+
     fn field(&self, _name: &str) -> Option<&dyn Reflect> {
         None
     }


### PR DESCRIPTION
# About

Direct change of fields can break invariant. For example, dirty flag is not synced.

This PR adds `Reflect::set_field` method to perform legal value updates.
User can specify value update method with `#[reflect(setter = ..)]` attribute.

# Considerations before merge

Currently `Reflect::set_field` does not return `Box<dyn Reflect>`.
We might have to add `NodeTrait: Default` boundary to support reflect editor commands.

```rust
pub trait Reflect {
    fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>>;

    fn set_field(&mut self, field: &str, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
        /* ~~~~ */
    }

    // ~~~~
}
```

# Example

New test from `fyrox_core_derive/tests/it/reflect.rs`:

```rust
#[test]
fn reflect_custom_setter() {
    #[derive(Reflect)]
    pub struct Wrapper<T> {
        #[reflect(setter = "set_value")]
        value: T,
        is_dirty: bool,
    }

    impl<T> Wrapper<T> {
        pub fn set_value(&mut self, value: T) {
            self.value = value;
            self.is_dirty = true;
        }
    }

    let mut wrapper = Wrapper {
        value: 0.0f32,
        is_dirty: false,
    };

    let value = 10.0f32;
    assert!(wrapper.set_field(Wrapper::<()>::VALUE, Box::new(value)).is_ok());
    assert!(wrapper.is_dirty);

    // raw field access to the `#[reflect(setter = ..)]` field is forbidden
    assert!(wrapper.field_mut(Wrapper::<()>::VALUE).is_none());
}
```

`Reflect::set_field` expanded:

```Rust
fn set_field(&mut self, name: &str, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
    match name {
        "value" => {
            if let Ok(value) = value.take() {
                self.set_value(value);
            }
        }
        _ => {
            self.set(value)?;
        }
    }
    Ok(())
}
```