### PR TITLE
Add `#[derive(Inherit)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ opt-level = 3
 debug = true
 
 [dependencies]
+fyrox-core-derive = { path = "fyrox-core-derive", version = "0.16.0" }
 fyrox-core = { path = "fyrox-core", version = "0.21.0", features = ["serde"] }
 fyrox-sound = { path = "fyrox-sound", version = "0.28.0" }
 fyrox-ui = { path = "fyrox-ui", version = "0.18.0" }

--- a/fyrox-core-derive/Cargo.toml
+++ b/fyrox-core-derive/Cargo.toml
@@ -24,4 +24,5 @@ fxhash = "0.2.1"
 
 [dev-dependencies]
 fyrox-core = { path = "../fyrox-core" }
+fyrox = { path = "../" }
 futures = "0.3.16"

--- a/fyrox-core-derive/src/inherit.rs
+++ b/fyrox-core-derive/src/inherit.rs
@@ -3,8 +3,8 @@
 // not using `darling` (right now)
 
 use proc_macro2::TokenStream as TokenStream2;
+use quote::*;
 use syn::*;
-use quote::quote;
 
 pub fn impl_inherit(ast: DeriveInput) -> TokenStream2 {
     match &ast.data {
@@ -19,32 +19,38 @@ fn impl_struct(ast: &DeriveInput, s: &DataStruct) -> TokenStream2 {
         _ => todo!(),
     };
 
-    let fields = fields.named.iter().filter_map(|f| {
-        // find `Meta:Path` of `#[inherit]`
-        f.attrs.iter().find_map(|a| {
-            let meta = match a.parse_meta() {
-                Ok(meta) => meta,
-                Err(_) => return None,
-            };
+    let fields = fields
+        .named
+        .iter()
+        .filter_map(|f| {
+            // find `Meta:Path` of `#[inherit]`
+            f.attrs.iter().find_map(|a| {
+                let meta = match a.parse_meta() {
+                    Ok(meta) => meta,
+                    Err(_) => return None,
+                };
 
-            let path = match meta {
-                Meta::Path(p) => p,
-                _ => return None,
-            };
+                let path = match meta {
+                    Meta::Path(p) => p,
+                    _ => return None,
+                };
 
-            let segment = path.segments.first().unwrap();
-            if segment.ident == "inherit" {
-                Some(f)
-            } else {
-                None
-            }
+                let segment = path.segments.first().unwrap();
+                if segment.ident == "inherit" {
+                    Some(f)
+                } else {
+                    None
+                }
+            })
         })
-    });
+        .collect::<Vec<_>>();
 
-    let field_idents = fields.map(|f| &f.ident).collect::<Vec<_>>();
+    let field_idents = fields.iter().map(|f| &f.ident).collect::<Vec<_>>();
 
     let ty_ident = &ast.ident;
-    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let generics = self::impl_generics(ast, &fields);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
         impl #impl_generics DirectlyInheritableEntity for #ty_ident #ty_generics #where_clause {
@@ -61,4 +67,18 @@ fn impl_struct(ast: &DeriveInput, s: &DataStruct) -> TokenStream2 {
             }
         }
     }
+}
+
+fn impl_generics(ast: &DeriveInput, fields: &[&Field]) -> Generics {
+    let mut generics = ast.generics.clone();
+
+    // Add where clause for every inherited field
+    generics.make_where_clause().predicates.extend(
+        fields
+            .iter()
+            .map(|f| &f.ty)
+            .map::<WherePredicate, _>(|ty| parse_quote! { #ty: InheritableVariable }),
+    );
+
+    generics
 }

--- a/fyrox-core-derive/src/inherit.rs
+++ b/fyrox-core-derive/src/inherit.rs
@@ -1,0 +1,64 @@
+//! Implements `DirectlyInheritableEntity` trait
+
+// not using `darling` (right now)
+
+use proc_macro2::TokenStream as TokenStream2;
+use syn::*;
+use quote::quote;
+
+pub fn impl_inherit(ast: DeriveInput) -> TokenStream2 {
+    match &ast.data {
+        Data::Struct(ref s) => self::impl_struct(&ast, s),
+        _ => todo!(),
+    }
+}
+
+fn impl_struct(ast: &DeriveInput, s: &DataStruct) -> TokenStream2 {
+    let fields = match &s.fields {
+        Fields::Named(xs) => xs,
+        _ => todo!(),
+    };
+
+    let fields = fields.named.iter().filter_map(|f| {
+        // find `Meta:Path` of `#[inherit]`
+        f.attrs.iter().find_map(|a| {
+            let meta = match a.parse_meta() {
+                Ok(meta) => meta,
+                Err(_) => return None,
+            };
+
+            let path = match meta {
+                Meta::Path(p) => p,
+                _ => return None,
+            };
+
+            let segment = path.segments.first().unwrap();
+            if segment.ident == "inherit" {
+                Some(f)
+            } else {
+                None
+            }
+        })
+    });
+
+    let field_idents = fields.map(|f| &f.ident).collect::<Vec<_>>();
+
+    let ty_ident = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics DirectlyInheritableEntity for #ty_ident #ty_generics #where_clause {
+            fn inheritable_properties_ref(&self) -> Vec<&dyn InheritableVariable> {
+                vec![
+                    #( &self.#field_idents, )*
+                ]
+            }
+
+            fn inheritable_properties_mut(&mut self) -> Vec<&mut dyn InheritableVariable> {
+                vec![
+                    #( &mut self.#field_idents, )*
+                ]
+            }
+        }
+    }
+}

--- a/fyrox-core-derive/src/lib.rs
+++ b/fyrox-core-derive/src/lib.rs
@@ -1,3 +1,4 @@
+mod inherit;
 mod inspect;
 mod reflect;
 mod visit;
@@ -61,4 +62,12 @@ pub fn impl_reflect(input: TokenStream) -> TokenStream {
     let reflect_impl = reflect::impl_reflect(&ty_args);
 
     TokenStream::from(reflect_impl)
+}
+
+/// Implements `DirectlyInheritableEntity` trait
+// The trait is not in `fyrox_core` though
+#[proc_macro_derive(Inherit, attributes(inherit))]
+pub fn inherit(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(inherit::impl_inherit(ast))
 }

--- a/fyrox-core-derive/tests/it/inherit.rs
+++ b/fyrox-core-derive/tests/it/inherit.rs
@@ -1,0 +1,63 @@
+use fyrox::{
+    core::{
+        algebra::{UnitQuaternion, Vector3},
+        reflect::Reflect,
+        variable::{InheritableVariable, TemplateVariable},
+    },
+    scene::{DirectlyInheritableEntity, Inherit},
+};
+
+fn as_dyn(x: &impl InheritableVariable) -> &dyn InheritableVariable {
+    x
+}
+
+fn as_dyn_mut(x: &mut impl InheritableVariable) -> &mut dyn InheritableVariable {
+    x
+}
+
+fn test<'a, 'b>(
+    xs: impl IntoIterator<Item = &'a dyn InheritableVariable>,
+    ys: impl IntoIterator<Item = &'b dyn InheritableVariable>,
+) {
+    assert_eq!(
+        xs.into_iter().map(|x| x.as_any().type_id()).collect::<Vec<_>>(),
+        ys.into_iter().map(|y| y.as_any().type_id()).collect::<Vec<_>>(),
+    );
+}
+
+fn test_mut<'a, 'b>(
+    xs: impl IntoIterator<Item = &'a mut dyn InheritableVariable>,
+    ys: impl IntoIterator<Item = &'b mut dyn InheritableVariable>,
+) {
+    assert_eq!(
+        xs.into_iter().map(|x| x.as_any().type_id()).collect::<Vec<_>>(),
+        ys.into_iter().map(|y| y.as_any().type_id()).collect::<Vec<_>>(),
+    );
+}
+
+#[derive(Default, Clone, Reflect, Inherit)]
+struct Foo {
+    #[inherit]
+    #[reflect(hidden)]
+    inheritable_field: TemplateVariable<Vector3<f32>>,
+    other_field: String,
+    #[inherit]
+    #[reflect(hidden)]
+    x: TemplateVariable<UnitQuaternion<f32>>,
+}
+
+#[test]
+fn test_inherit() {
+    let mut foo1 = Foo::default();
+    let mut foo2 = Foo::default();
+
+    test(
+        foo1.inheritable_properties_ref(),
+        [as_dyn(&foo2.inheritable_field), as_dyn(&foo2.x)],
+    );
+
+    test_mut(
+        foo1.inheritable_properties_mut(),
+        [as_dyn_mut(&mut foo2.inheritable_field), as_dyn_mut(&mut foo2.x)],
+    );
+}

--- a/fyrox-core-derive/tests/it/inherit.rs
+++ b/fyrox-core-derive/tests/it/inherit.rs
@@ -20,8 +20,12 @@ fn test<'a, 'b>(
     ys: impl IntoIterator<Item = &'b dyn InheritableVariable>,
 ) {
     assert_eq!(
-        xs.into_iter().map(|x| x.as_any().type_id()).collect::<Vec<_>>(),
-        ys.into_iter().map(|y| y.as_any().type_id()).collect::<Vec<_>>(),
+        xs.into_iter()
+            .map(|x| x.as_any().type_id())
+            .collect::<Vec<_>>(),
+        ys.into_iter()
+            .map(|y| y.as_any().type_id())
+            .collect::<Vec<_>>(),
     );
 }
 
@@ -30,8 +34,12 @@ fn test_mut<'a, 'b>(
     ys: impl IntoIterator<Item = &'b mut dyn InheritableVariable>,
 ) {
     assert_eq!(
-        xs.into_iter().map(|x| x.as_any().type_id()).collect::<Vec<_>>(),
-        ys.into_iter().map(|y| y.as_any().type_id()).collect::<Vec<_>>(),
+        xs.into_iter()
+            .map(|x| x.as_any().type_id())
+            .collect::<Vec<_>>(),
+        ys.into_iter()
+            .map(|y| y.as_any().type_id())
+            .collect::<Vec<_>>(),
     );
 }
 
@@ -58,6 +66,23 @@ fn test_inherit() {
 
     test_mut(
         foo1.inheritable_properties_mut(),
-        [as_dyn_mut(&mut foo2.inheritable_field), as_dyn_mut(&mut foo2.x)],
+        [
+            as_dyn_mut(&mut foo2.inheritable_field),
+            as_dyn_mut(&mut foo2.x),
+        ],
     );
+}
+
+#[derive(Default, Clone, Reflect, Inherit)]
+struct Generic<T> {
+    #[inherit]
+    #[reflect(hidden)]
+    f: T,
+}
+
+#[test]
+fn test_inherit_for_generic_type() {
+    let mut gen = Generic::<TemplateVariable<Vector3<f32>>>::default();
+    assert_eq!(gen.inheritable_properties_ref().len(), 1);
+    assert_eq!(gen.inheritable_properties_mut().len(), 1);
 }

--- a/fyrox-core-derive/tests/it/main.rs
+++ b/fyrox-core-derive/tests/it/main.rs
@@ -3,10 +3,9 @@
 //! c.f. https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
 
 // #![feature(trace_macros)]
-
-pub mod visit;
-
 // trace_macros!(true);
-pub mod inspect;
 
+pub mod inherit;
+pub mod inspect;
 pub mod reflect;
+pub mod visit;

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -69,6 +69,8 @@ use std::{
     time::Duration,
 };
 
+pub use fyrox_core_derive::Inherit;
+
 /// A trait for object that has any TemplateVariable and should support property inheritance.
 pub trait DirectlyInheritableEntity: Reflect {
     /// Returns a list of references to inheritable variables of an entity.


### PR DESCRIPTION
Closes #354.

- Currently `#[derive(Inherit)]` is only supported for `StructWith { named: Field }`.
- Generics are also considered.
- Adding support for tuple structs and enums are not much hard. Call me when needed!
