### PR TITLE
Remove `?` operators from proc-macro generated code

### DIFF
--- a/fyrox-core-derive/src/reflect.rs
+++ b/fyrox-core-derive/src/reflect.rs
@@ -300,7 +300,11 @@ fn gen_impl(
             }
 
             fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-                let this = std::mem::replace(self, value.take()?);
+                let value = match value.take() {
+                    Ok(x) => x,
+                    Err(err) => return Err(err),
+                };
+                let this = std::mem::replace(self, value);
                 Ok(Box::new(this))
             }
 

--- a/fyrox-core-derive/src/visit/utils.rs
+++ b/fyrox-core-derive/src/visit/utils.rs
@@ -18,6 +18,7 @@ pub fn create_impl(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
+        #[allow(clippy::question_mark)]
         impl #impl_generics Visit for #ty_ident #ty_generics #where_clause {
             fn visit(
                 &mut self,

--- a/fyrox-core-derive/src/visit/utils.rs
+++ b/fyrox-core-derive/src/visit/utils.rs
@@ -47,15 +47,15 @@ fn create_impl_generics(
     generics
 }
 
-/// `<prefix>field.visit("name", visitor);`
+/// `<prefix>field.visit("name", visitor)?;`
 pub fn create_field_visits<'a>(
-    // None or `f` when bindings tuple variants. NOTE: We can't use `prefix: Ident`
-    prefix: Option<Ident>,
+    // false if enum variant
+    is_struct: bool,
     fields: impl Iterator<Item = &'a args::FieldArgs>,
     field_style: ast::Style,
 ) -> Vec<TokenStream2> {
     if field_style == ast::Style::Unit {
-        // `Unit` (struct/enum variant) has no field to visit.
+        // `Unit` struct/enum variant has no field to visit.
         // We won't even enter this region:
         return vec![];
     }
@@ -76,14 +76,14 @@ pub fn create_field_visits<'a>(
                 }
                 // `Tuple(f32, ..)`
                 ast::Style::Tuple => {
-                    let ident = Index::from(field_index);
-
-                    let ident = match prefix {
-                        Some(ref prefix) => {
-                            let ident = format_ident!("{}{}", prefix, ident);
-                            quote!(#ident)
-                        }
-                        None => quote!(#ident),
+                    let index = Index::from(field_index);
+                    let ident = if is_struct {
+                        // accessed with `self.<index>`
+                        quote!(#index)
+                    } else {
+                        // named as `f<index>`
+                        let ident = format_ident!("f{}", index);
+                        quote!(#ident)
                     };
 
                     (ident, format!("{}", field_index))
@@ -114,16 +114,20 @@ pub fn create_field_visits<'a>(
         }
     }
 
+    let prefix = if is_struct { Some(quote!(self.)) } else { None };
+
     visit_args
         .iter()
         .map(|(ident, name, optional)| {
             if *optional {
                 quote! {
-                    #ident.visit(#name, &mut region).ok();
+                    #prefix #ident.visit(#name, &mut region).ok();
                 }
             } else {
                 quote! {
-                    #ident.visit(#name, &mut region)?;
+                    if let Err(err) = #prefix #ident.visit(#name, &mut region) {
+                        return Err(err);
+                    }
                 }
             }
         })


### PR DESCRIPTION
This is an internal clean up PR. Hopefully it can also improve the compile time a bit.

From Twitter:

- [MiniJinja author said](https://twitter.com/mitsuhiko/status/1574111459361132549) avoiding `?` improved both the compile time and the runtime performances.
- [dtolnay said](https://twitter.com/davidtolnay/status/1574266317762224128) they don't use `?` operators in `serde` and `serde-json` "because it is too slow".
- [serde has their own `try!` macro](https://github.com/serde-rs/serde/blob/master/serde_derive/src/try.rs) that avoids type conversion
- [Relevant issue on the rust repo](https://github.com/rust-lang/rust/issues/37939)
