### PR TITLE
fix extra double quote

### DIFF
--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -268,7 +268,7 @@ fn init_workspace(base_path: &Path) {
         base_path.join("Cargo.toml"),
         r#"
 [workspace]
-members = ["editor", "executor", "game"]"
+members = ["editor", "executor", "game"]
 
 # Optimize the engine in debug builds, but leave project's code non-optimized.
 # By using this technique, you can still debug you code, but engine will be fully


### PR DESCRIPTION
Note: I made this change through githubs own UI so... no checks at all from my side. I just noticed that the Cargo.toml file that got generated had one too many double quotes and decided to find and purge the extra one.