### PR TITLE
Add support for Collider intersection check

### DIFF
--- a/src/scene/collider.rs
+++ b/src/scene/collider.rs
@@ -928,12 +928,14 @@ impl ColliderBuilder {
 
 #[cfg(test)]
 mod test {
-    use crate::core::reflect::Reflect;
+    use crate::core::{algebra::Vector2, reflect::Reflect};
     use crate::scene::collider::BitMask;
     use crate::scene::{
         base::{test::check_inheritable_properties_equality, BaseBuilder},
         collider::{Collider, ColliderBuilder, ColliderShape, InteractionGroups},
         graph::physics::CoefficientCombineRule,
+        graph::Graph,
+        rigidbody::{RigidBodyBuilder, RigidBodyType},
     };
     use fyrox_core::variable::try_inherit_properties;
 
@@ -959,5 +961,67 @@ mod test {
 
         check_inheritable_properties_equality(&child.base, &parent.base);
         check_inheritable_properties_equality(&child, parent);
+    }
+
+    #[test]
+    fn test_collider_intersect() {
+        let mut graph = Graph::new();
+
+        let mut create_rigid_body = |is_sensor| {
+            let cube_half_size = 0.5;
+            let collider_sensor = ColliderBuilder::new(BaseBuilder::new())
+                .with_shape(ColliderShape::cuboid(
+                    cube_half_size,
+                    cube_half_size,
+                    cube_half_size,
+                ))
+                .with_sensor(is_sensor)
+                .build(&mut graph);
+
+            RigidBodyBuilder::new(BaseBuilder::new().with_children(&[collider_sensor]))
+                .with_body_type(RigidBodyType::Static)
+                .build(&mut graph);
+
+            collider_sensor
+        };
+
+        let collider_sensor = create_rigid_body(true);
+        let collider_non_sensor = create_rigid_body(false);
+
+        // need to call two times for the physics engine to execute
+        graph.update(Vector2::new(800.0, 600.0), 1.0);
+        graph.update(Vector2::new(800.0, 600.0), 1.0);
+
+        // we don't expect contact between regular body and sensor
+        assert_eq!(
+            0,
+            graph[collider_sensor]
+                .as_collider()
+                .contacts(&graph.physics)
+                .count()
+        );
+        assert_eq!(
+            0,
+            graph[collider_non_sensor]
+                .as_collider()
+                .contacts(&graph.physics)
+                .count()
+        );
+
+        // we expect intersection between regular body and sensor
+        assert_eq!(
+            1,
+            graph[collider_sensor]
+                .as_collider()
+                .intersects(&graph.physics)
+                .count()
+        );
+        assert_eq!(
+            1,
+            graph[collider_non_sensor]
+                .as_collider()
+                .intersects(&graph.physics)
+                .count()
+        );
     }
 }

--- a/src/scene/collider.rs
+++ b/src/scene/collider.rs
@@ -17,7 +17,7 @@ use crate::{
     scene::{
         base::{Base, BaseBuilder},
         graph::{
-            physics::{CoefficientCombineRule, ContactPair, PhysicsWorld},
+            physics::{CoefficientCombineRule, ContactPair, IntersectionPair, PhysicsWorld},
             Graph,
         },
         node::{Node, NodeTrait, SyncContext, TypeUuidProvider},
@@ -730,11 +730,21 @@ impl Collider {
     }
 
     /// Returns an iterator that yields contact information for the collider.
+    /// Contacts checks between two regular colliders
     pub fn contacts<'a>(
         &self,
         physics: &'a PhysicsWorld,
     ) -> impl Iterator<Item = ContactPair> + 'a {
         physics.contacts_with(self.native.get())
+    }
+
+    /// Returns an iterator that yields intersection information for the collider.
+    /// Intersections checks between regular colliders and sensor colliders
+    pub fn intersects<'a>(
+        &self,
+        physics: &'a PhysicsWorld,
+    ) -> impl Iterator<Item = IntersectionPair> + 'a {
+        physics.intersections_with(self.native.get())
     }
 
     pub(crate) fn needs_sync_model(&self) -> bool {

--- a/src/scene/dim2/collider.rs
+++ b/src/scene/dim2/collider.rs
@@ -17,7 +17,7 @@ use crate::{
         base::{Base, BaseBuilder},
         collider::InteractionGroups,
         dim2::{
-            physics::{ContactPair, PhysicsWorld},
+            physics::{ContactPair, IntersectionPair, PhysicsWorld},
             rigidbody::RigidBody,
         },
         graph::{physics::CoefficientCombineRule, Graph},
@@ -506,11 +506,21 @@ impl Collider {
     }
 
     /// Returns an iterator that yields contact information for the collider.
+    /// Contacts checks between two regular colliders
     pub fn contacts<'a>(
         &self,
         physics: &'a PhysicsWorld,
     ) -> impl Iterator<Item = ContactPair> + 'a {
         physics.contacts_with(self.native.get())
+    }
+
+    /// Returns an iterator that yields intersection information for the collider.
+    /// Intersections checks between regular colliders and sensor colliders
+    pub fn intersects<'a>(
+        &self,
+        physics: &'a PhysicsWorld,
+    ) -> impl Iterator<Item = IntersectionPair> + 'a {
+        physics.intersections_with(self.native.get())
     }
 
     pub(crate) fn needs_sync_model(&self) -> bool {

--- a/src/scene/dim2/collider.rs
+++ b/src/scene/dim2/collider.rs
@@ -705,13 +705,18 @@ impl ColliderBuilder {
 #[cfg(test)]
 mod test {
 
-    use crate::core::reflect::Reflect;
     use crate::core::variable::try_inherit_properties;
+    use crate::core::{algebra::Vector2, reflect::Reflect};
     use crate::scene::collider::BitMask;
     use crate::scene::{
         base::{test::check_inheritable_properties_equality, BaseBuilder},
-        dim2::collider::{Collider, ColliderBuilder, ColliderShape, InteractionGroups},
+        dim2::{
+            collider::{Collider, ColliderBuilder, ColliderShape, InteractionGroups},
+            rigidbody::RigidBodyBuilder,
+        },
         graph::physics::CoefficientCombineRule,
+        graph::Graph,
+        rigidbody::RigidBodyType,
     };
 
     #[test]
@@ -736,5 +741,63 @@ mod test {
 
         check_inheritable_properties_equality(&child.base, &parent.base);
         check_inheritable_properties_equality(&child, parent);
+    }
+
+    #[test]
+    fn test_collider_2d_intersect() {
+        let mut graph = Graph::new();
+
+        let mut create_rigid_body = |is_sensor| {
+            let cube_half_size = 0.5;
+            let collider_sensor = ColliderBuilder::new(BaseBuilder::new())
+                .with_shape(ColliderShape::cuboid(cube_half_size, cube_half_size))
+                .with_sensor(is_sensor)
+                .build(&mut graph);
+
+            RigidBodyBuilder::new(BaseBuilder::new().with_children(&[collider_sensor]))
+                .with_body_type(RigidBodyType::Static)
+                .build(&mut graph);
+
+            collider_sensor
+        };
+
+        let collider_sensor = create_rigid_body(true);
+        let collider_non_sensor = create_rigid_body(false);
+
+        // need to call two times for the physics engine to execute
+        graph.update(Vector2::new(800.0, 600.0), 1.0);
+        graph.update(Vector2::new(800.0, 600.0), 1.0);
+
+        // we don't expect contact between regular body and sensor
+        assert_eq!(
+            0,
+            graph[collider_sensor]
+                .as_collider2d()
+                .contacts(&graph.physics2d)
+                .count()
+        );
+        assert_eq!(
+            0,
+            graph[collider_non_sensor]
+                .as_collider2d()
+                .contacts(&graph.physics2d)
+                .count()
+        );
+
+        // we expect intersection between regular body and sensor
+        assert_eq!(
+            1,
+            graph[collider_sensor]
+                .as_collider2d()
+                .intersects(&graph.physics2d)
+                .count()
+        );
+        assert_eq!(
+            1,
+            graph[collider_non_sensor]
+                .as_collider2d()
+                .intersects(&graph.physics2d)
+                .count()
+        );
     }
 }

--- a/src/scene/dim2/physics.rs
+++ b/src/scene/dim2/physics.rs
@@ -988,6 +988,31 @@ impl PhysicsWorld {
         }
     }
 
+    /// Intersections checks between regular colliders and sensor colliders
+    pub(crate) fn intersections_with(
+        &self,
+        collider: ColliderHandle,
+    ) -> impl Iterator<Item = IntersectionPair> + '_ {
+        self.narrow_phase.intersections_with(collider).map(
+            |(collider1, collider2, intersecting)| IntersectionPair {
+                collider1: self
+                    .colliders
+                    .map
+                    .value_of(&collider1)
+                    .cloned()
+                    .unwrap_or_default(),
+                collider2: self
+                    .colliders
+                    .map
+                    .value_of(&collider2)
+                    .cloned()
+                    .unwrap_or_default(),
+                has_any_active_contact: intersecting,
+            },
+        )
+    }
+
+    /// Contacts checks between two regular colliders
     pub(crate) fn contacts_with(
         &self,
         collider: ColliderHandle,

--- a/src/scene/dim2/physics.rs
+++ b/src/scene/dim2/physics.rs
@@ -191,6 +191,16 @@ pub struct ContactPair {
     pub has_any_active_contact: bool,
 }
 
+/// Intersection info for pair of colliders.
+pub struct IntersectionPair {
+    /// The first collider involved in the contact pair.
+    pub collider1: Handle<Node>,
+    /// The second collider involved in the contact pair.
+    pub collider2: Handle<Node>,
+    /// Is there any active contact in this contact pair?
+    pub has_any_active_contact: bool,
+}
+
 pub(super) struct Container<S, A>
 where
     A: Hash + Eq + Clone,

--- a/src/scene/graph/physics.rs
+++ b/src/scene/graph/physics.rs
@@ -1576,11 +1576,38 @@ impl PhysicsWorld {
         }
     }
 
+    /// Intersections checks between regular colliders and sensor colliders
+    pub(crate) fn intersections_with(
+        &self,
+        collider: ColliderHandle,
+    ) -> impl Iterator<Item = IntersectionPair> + '_ {
+        self.narrow_phase.intersections_with(collider).map(
+            |(collider1, collider2, intersecting)| IntersectionPair {
+                collider1: self
+                    .colliders
+                    .map
+                    .value_of(&collider1)
+                    .cloned()
+                    .unwrap_or_default(),
+                collider2: self
+                    .colliders
+                    .map
+                    .value_of(&collider2)
+                    .cloned()
+                    .unwrap_or_default(),
+                has_any_active_contact: intersecting,
+            },
+        )
+    }
+
+    /// Contacts checks between two regular colliders
     pub(crate) fn contacts_with(
         &self,
         collider: ColliderHandle,
     ) -> impl Iterator<Item = ContactPair> + '_ {
         self.narrow_phase
+            // Note: contacts with will only return the interaction between 2 non-sensor nodes
+            // https://rapier.rs/docs/user_guides/rust/advanced_collision_detection/#the-contact-graph
             .contacts_with(collider)
             .map(|c| ContactPair {
                 collider1: self

--- a/src/scene/graph/physics.rs
+++ b/src/scene/graph/physics.rs
@@ -334,6 +334,16 @@ pub struct ContactPair {
     pub has_any_active_contact: bool,
 }
 
+/// Intersection info for pair of colliders.
+pub struct IntersectionPair {
+    /// The first collider involved in the contact pair.
+    pub collider1: Handle<Node>,
+    /// The second collider involved in the contact pair.
+    pub collider2: Handle<Node>,
+    /// Is there any active contact in this contact pair?
+    pub has_any_active_contact: bool,
+}
+
 pub(super) struct Container<S, A>
 where
     A: Hash + Eq + Clone,


### PR DESCRIPTION
This PR adds support for Rapier3d's  [intersection check](https://rapier.rs/docs/user_guides/rust/advanced_collision_detection/#the-intersection-graph)). This is needed to be able to use colliders which are in sensor mode. The existing `Collider::contacts()` only provides collisions on two non-sensor colliders.

This PR adds a new method `Collider::intersects()` to both the 2d and 3d Collider and adds respective unit tests.

 