### PR TITLE
Bugfix - Made audio panel in editor a Tile

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -668,7 +668,16 @@ impl Editor {
                                                                                 ),
                                                                             )
                                                                             .build(ctx),
-                                                                            audio_panel.window,
+                                                                            TileBuilder::new(
+                                                                                WidgetBuilder::new(
+                                                                                ),
+                                                                            )
+                                                                            .with_content(
+                                                                                TileContent::Window(
+                                                                                    audio_panel.window,
+                                                                                ),
+                                                                            )
+                                                                            .build(ctx),
                                                                         ],
                                                                     },
                                                                 )


### PR DESCRIPTION
Currently the audio panel in the editor is not a Tile, small change to make it a tile to enable docking.