### PR TITLE
Update audit.yml

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,6 +28,5 @@ jobs:
       - run: cargo audit --version
       # RUSTSEC-2020-0097: xcb - Soundness issue with base::Error
       # RUSTSEC-2022-0048: xml-rs is Unmaintained
-      # RUSTSEC-2021-0145: atty is Unmaintained
       # For more info: https://github.com/FyroxEngine/Fyrox/issues/208
-      - run: cargo audit --deny warnings --ignore RUSTSEC-2020-0097 --ignore RUSTSEC-2022-0048 --ignore RUSTSEC-2021-0145
+      - run: cargo audit --deny warnings --ignore RUSTSEC-2020-0097 --ignore RUSTSEC-2022-0048


### PR DESCRIPTION
Clap has replaced atty with is-terminal so this should no longer be an issue: https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#4027---2022-11-24

People might need to run cargo update locally if they keep seeing the warning since cargo audit uses the existing lockfile and only creates a new one if it doesn't exist.