### PR TITLE
Minimal support for headless mode

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -511,6 +511,7 @@ impl Editor {
             serialization_context,
             events_loop: event_loop,
             vsync: true,
+            headless: false,
         })
         .unwrap();
 

--- a/examples/custom_loader.rs
+++ b/examples/custom_loader.rs
@@ -203,6 +203,7 @@ fn main() {
         serialization_context,
         events_loop: &event_loop,
         vsync: false,
+        headless: false,
     })
     .unwrap();
 

--- a/examples/custom_loop.rs
+++ b/examples/custom_loop.rs
@@ -31,6 +31,7 @@ fn main() {
         serialization_context,
         events_loop: &event_loop,
         vsync: true,
+        headless: false,
     })
     .unwrap();
 

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -118,6 +118,7 @@ fn main() {
         serialization_context,
         events_loop: &event_loop,
         vsync: false,
+        headless: false,
     })
     .unwrap();
 

--- a/examples/lightmap.rs
+++ b/examples/lightmap.rs
@@ -296,6 +296,7 @@ fn main() {
         serialization_context,
         events_loop: &event_loop,
         vsync: true,
+        headless: false,
     })
     .unwrap();
 

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -143,6 +143,7 @@ fn main() {
         serialization_context,
         events_loop: &event_loop,
         vsync: true,
+        headless: false,
     })
     .unwrap();
 

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -88,6 +88,7 @@ fn main() {
         serialization_context,
         events_loop: &event_loop,
         vsync: true,
+        headless: false,
     })
     .unwrap();
 

--- a/examples/shared/mod.rs
+++ b/examples/shared/mod.rs
@@ -134,6 +134,7 @@ impl Game {
             serialization_context,
             events_loop: &event_loop,
             vsync: false,
+            headless: false,
         })
         .unwrap();
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -333,6 +333,7 @@ fn main() {
         serialization_context,
         events_loop: &event_loop,
         vsync: false,
+        headless: false,
     })
     .unwrap();
 

--- a/examples/wasm/src/lib.rs
+++ b/examples/wasm/src/lib.rs
@@ -282,6 +282,7 @@ pub fn main_js() {
         serialization_context,
         events_loop: &event_loop,
         vsync: true,
+        headless: false,
     })
     .unwrap();
 

--- a/fyrox-sound/src/device/dummy.rs
+++ b/fyrox-sound/src/device/dummy.rs
@@ -1,8 +1,7 @@
 use crate::{
-    device::{Device, FeedCallback, MixContext, NativeSample},
+    device::{Device, MixContext},
     error::SoundError,
 };
-use std::mem::size_of;
 
 pub struct DummySoundDevice;
 

--- a/fyrox-sound/src/device/dummy.rs
+++ b/fyrox-sound/src/device/dummy.rs
@@ -1,7 +1,4 @@
-use crate::{
-    device::{Device, MixContext},
-    error::SoundError,
-};
+use crate::device::{Device, MixContext};
 
 pub struct DummySoundDevice;
 
@@ -9,8 +6,8 @@ impl DummySoundDevice {
     pub fn new<F: FnMut(&mut [(f32, f32)]) + Send + 'static>(
         _buffer_len_bytes: u32,
         _callback: F,
-    ) -> Result<Self, SoundError> {
-        Ok(Self)
+    ) -> Self {
+        Self
     }
 }
 

--- a/fyrox-sound/src/device/mod.rs
+++ b/fyrox-sound/src/device/mod.rs
@@ -83,7 +83,7 @@ where
     #[cfg(not(target_arch = "wasm32"))]
     std::thread::spawn(move || {
         if headless {
-            let mut device = dummy::DummySoundDevice::new(buffer_len_bytes, callback).unwrap();
+            let mut device = dummy::DummySoundDevice::new(buffer_len_bytes, callback);
             device.run();
         } else {
             #[cfg(target_os = "windows")]
@@ -94,7 +94,7 @@ where
             let mut device =
                 coreaudio::CoreaudioSoundDevice::new(buffer_len_bytes, callback).unwrap();
             #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
-            let mut device = dummy::DummySoundDevice::new(buffer_len_bytes, callback).unwrap();
+            let mut device = dummy::DummySoundDevice::new(buffer_len_bytes, callback);
             device.run()
         }
     });

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -69,6 +69,7 @@ impl Executor {
             serialization_context,
             events_loop: &event_loop,
             vsync,
+            headless: false,
         })
         .unwrap();
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -415,6 +415,9 @@ pub struct EngineInitParams<'a> {
     /// vertical synchronization might not be available on your OS and engine might fail to
     /// initialize if v-sync is on.
     pub vsync: bool,
+    /// Run the engine without opening a window (TODO) and without sound.
+    /// Useful for dedicated game servers or running on CI.
+    pub headless: bool,
 }
 
 fn process_node<T>(context: &mut ScriptContext, func: &mut T)
@@ -512,6 +515,7 @@ impl Engine {
     ///     serialization_context,
     ///     events_loop: &evt,
     ///     vsync: false,
+    ///     headless: false,
     /// })
     /// .unwrap();
     /// ```
@@ -524,6 +528,7 @@ impl Engine {
             resource_manager,
             events_loop,
             vsync,
+            headless,
         } = params;
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -585,7 +590,11 @@ impl Engine {
         let glow_context =
             { unsafe { glow::Context::from_loader_function(|s| context.get_proc_address(s)) } };
 
-        let sound_engine = SoundEngine::new();
+        let sound_engine = if headless {
+            SoundEngine::new_headless()
+        } else {
+            SoundEngine::new()
+        };
 
         let renderer = Renderer::new(
             glow_context,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -415,8 +415,11 @@ pub struct EngineInitParams<'a> {
     /// vertical synchronization might not be available on your OS and engine might fail to
     /// initialize if v-sync is on.
     pub vsync: bool,
-    /// Run the engine without opening a window (TODO) and without sound.
+    /// (experimental) Run the engine without opening a window (TODO) and without sound.
     /// Useful for dedicated game servers or running on CI.
+    ///
+    /// Headless support is incomplete, for progress see
+    /// https://github.com/FyroxEngine/Fyrox/issues/222
     pub headless: bool,
 }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -412,7 +412,7 @@ pub struct EngineInitParams<'a> {
     pub events_loop: &'a EventLoop<()>,
     /// Whether to use vertical synchronization or not. V-sync will force your game to render
     /// frames with the synchronization rate of your monitor (which is ~60 FPS). Keep in mind
-    /// vertical synchronization could not be available on your OS and engine might fail to
+    /// vertical synchronization might not be available on your OS and engine might fail to
     /// initialize if v-sync is on.
     pub vsync: bool,
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -419,7 +419,7 @@ pub struct EngineInitParams<'a> {
     /// Useful for dedicated game servers or running on CI.
     ///
     /// Headless support is incomplete, for progress see
-    /// https://github.com/FyroxEngine/Fyrox/issues/222
+    /// <https://github.com/FyroxEngine/Fyrox/issues/222>.
     pub headless: bool,
 }
 


### PR DESCRIPTION
Related to #222 - see latest comment.

I am not sure if the field should be named headless because it just disables sound, not graphics but i figured if adding this field is gonna be a breaking change, might as well call it that so that when somebody figures out a way to disable window creation, it's not another breaking change later.

Basically i thought i'd need to implement a full headless mode but for my usecase (running on CI) it turns disabling sound is all that's needed. I currently don't have any intention of looking into how to implemented a full headless mode because i suspect it would be a lot of effort. Nonetheless, i think this PR is very useful to be able to run fyrox games on CI, the only issue for me is whether i should keep calling that field `headless` or change the name to `noaudio`, `no_sound` or something similar.