### PR TITLE
Add a missing reference to the script template

### DIFF
--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -475,7 +475,7 @@ fn init_script(raw_name: &str) {
         format!(
             r#"
 use fyrox::{{
-    core::{{uuid::{{Uuid, uuid}}, visitor::prelude::*, reflect::Reflect}},
+    core::{{uuid::{{Uuid, uuid}}, visitor::prelude::*, reflect::{{FieldInfo, Reflect}}}},
     engine::resource_manager::ResourceManager,
     event::Event, impl_component_provider,
     scene::{{node::TypeUuidProvider}},


### PR DESCRIPTION
The `fyrox-template script` utility generates an invalid code that cannot be compiled.

```
❯ cargo run --package editor --release
   Compiling my_game v0.1.0 (/home/user/test/my_game/game)
error[E0412]: cannot find type `FieldInfo` in this scope
  --> game/src/my_script.rs:10:17
   |
10 | #[derive(Visit, Reflect, Default, Debug, Clone)]
   |                 ^^^^^^^- help: you might be missing a type parameter: `<FieldInfo>`
   |                 |
   |                 not found in this scope
   |
   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0412`.
error: could not compile `my_game` due to previous error
```

This patch fixes the auto-generated code.