### PR TITLE
Blend space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ strum = "0.24.0"
 strum_macros = "0.24.0"
 notify = "5"
 clap = { version = "4", features = ["derive"] }
+spade = "2.1.0"
 
 [features]
 enable_profiler = ["fyrox-core/enable_profiler"]

--- a/editor/src/absm/blendspace.rs
+++ b/editor/src/absm/blendspace.rs
@@ -28,6 +28,7 @@ use fyrox::{
         message::{MessageDirection, MouseButton, UiMessage},
         popup::{Placement, PopupBuilder, PopupMessage},
         stack_panel::StackPanelBuilder,
+        text::TextBuilder,
         widget::{Widget, WidgetBuilder, WidgetMessage},
         window::{WindowBuilder, WindowMessage, WindowTitle},
         BuildContext, Control, Thickness, UiNode, UserInterface, BRUSH_DARK, BRUSH_LIGHT,
@@ -132,13 +133,15 @@ fn make_points<P: Iterator<Item = Vector2<f32>>>(
     ctx: &mut BuildContext,
 ) -> Vec<Handle<UiNode>> {
     points
-        .map(|p| {
+        .enumerate()
+        .map(|(i, p)| {
             BlendSpaceFieldPointBuilder::new(
                 WidgetBuilder::new()
                     .with_context_menu(context_menu)
                     .with_background(BRUSH_LIGHTEST)
                     .with_foreground(Brush::Solid(Color::WHITE))
                     .with_desired_position(p),
+                i,
             )
             .build(ctx)
         })
@@ -493,6 +496,7 @@ impl BlendSpaceFieldBuilder {
         let field = BlendSpaceField {
             widget: self
                 .widget_builder
+                .with_clip_to_bounds(false)
                 .with_preview_messages(true)
                 .with_context_menu(menu)
                 .build(),
@@ -576,17 +580,31 @@ impl Control for BlendSpaceFieldPoint {
 
 struct BlendSpaceFieldPointBuilder {
     widget_builder: WidgetBuilder,
+    index: usize,
 }
 
 impl BlendSpaceFieldPointBuilder {
-    fn new(widget_builder: WidgetBuilder) -> Self {
-        Self { widget_builder }
+    fn new(widget_builder: WidgetBuilder, index: usize) -> Self {
+        Self {
+            widget_builder,
+            index,
+        }
     }
 
     fn build(self, ctx: &mut BuildContext) -> Handle<UiNode> {
         let point = BlendSpaceFieldPoint {
             widget: self
                 .widget_builder
+                .with_clip_to_bounds(false)
+                .with_child(
+                    TextBuilder::new(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::left(10.0))
+                            .with_clip_to_bounds(false),
+                    )
+                    .with_text(format!("{:?}", self.index))
+                    .build(ctx),
+                )
                 .with_width(10.0)
                 .with_height(10.0)
                 .build(),
@@ -606,7 +624,7 @@ impl BlendSpaceEditor {
     pub fn new(ctx: &mut BuildContext) -> Self {
         let field = BlendSpaceFieldBuilder::new(
             WidgetBuilder::new()
-                .with_margin(Thickness::uniform(10.0))
+                .with_margin(Thickness::uniform(15.0))
                 .with_foreground(BRUSH_LIGHTEST)
                 .with_background(BRUSH_DARK),
         )

--- a/editor/src/absm/blendspace.rs
+++ b/editor/src/absm/blendspace.rs
@@ -70,7 +70,7 @@ fn blend_to_local(
 ) -> Vector2<f32> {
     let kx = (p.x - min.x) / (max.x - min.x);
     let ky = (p.y - min.y) / (max.y - min.y);
-    bounds.position + Vector2::new(kx * bounds.w(), ky * bounds.h())
+    bounds.position + Vector2::new(kx * bounds.w(), bounds.h() - ky * bounds.h())
 }
 
 fn make_points<P: Iterator<Item = Vector2<f32>>>(

--- a/editor/src/absm/blendspace.rs
+++ b/editor/src/absm/blendspace.rs
@@ -1,0 +1,180 @@
+use fyrox::{
+    core::pool::Handle,
+    gui::{
+        border::BorderBuilder,
+        grid::{Column, GridBuilder, Row},
+        message::MessageDirection,
+        numeric::NumericUpDownBuilder,
+        stack_panel::StackPanelBuilder,
+        text_box::TextBoxBuilder,
+        widget::WidgetBuilder,
+        window::{WindowBuilder, WindowMessage, WindowTitle},
+        BuildContext, Orientation, UiNode, UserInterface, VerticalAlignment,
+    },
+};
+
+pub struct BlendSpaceEditor {
+    pub window: Handle<UiNode>,
+    min_x: Handle<UiNode>,
+    max_x: Handle<UiNode>,
+    min_y: Handle<UiNode>,
+    max_y: Handle<UiNode>,
+    x_axis_name: Handle<UiNode>,
+    y_axis_name: Handle<UiNode>,
+}
+
+impl BlendSpaceEditor {
+    pub fn new(ctx: &mut BuildContext) -> Self {
+        let min_x;
+        let max_x;
+        let min_y;
+        let max_y;
+        let x_axis_name;
+        let y_axis_name;
+        let content = GridBuilder::new(
+            WidgetBuilder::new()
+                .with_child(
+                    StackPanelBuilder::new(WidgetBuilder::new().on_row(0).on_column(0))
+                        .with_orientation(Orientation::Horizontal)
+                        .build(ctx),
+                )
+                .with_child(
+                    GridBuilder::new(
+                        WidgetBuilder::new()
+                            .on_row(1)
+                            .on_column(0)
+                            .with_child(
+                                GridBuilder::new(
+                                    WidgetBuilder::new()
+                                        .with_child({
+                                            max_y = NumericUpDownBuilder::new(
+                                                WidgetBuilder::new()
+                                                    .on_row(0)
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Top,
+                                                    ),
+                                            )
+                                            .with_value(0.0f32)
+                                            .build(ctx);
+                                            max_y
+                                        })
+                                        .with_child({
+                                            y_axis_name = TextBoxBuilder::new(
+                                                WidgetBuilder::new()
+                                                    .with_height(22.0)
+                                                    .on_row(1)
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Center,
+                                                    ),
+                                            )
+                                            .build(ctx);
+                                            y_axis_name
+                                        })
+                                        .with_child({
+                                            min_y = NumericUpDownBuilder::new(
+                                                WidgetBuilder::new()
+                                                    .on_row(2)
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Bottom,
+                                                    ),
+                                            )
+                                            .with_value(0.0f32)
+                                            .build(ctx);
+                                            min_y
+                                        }),
+                                )
+                                .add_row(Row::stretch())
+                                .add_row(Row::stretch())
+                                .add_row(Row::stretch())
+                                .add_column(Column::strict(50.0))
+                                .build(ctx),
+                            )
+                            .with_child(
+                                BorderBuilder::new(WidgetBuilder::new().on_row(0).on_column(1))
+                                    .build(ctx),
+                            )
+                            .with_child(
+                                GridBuilder::new(
+                                    WidgetBuilder::new()
+                                        .on_row(1)
+                                        .on_column(1)
+                                        .with_child({
+                                            min_x = NumericUpDownBuilder::new(
+                                                WidgetBuilder::new()
+                                                    .on_column(0)
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Top,
+                                                    ),
+                                            )
+                                            .with_value(0.0f32)
+                                            .build(ctx);
+                                            min_x
+                                        })
+                                        .with_child({
+                                            x_axis_name = TextBoxBuilder::new(
+                                                WidgetBuilder::new()
+                                                    .on_column(1)
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Center,
+                                                    ),
+                                            )
+                                            .build(ctx);
+                                            x_axis_name
+                                        })
+                                        .with_child({
+                                            max_x = NumericUpDownBuilder::new(
+                                                WidgetBuilder::new()
+                                                    .on_column(2)
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Bottom,
+                                                    ),
+                                            )
+                                            .with_value(0.0f32)
+                                            .build(ctx);
+                                            max_x
+                                        }),
+                                )
+                                .add_column(Column::stretch())
+                                .add_column(Row::stretch())
+                                .add_column(Row::stretch())
+                                .add_row(Column::strict(22.0))
+                                .build(ctx),
+                            ),
+                    )
+                    .add_row(Row::stretch())
+                    .add_row(Row::auto())
+                    .add_column(Column::auto())
+                    .add_column(Column::stretch())
+                    .build(ctx),
+                ),
+        )
+        .add_row(Row::strict(22.0))
+        .add_row(Row::stretch())
+        .add_column(Column::stretch())
+        .build(ctx);
+
+        let window = WindowBuilder::new(WidgetBuilder::new().with_width(400.0).with_height(300.0))
+            .open(false)
+            .with_content(content)
+            .with_title(WindowTitle::text("Blend Space Editor"))
+            .build(ctx);
+
+        Self {
+            window,
+            min_x,
+            max_x,
+            min_y,
+            max_y,
+            x_axis_name,
+            y_axis_name,
+        }
+    }
+
+    pub fn open(&self, ui: &UserInterface) {
+        ui.send_message(WindowMessage::open(
+            self.window,
+            MessageDirection::ToWidget,
+            true,
+        ));
+    }
+}

--- a/editor/src/absm/blendspace.rs
+++ b/editor/src/absm/blendspace.rs
@@ -1,6 +1,9 @@
 use crate::{
-    absm::selection::{AbsmSelection, SelectedEntity},
-    send_sync_message,
+    absm::{
+        command::blend::SetBlendSpacePointPositionCommand,
+        selection::{AbsmSelection, SelectedEntity},
+    },
+    send_sync_message, Message,
 };
 use fyrox::{
     animation::machine::{MachineLayer, Parameter, ParameterContainer, PoseNode},
@@ -10,25 +13,22 @@ use fyrox::{
         math::{Rect, TriangleDefinition},
         pool::Handle,
     },
+    gui::message::MouseButton,
     gui::{
         brush::Brush,
         define_constructor, define_widget_deref,
         draw::{CommandTexture, Draw, DrawingContext},
-        grid::{Column, GridBuilder, Row},
         message::{MessageDirection, UiMessage},
-        numeric::{NumericUpDownBuilder, NumericUpDownMessage},
-        stack_panel::StackPanelBuilder,
-        text::{TextBuilder, TextMessage},
-        text_box::TextBoxBuilder,
         widget::{Widget, WidgetBuilder, WidgetMessage},
         window::{WindowBuilder, WindowMessage, WindowTitle},
-        BuildContext, Control, HorizontalAlignment, Orientation, Thickness, UiNode, UserInterface,
-        VerticalAlignment, BRUSH_DARK, BRUSH_LIGHT, BRUSH_LIGHTEST,
+        BuildContext, Control, Thickness, UiNode, UserInterface, BRUSH_DARK, BRUSH_LIGHT,
+        BRUSH_LIGHTEST,
     },
 };
 use std::{
     any::{Any, TypeId},
     ops::{Deref, DerefMut},
+    sync::mpsc::Sender,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -39,6 +39,10 @@ pub enum BlendSpaceFieldMessage {
     MaxValues(Vector2<f32>),
     SnapStep(Vector2<f32>),
     SamplingPoint(Vector2<f32>),
+    MovePoint {
+        index: usize,
+        position: Vector2<f32>,
+    },
 }
 
 impl BlendSpaceFieldMessage {
@@ -48,6 +52,12 @@ impl BlendSpaceFieldMessage {
     define_constructor!(BlendSpaceFieldMessage:MaxValues => fn max_values(Vector2<f32>), layout: false);
     define_constructor!(BlendSpaceFieldMessage:SnapStep => fn snap_step(Vector2<f32>), layout: false);
     define_constructor!(BlendSpaceFieldMessage:SamplingPoint => fn sampling_point(Vector2<f32>), layout: false);
+    define_constructor!(BlendSpaceFieldMessage:MovePoint  => fn move_point(index: usize, position: Vector2<f32>), layout: false);
+}
+
+#[derive(Clone)]
+struct DragContext {
+    point: usize,
 }
 
 #[derive(Clone)]
@@ -61,6 +71,7 @@ struct BlendSpaceField {
     triangles: Vec<TriangleDefinition>,
     grid_brush: Brush,
     sampling_point: Vector2<f32>,
+    drag_context: Option<DragContext>,
 }
 
 define_widget_deref!(BlendSpaceField);
@@ -76,6 +87,20 @@ fn blend_to_local(
     bounds.position + Vector2::new(kx * bounds.w(), bounds.h() - ky * bounds.h())
 }
 
+fn screen_to_blend(
+    pos: Vector2<f32>,
+    min: Vector2<f32>,
+    max: Vector2<f32>,
+    screen_bounds: Rect<f32>,
+) -> Vector2<f32> {
+    let rel = pos - screen_bounds.position;
+    let kx = (rel.x / screen_bounds.w()).clamp(0.0, 1.0);
+    let ky = 1.0 - (rel.y / screen_bounds.h()).clamp(0.0, 1.0);
+    let bx = min.x + kx * (max.x - min.x);
+    let by = min.y + ky * (max.y - min.y);
+    Vector2::new(bx, by)
+}
+
 fn make_points<P: Iterator<Item = Vector2<f32>>>(
     points: P,
     ctx: &mut BuildContext,
@@ -84,6 +109,7 @@ fn make_points<P: Iterator<Item = Vector2<f32>>>(
         .map(|p| {
             BlendSpaceFieldPointBuilder::new(
                 WidgetBuilder::new()
+                    .with_background(BRUSH_LIGHTEST)
                     .with_foreground(Brush::Solid(Color::WHITE))
                     .with_desired_position(p),
             )
@@ -267,7 +293,67 @@ impl Control for BlendSpaceField {
                     BlendSpaceFieldMessage::SamplingPoint(sampling_point) => {
                         self.sampling_point = *sampling_point;
                     }
+                    BlendSpaceFieldMessage::MovePoint { .. } => {
+                        // Do nothing
+                    }
                 }
+            }
+        }
+
+        if let Some(msg) = message.data::<WidgetMessage>() {
+            match msg {
+                WidgetMessage::MouseDown { button, .. } => {
+                    if *button == MouseButton::Left {
+                        if let Some(pos) =
+                            self.points.iter().position(|p| *p == message.destination())
+                        {
+                            self.drag_context = Some(DragContext { point: pos });
+
+                            ui.send_message(BlendSpaceFieldPointMessage::select(
+                                self.points[pos],
+                                MessageDirection::ToWidget,
+                            ));
+
+                            ui.capture_mouse(self.handle);
+                        }
+                    }
+                }
+                WidgetMessage::MouseUp { button, pos, .. } => {
+                    if let Some(drag_context) = self.drag_context.take() {
+                        if *button == MouseButton::Left {
+                            ui.send_message(BlendSpaceFieldMessage::move_point(
+                                self.handle,
+                                MessageDirection::ToWidget,
+                                drag_context.point,
+                                screen_to_blend(
+                                    *pos,
+                                    self.min_values,
+                                    self.max_values,
+                                    self.screen_bounds(),
+                                ),
+                            ));
+
+                            ui.release_mouse_capture();
+                        }
+                    }
+                }
+                WidgetMessage::MouseMove { pos, .. } => {
+                    if let Some(drag_context) = self.drag_context.as_ref() {
+                        let blend_pos = screen_to_blend(
+                            *pos,
+                            self.min_values,
+                            self.max_values,
+                            self.screen_bounds(),
+                        );
+
+                        ui.send_message(WidgetMessage::desired_position(
+                            self.points[drag_context.point],
+                            MessageDirection::ToWidget,
+                            blend_pos,
+                        ));
+                    }
+                }
+                _ => (),
             }
         }
     }
@@ -301,15 +387,26 @@ impl BlendSpaceFieldBuilder {
             triangles: Default::default(),
             grid_brush: BRUSH_LIGHT,
             sampling_point: Vector2::new(0.25, 0.5),
+            drag_context: None,
         };
 
         ctx.add_node(UiNode::new(field))
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum BlendSpaceFieldPointMessage {
+    Select,
+}
+
+impl BlendSpaceFieldPointMessage {
+    define_constructor!(BlendSpaceFieldPointMessage:Select => fn select(), layout: false);
+}
+
 #[derive(Clone)]
 struct BlendSpaceFieldPoint {
     widget: Widget,
+    selected: bool,
 }
 
 define_widget_deref!(BlendSpaceFieldPoint);
@@ -332,14 +429,24 @@ impl Control for BlendSpaceFieldPoint {
         );
         drawing_context.commit(
             self.clip_bounds(),
-            self.foreground(),
+            if self.selected {
+                self.foreground()
+            } else {
+                self.background()
+            },
             CommandTexture::None,
             None,
         );
     }
 
     fn handle_routed_message(&mut self, ui: &mut UserInterface, message: &mut UiMessage) {
-        self.widget.handle_routed_message(ui, message)
+        self.widget.handle_routed_message(ui, message);
+
+        if let Some(BlendSpaceFieldPointMessage::Select) = message.data() {
+            if message.destination() == self.handle {
+                self.selected = true;
+            }
+        }
     }
 }
 
@@ -359,6 +466,7 @@ impl BlendSpaceFieldPointBuilder {
                 .with_width(10.0)
                 .with_height(10.0)
                 .build(),
+            selected: false,
         };
 
         ctx.add_node(UiNode::new(point))
@@ -367,229 +475,26 @@ impl BlendSpaceFieldPointBuilder {
 
 pub struct BlendSpaceEditor {
     pub window: Handle<UiNode>,
-    min_x: Handle<UiNode>,
-    max_x: Handle<UiNode>,
-    min_y: Handle<UiNode>,
-    max_y: Handle<UiNode>,
-    x_axis_name: Handle<UiNode>,
-    y_axis_name: Handle<UiNode>,
     field: Handle<UiNode>,
-    snap_step_x: Handle<UiNode>,
-    snap_step_y: Handle<UiNode>,
 }
 
 impl BlendSpaceEditor {
     pub fn new(ctx: &mut BuildContext) -> Self {
-        let min_x;
-        let max_x;
-        let min_y;
-        let max_y;
-        let x_axis_name;
-        let y_axis_name;
-        let field;
-        let snap_step_x;
-        let snap_step_y;
-        let content = GridBuilder::new(
+        let field = BlendSpaceFieldBuilder::new(
             WidgetBuilder::new()
-                .with_child(
-                    StackPanelBuilder::new(
-                        WidgetBuilder::new()
-                            .on_row(0)
-                            .on_column(0)
-                            .with_child(
-                                TextBuilder::new(
-                                    WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
-                                )
-                                .with_text("Snapping X:")
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .build(ctx),
-                            )
-                            .with_child({
-                                snap_step_x = NumericUpDownBuilder::new(
-                                    WidgetBuilder::new()
-                                        .on_row(0)
-                                        .with_margin(Thickness::uniform(1.0)),
-                                )
-                                .with_value(0.0f32)
-                                .build(ctx);
-                                snap_step_x
-                            })
-                            .with_child(
-                                TextBuilder::new(
-                                    WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
-                                )
-                                .with_text("Y:")
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .build(ctx),
-                            )
-                            .with_child({
-                                snap_step_y = NumericUpDownBuilder::new(
-                                    WidgetBuilder::new()
-                                        .on_row(0)
-                                        .with_margin(Thickness::uniform(1.0)),
-                                )
-                                .with_value(0.0f32)
-                                .build(ctx);
-                                snap_step_y
-                            }),
-                    )
-                    .with_orientation(Orientation::Horizontal)
-                    .build(ctx),
-                )
-                .with_child(
-                    GridBuilder::new(
-                        WidgetBuilder::new()
-                            .on_row(1)
-                            .on_column(0)
-                            .with_child(
-                                GridBuilder::new(
-                                    WidgetBuilder::new()
-                                        .with_child({
-                                            max_y = NumericUpDownBuilder::new(
-                                                WidgetBuilder::new()
-                                                    .on_row(0)
-                                                    .with_margin(Thickness::uniform(1.0))
-                                                    .with_height(22.0)
-                                                    .with_vertical_alignment(
-                                                        VerticalAlignment::Top,
-                                                    ),
-                                            )
-                                            .with_value(0.0f32)
-                                            .build(ctx);
-                                            max_y
-                                        })
-                                        .with_child({
-                                            y_axis_name = TextBoxBuilder::new(
-                                                WidgetBuilder::new()
-                                                    .with_height(22.0)
-                                                    .on_row(1)
-                                                    .with_margin(Thickness::uniform(1.0))
-                                                    .with_vertical_alignment(
-                                                        VerticalAlignment::Center,
-                                                    ),
-                                            )
-                                            .with_vertical_text_alignment(VerticalAlignment::Center)
-                                            .build(ctx);
-                                            y_axis_name
-                                        })
-                                        .with_child({
-                                            min_y = NumericUpDownBuilder::new(
-                                                WidgetBuilder::new()
-                                                    .with_height(22.0)
-                                                    .on_row(2)
-                                                    .with_margin(Thickness::uniform(1.0))
-                                                    .with_vertical_alignment(
-                                                        VerticalAlignment::Bottom,
-                                                    ),
-                                            )
-                                            .with_value(0.0f32)
-                                            .build(ctx);
-                                            min_y
-                                        }),
-                                )
-                                .add_row(Row::stretch())
-                                .add_row(Row::stretch())
-                                .add_row(Row::stretch())
-                                .add_column(Column::strict(50.0))
-                                .build(ctx),
-                            )
-                            .with_child({
-                                field = BlendSpaceFieldBuilder::new(
-                                    WidgetBuilder::new()
-                                        .with_margin(Thickness::uniform(1.0))
-                                        .on_row(0)
-                                        .on_column(1)
-                                        .with_foreground(BRUSH_LIGHTEST)
-                                        .with_background(BRUSH_DARK),
-                                )
-                                .build(ctx);
-                                field
-                            })
-                            .with_child(
-                                GridBuilder::new(
-                                    WidgetBuilder::new()
-                                        .on_row(1)
-                                        .on_column(1)
-                                        .with_child({
-                                            min_x = NumericUpDownBuilder::new(
-                                                WidgetBuilder::new()
-                                                    .on_column(0)
-                                                    .with_margin(Thickness::uniform(1.0))
-                                                    .with_width(50.0)
-                                                    .with_horizontal_alignment(
-                                                        HorizontalAlignment::Left,
-                                                    ),
-                                            )
-                                            .with_value(0.0f32)
-                                            .build(ctx);
-                                            min_x
-                                        })
-                                        .with_child({
-                                            x_axis_name = TextBoxBuilder::new(
-                                                WidgetBuilder::new()
-                                                    .on_column(1)
-                                                    .with_margin(Thickness::uniform(1.0))
-                                                    .with_width(50.0)
-                                                    .with_horizontal_alignment(
-                                                        HorizontalAlignment::Center,
-                                                    ),
-                                            )
-                                            .with_vertical_text_alignment(VerticalAlignment::Center)
-                                            .build(ctx);
-                                            x_axis_name
-                                        })
-                                        .with_child({
-                                            max_x = NumericUpDownBuilder::new(
-                                                WidgetBuilder::new()
-                                                    .on_column(2)
-                                                    .with_margin(Thickness::uniform(1.0))
-                                                    .with_width(50.0)
-                                                    .with_horizontal_alignment(
-                                                        HorizontalAlignment::Right,
-                                                    ),
-                                            )
-                                            .with_value(0.0f32)
-                                            .build(ctx);
-                                            max_x
-                                        }),
-                                )
-                                .add_column(Column::stretch())
-                                .add_column(Row::stretch())
-                                .add_column(Row::stretch())
-                                .add_row(Column::strict(22.0))
-                                .build(ctx),
-                            ),
-                    )
-                    .add_row(Row::stretch())
-                    .add_row(Row::auto())
-                    .add_column(Column::auto())
-                    .add_column(Column::stretch())
-                    .build(ctx),
-                ),
+                .with_margin(Thickness::uniform(10.0))
+                .with_foreground(BRUSH_LIGHTEST)
+                .with_background(BRUSH_DARK),
         )
-        .add_row(Row::strict(24.0))
-        .add_row(Row::stretch())
-        .add_column(Column::stretch())
         .build(ctx);
 
-        let window = WindowBuilder::new(WidgetBuilder::new().with_width(400.0).with_height(300.0))
+        let window = WindowBuilder::new(WidgetBuilder::new().with_width(500.0).with_height(400.0))
             .open(false)
-            .with_content(content)
+            .with_content(field)
             .with_title(WindowTitle::text("Blend Space Editor"))
             .build(ctx);
 
-        Self {
-            window,
-            min_x,
-            max_x,
-            min_y,
-            max_y,
-            x_axis_name,
-            y_axis_name,
-            field,
-            snap_step_x,
-            snap_step_y,
-        }
+        Self { window, field }
     }
 
     pub fn open(&self, ui: &UserInterface) {
@@ -609,37 +514,6 @@ impl BlendSpaceEditor {
     ) {
         if let Some(SelectedEntity::PoseNode(first)) = selection.entities.first() {
             if let PoseNode::BlendSpace(blend_space) = layer.node(*first) {
-                let sync_numeric = |destination: Handle<UiNode>, v: f32| {
-                    send_sync_message(
-                        ui,
-                        NumericUpDownMessage::value(destination, MessageDirection::ToWidget, v),
-                    );
-                };
-
-                sync_numeric(self.min_x, blend_space.min_values().x);
-                sync_numeric(self.max_x, blend_space.max_values().x);
-                sync_numeric(self.min_y, blend_space.min_values().y);
-                sync_numeric(self.max_y, blend_space.max_values().y);
-                sync_numeric(self.snap_step_x, blend_space.snap_step().x);
-                sync_numeric(self.snap_step_y, blend_space.snap_step().y);
-
-                send_sync_message(
-                    ui,
-                    TextMessage::text(
-                        self.x_axis_name,
-                        MessageDirection::ToWidget,
-                        blend_space.x_axis_name().to_string(),
-                    ),
-                );
-                send_sync_message(
-                    ui,
-                    TextMessage::text(
-                        self.y_axis_name,
-                        MessageDirection::ToWidget,
-                        blend_space.y_axis_name().to_string(),
-                    ),
-                );
-
                 send_sync_message(
                     ui,
                     BlendSpaceFieldMessage::min_values(
@@ -692,6 +566,35 @@ impl BlendSpaceEditor {
                             *pt,
                         ),
                     );
+                }
+            }
+        }
+    }
+
+    pub fn handle_ui_message(
+        &mut self,
+        selection: &AbsmSelection,
+        message: &UiMessage,
+        sender: &Sender<Message>,
+    ) {
+        if let Some(SelectedEntity::PoseNode(first)) = selection.entities.first() {
+            if let Some(layer_index) = selection.layer {
+                if message.destination() == self.field {
+                    if let Some(&BlendSpaceFieldMessage::MovePoint { index, position }) =
+                        message.data()
+                    {
+                        sender
+                            .send(Message::do_scene_command(
+                                SetBlendSpacePointPositionCommand {
+                                    node_handle: selection.absm_node_handle,
+                                    handle: *first,
+                                    layer_index,
+                                    index,
+                                    value: position,
+                                },
+                            ))
+                            .unwrap();
+                    }
                 }
             }
         }

--- a/editor/src/absm/command/blend.rs
+++ b/editor/src/absm/command/blend.rs
@@ -3,6 +3,7 @@ use crate::{
     define_set_collection_element_command, scene::commands::SceneContext,
 };
 use fyrox::animation::machine::node::blendspace::BlendSpacePoint;
+use fyrox::core::algebra::Vector2;
 use fyrox::{
     animation::machine::node::{
         blend::{BlendPose, IndexedBlendInput},
@@ -62,3 +63,30 @@ define_set_collection_element_command!(
         }
     }
 );
+
+define_set_collection_element_command!(
+    SetBlendSpacePointPositionCommand<Handle<PoseNode>, Vector2<f32>>(self, context) {
+        let machine = fetch_machine(context, self.node_handle);
+        if let PoseNode::BlendSpace(ref mut definition) = machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
+            std::mem::swap( &mut definition.points_mut()[self.index].position, &mut self.value);
+        }
+    }
+);
+
+/*
+pub struct SetBlendSpacePointPosition {
+    scene_node_handle: Handle<Node>,
+    layer_index: usize,
+    node_handle: Handle<PoseNode>,
+    point_index: usize,
+    position: Vector2<f32>
+}
+
+impl SetBlendSpacePointPosition {
+    fn swap(&mut self, context: &mut SceneContext) {
+        let machine = fetch_machine(context, self.scene_node_handle);
+        if let PoseNode::BlendSpace(ref mut definition) = machine.layers_mut()[self.layer_index].nodes_mut()[self.node_handle] {
+            std::mem::swap(&mut definition.points_mut()[self.point_index].position, &mut self.position);
+        }
+    }
+}*/

--- a/editor/src/absm/command/blend.rs
+++ b/editor/src/absm/command/blend.rs
@@ -39,11 +39,8 @@ define_push_element_to_collection_command!(AddBlendSpacePointCommand<Handle<Pose
 define_set_collection_element_command!(
     SetBlendAnimationByIndexInputPoseSourceCommand<Handle<PoseNode>, Handle<PoseNode>>(self, context) {
         let machine = fetch_machine(context, self.node_handle);
-        match machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
-            PoseNode::BlendAnimationsByIndex(ref mut definition) => {
-                &mut definition.inputs[self.index].pose_source
-            }
-            _ => unreachable!(),
+        if let PoseNode::BlendAnimationsByIndex(ref mut definition) = machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
+            std::mem::swap(&mut definition.inputs[self.index].pose_source, &mut self.value)
         }
     }
 );
@@ -51,11 +48,8 @@ define_set_collection_element_command!(
 define_set_collection_element_command!(
     SetBlendAnimationsPoseSourceCommand<Handle<PoseNode>, Handle<PoseNode>>(self, context) {
         let machine = fetch_machine(context, self.node_handle);
-        match machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
-            PoseNode::BlendAnimations(ref mut definition) => {
-                &mut definition.pose_sources[self.index].pose_source
-            }
-            _ => unreachable!(),
+        if let PoseNode::BlendAnimations(ref mut definition) = machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
+            std::mem::swap(&mut definition.pose_sources[self.index].pose_source, &mut self.value);
         }
     }
 );
@@ -63,11 +57,8 @@ define_set_collection_element_command!(
 define_set_collection_element_command!(
     SetBlendSpacePoseSourceCommand<Handle<PoseNode>, Handle<PoseNode>>(self, context) {
         let machine = fetch_machine(context, self.node_handle);
-        match machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
-            PoseNode::BlendSpace(ref mut definition) => {
-                &mut definition.points_mut()[self.index].pose_source
-            }
-            _ => unreachable!(),
+        if let PoseNode::BlendSpace(ref mut definition) = machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
+            std::mem::swap( &mut definition.points_mut()[self.index].pose_source, &mut self.value);
         }
     }
 );

--- a/editor/src/absm/command/blend.rs
+++ b/editor/src/absm/command/blend.rs
@@ -69,24 +69,7 @@ define_set_collection_element_command!(
         let machine = fetch_machine(context, self.node_handle);
         if let PoseNode::BlendSpace(ref mut definition) = machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
             std::mem::swap( &mut definition.points_mut()[self.index].position, &mut self.value);
+            definition.try_snap_points();
         }
     }
 );
-
-/*
-pub struct SetBlendSpacePointPosition {
-    scene_node_handle: Handle<Node>,
-    layer_index: usize,
-    node_handle: Handle<PoseNode>,
-    point_index: usize,
-    position: Vector2<f32>
-}
-
-impl SetBlendSpacePointPosition {
-    fn swap(&mut self, context: &mut SceneContext) {
-        let machine = fetch_machine(context, self.scene_node_handle);
-        if let PoseNode::BlendSpace(ref mut definition) = machine.layers_mut()[self.layer_index].nodes_mut()[self.node_handle] {
-            std::mem::swap(&mut definition.points_mut()[self.point_index].position, &mut self.position);
-        }
-    }
-}*/

--- a/editor/src/absm/command/blend.rs
+++ b/editor/src/absm/command/blend.rs
@@ -2,6 +2,7 @@ use crate::{
     absm::command::fetch_machine, command::Command, define_push_element_to_collection_command,
     define_set_collection_element_command, scene::commands::SceneContext,
 };
+use fyrox::animation::machine::node::blendspace::BlendSpacePoint;
 use fyrox::{
     animation::machine::node::{
         blend::{BlendPose, IndexedBlendInput},
@@ -27,6 +28,14 @@ define_push_element_to_collection_command!(AddPoseSourceCommand<Handle<PoseNode>
     }
 });
 
+define_push_element_to_collection_command!(AddBlendSpacePointCommand<Handle<PoseNode>, BlendSpacePoint>(self, context) {
+    let machine = fetch_machine(context, self.node_handle);
+    match &mut machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
+        PoseNode::BlendSpace(definition) => definition.points_mut(),
+        _ => unreachable!(),
+    }
+});
+
 define_set_collection_element_command!(
     SetBlendAnimationByIndexInputPoseSourceCommand<Handle<PoseNode>, Handle<PoseNode>>(self, context) {
         let machine = fetch_machine(context, self.node_handle);
@@ -45,6 +54,18 @@ define_set_collection_element_command!(
         match machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
             PoseNode::BlendAnimations(ref mut definition) => {
                 &mut definition.pose_sources[self.index].pose_source
+            }
+            _ => unreachable!(),
+        }
+    }
+);
+
+define_set_collection_element_command!(
+    SetBlendSpacePoseSourceCommand<Handle<PoseNode>, Handle<PoseNode>>(self, context) {
+        let machine = fetch_machine(context, self.node_handle);
+        match machine.layers_mut()[self.layer_index].nodes_mut()[self.handle] {
+            PoseNode::BlendSpace(ref mut definition) => {
+                &mut definition.points_mut()[self.index].pose_source
             }
             _ => unreachable!(),
         }

--- a/editor/src/absm/command/mod.rs
+++ b/editor/src/absm/command/mod.rs
@@ -607,13 +607,11 @@ macro_rules! define_push_element_to_collection_command {
             }
 
             fn execute(&mut $self, $context: &mut SceneContext) {
-                let collection = $get_collection;
-                collection.push($self.value.take().unwrap());
+                ($get_collection).push($self.value.take().unwrap());
             }
 
             fn revert(&mut $self, $context: &mut SceneContext) {
-                let collection = $get_collection;
-                $self.value = Some(collection.pop().unwrap());
+                $self.value = Some(($get_collection).pop().unwrap());
             }
         }
     };
@@ -660,7 +658,7 @@ macro_rules! define_remove_collection_element_command {
 
 #[macro_export]
 macro_rules! define_set_collection_element_command {
-    ($name:ident<$model_handle:ty, $value_type:ty>($self:ident, $context:ident) $get_value:block) => {
+    ($name:ident<$model_handle:ty, $value_type:ty>($self:ident, $context:ident) $swap_value:block) => {
         #[derive(Debug)]
         pub struct $name {
             pub node_handle: Handle<Node>,
@@ -672,8 +670,7 @@ macro_rules! define_set_collection_element_command {
 
         impl $name {
             pub fn swap(&mut $self, $context: &mut SceneContext) {
-                let value = $get_value;
-                std::mem::swap(value, &mut $self.value);
+                 $swap_value
             }
         }
 

--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -303,6 +303,7 @@ impl AbsmEditor {
                         absm_node,
                         &scene.graph,
                     );
+                    self.blend_space_editor.sync_to_model(layer, &selection, ui);
                 }
             }
         } else {

--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -397,6 +397,8 @@ impl AbsmEditor {
                     layer_index,
                     editor_scene,
                 );
+                self.blend_space_editor
+                    .handle_ui_message(&selection, message, sender);
             }
 
             self.parameter_panel.handle_ui_message(

--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -397,8 +397,13 @@ impl AbsmEditor {
                     layer_index,
                     editor_scene,
                 );
-                self.blend_space_editor
-                    .handle_ui_message(&selection, message, sender);
+                self.blend_space_editor.handle_ui_message(
+                    &selection,
+                    message,
+                    sender,
+                    absm_node.machine_mut(),
+                    self.preview_mode_data.is_some(),
+                );
             }
 
             self.parameter_panel.handle_ui_message(

--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -293,7 +293,8 @@ impl AbsmEditor {
             self.parameter_panel.sync_to_model(ui, absm_node);
             self.toolbar.sync_to_model(absm_node, ui, &selection);
             if let Some(layer_index) = selection.layer {
-                if let Some(layer) = absm_node.machine().layers().get(layer_index) {
+                let machine = absm_node.machine();
+                if let Some(layer) = machine.layers().get(layer_index) {
                     self.state_graph_viewer
                         .sync_to_model(layer, ui, editor_scene);
                     self.state_viewer.sync_to_model(
@@ -303,7 +304,12 @@ impl AbsmEditor {
                         absm_node,
                         &scene.graph,
                     );
-                    self.blend_space_editor.sync_to_model(layer, &selection, ui);
+                    self.blend_space_editor.sync_to_model(
+                        machine.parameters(),
+                        layer,
+                        &selection,
+                        ui,
+                    );
                 }
             }
         } else {

--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -510,6 +510,10 @@ impl AbsmEditor {
                                             )))
                                             .unwrap();
                                     }
+                                    PoseNode::BlendSpace(_) => {
+                                        // TODO
+                                        unimplemented!();
+                                    }
                                 }
                             }
                         }

--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -1,3 +1,4 @@
+use crate::absm::command::blend::AddBlendSpacePointCommand;
 use crate::{
     absm::{
         command::blend::{AddInputCommand, AddPoseSourceCommand},
@@ -11,6 +12,7 @@ use crate::{
     scene::{EditorScene, Selection},
     Message,
 };
+use fyrox::animation::machine::node::blendspace::BlendSpacePoint;
 use fyrox::fxhash::FxHashSet;
 use fyrox::{
     animation::machine::{BlendPose, Event, IndexedBlendInput, Machine, PoseNode, State},
@@ -511,8 +513,16 @@ impl AbsmEditor {
                                             .unwrap();
                                     }
                                     PoseNode::BlendSpace(_) => {
-                                        // TODO
-                                        unimplemented!();
+                                        sender
+                                            .send(Message::do_scene_command(
+                                                AddBlendSpacePointCommand::new(
+                                                    selection.absm_node_handle,
+                                                    node.model_handle,
+                                                    layer_index,
+                                                    BlendSpacePoint::default(),
+                                                ),
+                                            ))
+                                            .unwrap();
                                     }
                                 }
                             }

--- a/editor/src/absm/state_viewer/context.rs
+++ b/editor/src/absm/state_viewer/context.rs
@@ -300,7 +300,7 @@ impl ConnectionContextMenu {
 
                 let model_handle = dest_node_ref.model_handle;
                 match machine_layer.node(model_handle) {
-                    PoseNode::PlayAnimation(_) => {
+                    PoseNode::PlayAnimation(_) | PoseNode::BlendSpace(_) => {
                         // No connections
                     }
                     PoseNode::BlendAnimations(_) => sender

--- a/editor/src/absm/state_viewer/context.rs
+++ b/editor/src/absm/state_viewer/context.rs
@@ -1,3 +1,4 @@
+use crate::absm::command::blend::SetBlendSpacePoseSourceCommand;
 use crate::{
     absm::{
         command::{
@@ -17,6 +18,7 @@ use crate::{
     },
     Message,
 };
+use fyrox::animation::machine::node::blendspace::BlendSpace;
 use fyrox::{
     animation::machine::{
         node::BasePoseNode, BlendAnimations, BlendAnimationsByIndex, MachineLayer, PlayAnimation,
@@ -39,6 +41,7 @@ pub struct CanvasContextMenu {
     create_play_animation: Handle<UiNode>,
     create_blend_animations: Handle<UiNode>,
     create_blend_by_index: Handle<UiNode>,
+    create_blend_space: Handle<UiNode>,
     pub menu: Handle<UiNode>,
     pub canvas: Handle<UiNode>,
     pub node_context_menu: Handle<UiNode>,
@@ -49,6 +52,7 @@ impl CanvasContextMenu {
         let create_play_animation;
         let create_blend_animations;
         let create_blend_by_index;
+        let create_blend_space;
         let menu = PopupBuilder::new(
             WidgetBuilder::new()
                 .with_enabled(false) // Disabled by default.
@@ -68,6 +72,10 @@ impl CanvasContextMenu {
                     .with_child({
                         create_blend_by_index = create_menu_item("Blend By Index", vec![], ctx);
                         create_blend_by_index
+                    })
+                    .with_child({
+                        create_blend_space = create_menu_item("Blend Space", vec![], ctx);
+                        create_blend_space
                     }),
             )
             .build(ctx),
@@ -78,6 +86,7 @@ impl CanvasContextMenu {
             create_play_animation,
             create_blend_animations,
             create_blend_by_index,
+            create_blend_space,
             menu,
             canvas: Default::default(),
             node_context_menu: Default::default(),
@@ -128,6 +137,13 @@ impl CanvasContextMenu {
                     blend_time: Default::default(),
                     output_pose: Default::default(),
                 }))
+            } else if message.destination() == self.create_blend_space {
+                let mut blend_space = BlendSpace::default();
+
+                blend_space.position = position;
+                blend_space.parent_state = current_state;
+
+                Some(PoseNode::BlendSpace(blend_space))
             } else {
                 None
             };
@@ -300,7 +316,7 @@ impl ConnectionContextMenu {
 
                 let model_handle = dest_node_ref.model_handle;
                 match machine_layer.node(model_handle) {
-                    PoseNode::PlayAnimation(_) | PoseNode::BlendSpace(_) => {
+                    PoseNode::PlayAnimation(_) => {
                         // No connections
                     }
                     PoseNode::BlendAnimations(_) => sender
@@ -324,6 +340,15 @@ impl ConnectionContextMenu {
                                 value: Default::default(),
                             },
                         ))
+                        .unwrap(),
+                    PoseNode::BlendSpace(_) => sender
+                        .send(Message::do_scene_command(SetBlendSpacePoseSourceCommand {
+                            node_handle: absm_node_handle,
+                            layer_index,
+                            handle: model_handle,
+                            index,
+                            value: Default::default(),
+                        }))
                         .unwrap(),
                 }
             }

--- a/editor/src/absm/state_viewer/context.rs
+++ b/editor/src/absm/state_viewer/context.rs
@@ -18,7 +18,8 @@ use crate::{
     },
     Message,
 };
-use fyrox::animation::machine::node::blendspace::BlendSpace;
+use fyrox::animation::machine::node::blendspace::{BlendSpace, BlendSpacePoint};
+use fyrox::core::algebra::Vector2;
 use fyrox::{
     animation::machine::{
         node::BasePoseNode, BlendAnimations, BlendAnimationsByIndex, MachineLayer, PlayAnimation,
@@ -142,6 +143,24 @@ impl CanvasContextMenu {
 
                 blend_space.position = position;
                 blend_space.parent_state = current_state;
+                blend_space.set_points(vec![
+                    BlendSpacePoint {
+                        position: Vector2::new(0.0, 0.0),
+                        pose_source: Default::default(),
+                    },
+                    BlendSpacePoint {
+                        position: Vector2::new(1.0, 0.0),
+                        pose_source: Default::default(),
+                    },
+                    BlendSpacePoint {
+                        position: Vector2::new(1.0, 1.0),
+                        pose_source: Default::default(),
+                    },
+                    BlendSpacePoint {
+                        position: Vector2::new(0.5, 0.5),
+                        pose_source: Default::default(),
+                    },
+                ]);
 
                 Some(PoseNode::BlendSpace(blend_space))
             } else {

--- a/editor/src/absm/state_viewer/mod.rs
+++ b/editor/src/absm/state_viewer/mod.rs
@@ -3,7 +3,8 @@ use crate::{
         canvas::{AbsmCanvasBuilder, AbsmCanvasMessage},
         command::{
             blend::{
-                SetBlendAnimationByIndexInputPoseSourceCommand, SetBlendAnimationsPoseSourceCommand,
+                SetBlendAnimationByIndexInputPoseSourceCommand,
+                SetBlendAnimationsPoseSourceCommand, SetBlendSpacePoseSourceCommand,
             },
             MovePoseNodeCommand,
         },
@@ -342,8 +343,17 @@ impl StateViewer {
                                         .unwrap();
                                 }
                                 PoseNode::BlendSpace(_) => {
-                                    // TODO
-                                    unimplemented!()
+                                    sender
+                                        .send(Message::do_scene_command(
+                                            SetBlendSpacePoseSourceCommand {
+                                                node_handle: absm_node_handle,
+                                                layer_index,
+                                                handle: dest_node,
+                                                index: dest_socket_ref.index,
+                                                value: source_node,
+                                            },
+                                        ))
+                                        .unwrap();
                                 }
                             }
                         }

--- a/editor/src/absm/state_viewer/mod.rs
+++ b/editor/src/absm/state_viewer/mod.rs
@@ -454,25 +454,28 @@ impl StateViewer {
                         }) {
                             let node_ref = &machine_layer.nodes()[pose_definition];
 
-                            let (input_socket_count, name, can_add_sockets) = match node_ref {
-                                PoseNode::PlayAnimation(_) => {
-                                    // No input sockets
-                                    (0, "Play Animation", false)
-                                }
-                                PoseNode::BlendAnimations(blend_animations) => (
-                                    blend_animations.pose_sources.len(),
-                                    "Blend Animations",
-                                    true,
-                                ),
-                                PoseNode::BlendAnimationsByIndex(blend_animations) => (
-                                    blend_animations.inputs.len(),
-                                    "Blend Animations By Index",
-                                    true,
-                                ),
-                                PoseNode::BlendSpace(blend_space) => {
-                                    (blend_space.points().len(), "Blend Space", true)
-                                }
-                            };
+                            let (input_socket_count, name, can_add_sockets, editable) =
+                                match node_ref {
+                                    PoseNode::PlayAnimation(_) => {
+                                        // No input sockets
+                                        (0, "Play Animation", false, false)
+                                    }
+                                    PoseNode::BlendAnimations(blend_animations) => (
+                                        blend_animations.pose_sources.len(),
+                                        "Blend Animations",
+                                        true,
+                                        false,
+                                    ),
+                                    PoseNode::BlendAnimationsByIndex(blend_animations) => (
+                                        blend_animations.inputs.len(),
+                                        "Blend Animations By Index",
+                                        true,
+                                        false,
+                                    ),
+                                    PoseNode::BlendSpace(blend_space) => {
+                                        (blend_space.points().len(), "Blend Space", true, true)
+                                    }
+                                };
 
                             let node_view = AbsmNodeBuilder::new(
                                 WidgetBuilder::new()
@@ -504,6 +507,7 @@ impl StateViewer {
                             } else {
                                 SELECTED_BACKGROUND
                             })
+                            .with_editable(editable)
                             .with_model_handle(pose_definition)
                             .build(&mut ui.build_ctx());
 

--- a/editor/src/absm/state_viewer/mod.rs
+++ b/editor/src/absm/state_viewer/mod.rs
@@ -126,6 +126,9 @@ fn make_pose_node_name(
             "Blend {} Animations By Index",
             blend_animations_by_index.inputs.len()
         ),
+        PoseNode::BlendSpace(blend_space) => {
+            format!("Blend Space: {:?} animations", blend_space.points().len())
+        }
     }
 }
 
@@ -338,6 +341,10 @@ impl StateViewer {
                                         ))
                                         .unwrap();
                                 }
+                                PoseNode::BlendSpace(_) => {
+                                    // TODO
+                                    unimplemented!()
+                                }
                             }
                         }
                         _ => (),
@@ -462,6 +469,9 @@ impl StateViewer {
                                     "Blend Animations By Index",
                                     true,
                                 ),
+                                PoseNode::BlendSpace(blend_space) => {
+                                    (blend_space.points().len(), "Blend Space", true)
+                                }
                             };
 
                             let node_view = AbsmNodeBuilder::new(

--- a/editor/src/inspector/editors/mod.rs
+++ b/editor/src/inspector/editors/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     Message,
 };
+use fyrox::animation::machine::node::blendspace::{BlendSpace, BlendSpacePoint};
 use fyrox::{
     animation::{
         machine::{
@@ -304,11 +305,14 @@ pub fn make_property_editors_container(
     container.insert(InspectablePropertyEditorDefinition::<BasePoseNode>::new());
     container.insert(InspectablePropertyEditorDefinition::<IndexedBlendInput>::new());
     container.insert(VecCollectionPropertyEditorDefinition::<IndexedBlendInput>::new());
+    container.insert(InspectablePropertyEditorDefinition::<BlendSpacePoint>::new());
+    container.insert(VecCollectionPropertyEditorDefinition::<BlendSpacePoint>::new());
     container.insert(InspectablePropertyEditorDefinition::<BlendPose>::new());
     container.insert(VecCollectionPropertyEditorDefinition::<BlendPose>::new());
     container.insert(EnumPropertyEditorDefinition::<PoseWeight>::new());
     container.insert(InspectablePropertyEditorDefinition::<BlendAnimationsByIndex>::new());
     container.insert(InspectablePropertyEditorDefinition::<BlendAnimations>::new());
+    container.insert(InspectablePropertyEditorDefinition::<BlendSpace>::new());
     container.insert(InspectablePropertyEditorDefinition::<PlayAnimation>::new());
 
     container.insert(InspectablePropertyEditorDefinition::<Handle<PoseNode>>::new());

--- a/fyrox-core/src/math/mod.rs
+++ b/fyrox-core/src/math/mod.rs
@@ -697,7 +697,7 @@ impl PartialEq for TriangleEdge {
 
 impl Eq for TriangleEdge {}
 
-#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Hash, Reflect)]
 #[repr(C)]
 pub struct TriangleDefinition(pub [u32; 3]);
 

--- a/src/animation/machine/node/blendspace.rs
+++ b/src/animation/machine/node/blendspace.rs
@@ -14,9 +14,8 @@ use crate::{
     },
 };
 use spade::{DelaunayTriangulation, Point2, Triangulation};
-use std::cell::Cell;
 use std::{
-    cell::{Ref, RefCell},
+    cell::{Cell, Ref, RefCell},
     ops::{Deref, DerefMut},
 };
 
@@ -32,11 +31,18 @@ pub struct BlendSpace {
 
     points: Vec<BlendSpacePoint>,
 
+    #[reflect(hidden)]
     triangles: RefCell<Vec<TriangleDefinition>>,
 
     #[reflect(hidden)]
     #[visit(skip)]
     triangles_dirty: Cell<bool>,
+
+    #[reflect(setter = "set_x_axis_name")]
+    x_axis_name: String,
+
+    #[reflect(setter = "set_y_axis_name")]
+    y_axis_name: String,
 
     #[reflect(setter = "set_min_values")]
     min_values: Vector2<f32>,
@@ -62,6 +68,8 @@ impl Default for BlendSpace {
             points: vec![],
             triangles: Default::default(),
             triangles_dirty: Cell::new(true),
+            x_axis_name: "X".to_string(),
+            y_axis_name: "Y".to_string(),
             min_values: Default::default(),
             max_values: Vector2::new(1.0, 1.0),
             snap_step: Vector2::new(0.1, 0.1),
@@ -186,6 +194,22 @@ impl BlendSpace {
 
     pub fn sampling_parameter(&self) -> &str {
         &self.sampling_parameter
+    }
+
+    pub fn set_x_axis_name(&mut self, name: String) -> String {
+        std::mem::replace(&mut self.x_axis_name, name)
+    }
+
+    pub fn x_axis_name(&self) -> &str {
+        &self.x_axis_name
+    }
+
+    pub fn set_y_axis_name(&mut self, name: String) -> String {
+        std::mem::replace(&mut self.y_axis_name, name)
+    }
+
+    pub fn y_axis_name(&self) -> &str {
+        &self.y_axis_name
     }
 
     pub fn fetch_weights(&self, sampling_point: Vector2<f32>) -> Option<[(usize, f32); 3]> {

--- a/src/animation/machine/node/blendspace.rs
+++ b/src/animation/machine/node/blendspace.rs
@@ -229,6 +229,16 @@ impl BlendSpace {
         &self.y_axis_name
     }
 
+    pub fn try_snap_points(&mut self) {
+        for point in self.points.iter_mut() {
+            let x = math::round_to_step(point.position.x, self.snap_step.x)
+                .clamp(self.min_values.x, self.max_values.x);
+            let y = math::round_to_step(point.position.y, self.snap_step.y)
+                .clamp(self.min_values.y, self.max_values.y);
+            point.position = Vector2::new(x, y);
+        }
+    }
+
     pub fn fetch_weights(&self, sampling_point: Vector2<f32>) -> Option<[(usize, f32); 3]> {
         if self.points.is_empty() {
             return None;

--- a/src/animation/machine/node/blendspace.rs
+++ b/src/animation/machine/node/blendspace.rs
@@ -94,8 +94,8 @@ impl EvaluatePose for BlendSpace {
         &self,
         nodes: &Pool<PoseNode>,
         params: &ParameterContainer,
-        _animations: &AnimationContainer,
-        _dt: f32,
+        animations: &AnimationContainer,
+        dt: f32,
     ) -> Ref<AnimationPose> {
         let mut pose = self.pose.borrow_mut();
 
@@ -113,12 +113,14 @@ impl EvaluatePose for BlendSpace {
                     nodes.try_borrow(self.points[ib].pose_source),
                     nodes.try_borrow(self.points[ic].pose_source),
                 ) {
-                    pose.blend_with(&pose_a.pose(), wa);
-                    pose.blend_with(&pose_b.pose(), wb);
-                    pose.blend_with(&pose_c.pose(), wc);
+                    pose.blend_with(&pose_a.eval_pose(nodes, params, animations, dt), wa);
+                    pose.blend_with(&pose_b.eval_pose(nodes, params, animations, dt), wb);
+                    pose.blend_with(&pose_c.eval_pose(nodes, params, animations, dt), wc);
                 }
             }
         }
+
+        drop(pose);
 
         self.pose.borrow()
     }

--- a/src/animation/machine/node/blendspace.rs
+++ b/src/animation/machine/node/blendspace.rs
@@ -1,0 +1,108 @@
+#![allow(missing_docs)] // TODO
+
+use crate::{
+    animation::{
+        machine::{node::BasePoseNode, EvaluatePose, ParameterContainer, PoseNode},
+        AnimationContainer, AnimationPose,
+    },
+    core::{
+        algebra::Vector2,
+        math::TriangleDefinition,
+        pool::{Handle, Pool},
+        reflect::prelude::*,
+        visitor::prelude::*,
+    },
+    utils::log::Log,
+};
+use spade::{DelaunayTriangulation, InsertionError, Point2, Triangulation};
+use std::{
+    cell::{Ref, RefCell},
+    ops::{Deref, DerefMut},
+};
+
+#[derive(Debug, Visit, Clone, Reflect, PartialEq, Default)]
+pub struct BlendSpacePoint {
+    position: Vector2<u32>,
+    pose_source: Handle<PoseNode>,
+}
+
+#[derive(Debug, Visit, Clone, Reflect, PartialEq, Default)]
+pub struct BlendSpace {
+    base: BasePoseNode,
+
+    points: Vec<BlendSpacePoint>,
+    triangles: Vec<TriangleDefinition>,
+
+    #[reflect(hidden)]
+    #[visit(skip)]
+    pose: RefCell<AnimationPose>,
+}
+
+impl Deref for BlendSpace {
+    type Target = BasePoseNode;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl DerefMut for BlendSpace {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
+impl EvaluatePose for BlendSpace {
+    fn eval_pose(
+        &self,
+        nodes: &Pool<PoseNode>,
+        params: &ParameterContainer,
+        animations: &AnimationContainer,
+        dt: f32,
+    ) -> Ref<AnimationPose> {
+        todo!()
+    }
+
+    fn pose(&self) -> Ref<AnimationPose> {
+        self.pose.borrow()
+    }
+}
+
+impl BlendSpace {
+    pub fn set_points(&mut self, points: Vec<BlendSpacePoint>) {
+        self.points = points;
+        Log::verify(self.triangulate());
+    }
+
+    pub fn points(&self) -> &[BlendSpacePoint] {
+        &self.points
+    }
+
+    pub fn children(&self) -> Vec<Handle<PoseNode>> {
+        self.points.iter().map(|p| p.pose_source).collect()
+    }
+
+    fn triangulate(&mut self) -> Result<(), InsertionError> {
+        self.triangles.clear();
+
+        let mut triangulation: DelaunayTriangulation<_> = DelaunayTriangulation::new();
+
+        for point in self.points.iter() {
+            triangulation.insert(Point2::new(
+                point.position.x as f32,
+                point.position.y as f32,
+            ))?;
+        }
+
+        for face in triangulation.inner_faces() {
+            let edges = face.adjacent_edges();
+            self.triangles.push(TriangleDefinition([
+                edges[0].from().index() as u32,
+                edges[1].from().index() as u32,
+                edges[2].from().index() as u32,
+            ]))
+        }
+
+        Ok(())
+    }
+}

--- a/src/animation/machine/node/blendspace.rs
+++ b/src/animation/machine/node/blendspace.rs
@@ -12,7 +12,6 @@ use crate::{
         reflect::prelude::*,
         visitor::prelude::*,
     },
-    utils::log::Log,
 };
 use spade::{DelaunayTriangulation, InsertionError, Point2, Triangulation};
 use std::{
@@ -69,9 +68,9 @@ impl EvaluatePose for BlendSpace {
 }
 
 impl BlendSpace {
-    pub fn set_points(&mut self, points: Vec<BlendSpacePoint>) {
+    pub fn set_points(&mut self, points: Vec<BlendSpacePoint>) -> bool {
         self.points = points;
-        Log::verify(self.triangulate());
+        self.triangulate().is_ok()
     }
 
     pub fn points(&self) -> &[BlendSpacePoint] {
@@ -104,5 +103,44 @@ impl BlendSpace {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        animation::machine::node::blendspace::{BlendSpace, BlendSpacePoint},
+        core::{algebra::Vector2, math::TriangleDefinition},
+    };
+
+    #[test]
+    fn test_blend_space_triangulation() {
+        let mut blend_space = BlendSpace::default();
+
+        let result = blend_space.set_points(vec![
+            BlendSpacePoint {
+                position: Vector2::new(0, 0),
+                pose_source: Default::default(),
+            },
+            BlendSpacePoint {
+                position: Vector2::new(1, 0),
+                pose_source: Default::default(),
+            },
+            BlendSpacePoint {
+                position: Vector2::new(1, 1),
+                pose_source: Default::default(),
+            },
+            BlendSpacePoint {
+                position: Vector2::new(0, 1),
+                pose_source: Default::default(),
+            },
+        ]);
+
+        assert!(result);
+
+        assert_eq!(
+            blend_space.triangles,
+            vec![TriangleDefinition([2, 0, 1]), TriangleDefinition([3, 0, 2])]
+        )
     }
 }

--- a/src/animation/machine/node/blendspace.rs
+++ b/src/animation/machine/node/blendspace.rs
@@ -146,6 +146,12 @@ impl<'a> DerefMut for PointsMut<'a> {
     }
 }
 
+impl<'a> Drop for PointsMut<'a> {
+    fn drop(&mut self) {
+        self.blend_space.triangulate();
+    }
+}
+
 impl BlendSpace {
     pub fn add_point(&mut self, point: BlendSpacePoint) -> bool {
         self.points.push(point);

--- a/src/animation/machine/node/blendspace.rs
+++ b/src/animation/machine/node/blendspace.rs
@@ -158,6 +158,10 @@ impl BlendSpace {
         &mut self.points
     }
 
+    pub fn triangles(&self) -> Ref<Vec<TriangleDefinition>> {
+        self.triangles.borrow()
+    }
+
     pub fn children(&self) -> Vec<Handle<PoseNode>> {
         self.points.iter().map(|p| p.pose_source).collect()
     }

--- a/src/animation/machine/node/blendspace.rs
+++ b/src/animation/machine/node/blendspace.rs
@@ -29,8 +29,10 @@ pub struct BlendSpacePoint {
 pub struct BlendSpace {
     base: BasePoseNode,
 
+    #[reflect(hidden)]
     points: Vec<BlendSpacePoint>,
 
+    #[reflect(hidden)]
     triangles: Vec<TriangleDefinition>,
 
     #[reflect(setter = "set_x_axis_name")]

--- a/src/animation/machine/node/mod.rs
+++ b/src/animation/machine/node/mod.rs
@@ -48,6 +48,7 @@ pub enum PoseNode {
     /// See docs for [`BlendAnimationsByIndex`].
     BlendAnimationsByIndex(BlendAnimationsByIndex),
 
+    /// See doc for [`BlendSpace`]
     BlendSpace(BlendSpace),
 }
 

--- a/src/animation/machine/node/mod.rs
+++ b/src/animation/machine/node/mod.rs
@@ -4,7 +4,7 @@
 use crate::{
     animation::{
         machine::{
-            node::{blend::BlendAnimations, play::PlayAnimation},
+            node::{blend::BlendAnimations, blendspace::BlendSpace, play::PlayAnimation},
             BlendAnimationsByIndex, BlendPose, IndexedBlendInput, ParameterContainer, State,
         },
         Animation, AnimationContainer, AnimationPose,
@@ -22,6 +22,7 @@ use std::{
 };
 
 pub mod blend;
+pub mod blendspace;
 pub mod play;
 
 /// A set of common data fields that is used in every node.
@@ -46,6 +47,8 @@ pub enum PoseNode {
 
     /// See docs for [`BlendAnimationsByIndex`].
     BlendAnimationsByIndex(BlendAnimationsByIndex),
+
+    BlendSpace(BlendSpace),
 }
 
 impl Default for PoseNode {
@@ -81,8 +84,9 @@ impl PoseNode {
                 // No children nodes.
                 vec![]
             }
-            Self::BlendAnimations(definition) => definition.children(),
-            Self::BlendAnimationsByIndex(definition) => definition.children(),
+            Self::BlendAnimations(blend_animations) => blend_animations.children(),
+            Self::BlendAnimationsByIndex(blend_by_index) => blend_by_index.children(),
+            Self::BlendSpace(blend_space) => blend_space.children(),
         }
     }
 }
@@ -93,6 +97,7 @@ macro_rules! static_dispatch {
             PoseNode::PlayAnimation(v) => v.$func($($args),*),
             PoseNode::BlendAnimations(v) => v.$func($($args),*),
             PoseNode::BlendAnimationsByIndex(v) => v.$func($($args),*),
+            PoseNode::BlendSpace(v) => v.$func($($args),*),
         }
     };
 }

--- a/src/animation/machine/parameter.rs
+++ b/src/animation/machine/parameter.rs
@@ -22,6 +22,7 @@ pub enum Parameter {
     /// An index of a pose.
     Index(u32),
 
+    /// A sampling point. Usually it is used together with BlendSpace nodes.
     SamplingPoint(Vector2<f32>),
 }
 

--- a/src/animation/machine/parameter.rs
+++ b/src/animation/machine/parameter.rs
@@ -1,6 +1,6 @@
 //! Parameter is a name variable of a fixed type. See [`Parameter`] docs for more info.
 
-use crate::core::{reflect::prelude::*, visitor::prelude::*};
+use crate::core::{algebra::Vector2, reflect::prelude::*, visitor::prelude::*};
 use fxhash::FxHashMap;
 use std::{
     cell::{Cell, RefCell},
@@ -21,6 +21,8 @@ pub enum Parameter {
 
     /// An index of a pose.
     Index(u32),
+
+    SamplingPoint(Vector2<f32>),
 }
 
 impl Default for Parameter {


### PR DESCRIPTION
This PR adds support for 2-dimensional blend spaces. Blend space allows you to blend any number of animations using a single sampling 2d-vector parameter. They're especially useful for locomotion animations when you need to blend multiple animations into one depending on speed and direction of a character. An example of blend spaces could be found in Unreal Engine [docs](https://docs.unrealengine.com/4.27/en-US/AnimatingObjects/SkeletalMeshAnimation/Blendspaces/Overview/)