### PR TITLE
Changed sidebar to be inspector in the view dropdown menu

### DIFF
--- a/editor/src/menu/view.rs
+++ b/editor/src/menu/view.rs
@@ -11,7 +11,7 @@ use fyrox::{
 
 pub struct ViewMenu {
     pub menu: Handle<UiNode>,
-    sidebar: Handle<UiNode>,
+    inspector: Handle<UiNode>,
     world_viewer: Handle<UiNode>,
     asset_browser: Handle<UiNode>,
     light_panel: Handle<UiNode>,
@@ -32,7 +32,7 @@ fn switch_window_state(window: Handle<UiNode>, ui: &UserInterface, center: bool)
 
 impl ViewMenu {
     pub fn new(ctx: &mut BuildContext) -> Self {
-        let sidebar;
+        let inspector;
         let asset_browser;
         let world_viewer;
         let light_panel;
@@ -44,8 +44,8 @@ impl ViewMenu {
             "View",
             vec![
                 {
-                    sidebar = create_menu_item("Sidebar", vec![], ctx);
-                    sidebar
+                    inspector = create_menu_item("Inspector", vec![], ctx);
+                    inspector
                 },
                 {
                     asset_browser = create_menu_item("Asset Browser", vec![], ctx);
@@ -81,7 +81,7 @@ impl ViewMenu {
 
         Self {
             menu,
-            sidebar,
+            inspector,
             world_viewer,
             asset_browser,
             light_panel,
@@ -100,7 +100,7 @@ impl ViewMenu {
                 switch_window_state(panels.light_panel, ui, true);
             } else if message.destination() == self.world_viewer {
                 switch_window_state(panels.world_outliner_window, ui, false);
-            } else if message.destination() == self.sidebar {
+            } else if message.destination() == self.inspector {
                 switch_window_state(panels.inspector_window, ui, false);
             } else if message.destination() == self.log_panel {
                 switch_window_state(panels.log_panel, ui, false);


### PR DESCRIPTION
This pull request is focused on changing the "Sidebar" option to "Inspector" as that is the title of the widget and what we seem to be calling that section in documentation shown here "https://fyrox-book.github.io/fyrox/ui/inspector.html". In addition it changes some of the variable syntax from "sidebar" to "inspector". 

Ultimately this is a fairly minor change that is focused on trying to make the text in the view drop down correspond to the widget involved and change the sidebar variable name to be the widget involved similar to other variables.