### PR TITLE
Terrain refactoring

### DIFF
--- a/editor/src/inspector/editors/mod.rs
+++ b/editor/src/inspector/editors/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     Message,
 };
 use fyrox::animation::machine::node::blendspace::{BlendSpace, BlendSpacePoint};
+use fyrox::scene::terrain::Chunk;
 use fyrox::{
     animation::{
         machine::{
@@ -251,6 +252,9 @@ pub fn make_property_editors_container(
     container.register_inheritable_inspectable::<OrthographicProjection>();
     container.register_inheritable_inspectable::<Transform>();
     container.register_inheritable_inspectable::<CsmOptions>();
+
+    container.register_inheritable_inspectable::<Chunk>();
+    container.register_inheritable_vec_collection::<Chunk>();
 
     container.register_inheritable_option::<ColorGradingLut>();
     container.register_inheritable_option::<Biquad>();

--- a/editor/src/inspector/handlers/node/mod.rs
+++ b/editor/src/inspector/handlers/node/mod.rs
@@ -20,15 +20,15 @@ impl SceneNodePropertyChangedHandler {
         &self,
         args: &PropertyChanged,
         handle: Handle<Node>,
-        node: &mut Node,
+        _node: &mut Node,
     ) -> Option<SceneCommand> {
         // Terrain is special and have its own commands for specific properties.
         if args.path() == Terrain::LAYERS && args.owner_type_id == TypeId::of::<Terrain>() {
             match args.value {
                 FieldKind::Collection(ref collection_changed) => match **collection_changed {
-                    CollectionChanged::Add(_) => Some(SceneCommand::new(
-                        AddTerrainLayerCommand::new(handle, node.as_terrain()),
-                    )),
+                    CollectionChanged::Add(_) => {
+                        Some(SceneCommand::new(AddTerrainLayerCommand::new(handle)))
+                    }
                     CollectionChanged::Remove(index) => Some(SceneCommand::new(
                         DeleteTerrainLayerCommand::new(handle, index),
                     )),

--- a/editor/src/interaction/terrain.rs
+++ b/editor/src/interaction/terrain.rs
@@ -115,11 +115,13 @@ impl BrushGizmo {
 }
 
 fn copy_layer_masks(terrain: &Terrain, layer: usize) -> Vec<Vec<u8>> {
-    terrain.layers()[layer]
-        .chunk_masks()
-        .iter()
-        .map(|mask| mask.data_ref().data().to_vec())
-        .collect()
+    let mut masks = Vec::new();
+
+    for chunk in terrain.chunks_ref() {
+        masks.push(chunk.layer_masks[layer].data_ref().data().to_vec());
+    }
+
+    masks
 }
 
 impl InteractionMode for TerrainInteractionMode {

--- a/editor/src/menu/create.rs
+++ b/editor/src/menu/create.rs
@@ -375,7 +375,6 @@ impl CreateEntityMenu {
                                     material: create_terrain_layer_material(),
                                     mask_property_name: "maskTexture".to_owned(),
                                 }])
-                                .with_height_map_resolution(4.0)
                                 .build_node(),
                         )
                     } else if message.destination() == self.create_decal {

--- a/editor/src/menu/create.rs
+++ b/editor/src/menu/create.rs
@@ -7,11 +7,12 @@ use crate::{
     scene::commands::graph::AddNodeCommand,
     Message, Mode,
 };
-use fyrox::core::algebra::Vector3;
-use fyrox::core::math::TriangleDefinition;
-use fyrox::utils::navmesh::Navmesh;
 use fyrox::{
-    core::{algebra::Matrix4, pool::Handle},
+    core::{
+        algebra::{Matrix4, Vector3},
+        math::TriangleDefinition,
+        pool::Handle,
+    },
     gui::{
         menu::MenuItemMessage, message::MessageDirection, message::UiMessage,
         widget::WidgetMessage, BuildContext, UiNode, UserInterface,
@@ -37,8 +38,9 @@ use fyrox::{
         pivot::PivotBuilder,
         sound::{listener::ListenerBuilder, SoundBuilder},
         sprite::SpriteBuilder,
-        terrain::{LayerDefinition, TerrainBuilder},
+        terrain::{Layer, TerrainBuilder},
     },
+    utils::navmesh::Navmesh,
 };
 use std::sync::mpsc::Sender;
 
@@ -371,7 +373,7 @@ impl CreateEntityMenu {
                     } else if message.destination() == self.create_terrain {
                         Some(
                             TerrainBuilder::new(BaseBuilder::new().with_name("Terrain"))
-                                .with_layers(vec![LayerDefinition {
+                                .with_layers(vec![Layer {
                                     material: create_terrain_layer_material(),
                                     mask_property_name: "maskTexture".to_owned(),
                                 }])

--- a/examples/terrain.rs
+++ b/examples/terrain.rs
@@ -31,7 +31,7 @@ use fyrox::{
         base::BaseBuilder,
         light::{point::PointLightBuilder, BaseLightBuilder},
         node::{Node, TypeUuidProvider},
-        terrain::{Brush, BrushMode, BrushShape, LayerDefinition, TerrainBuilder},
+        terrain::{Brush, BrushMode, BrushShape, Layer, TerrainBuilder},
         transform::TransformBuilder,
         Scene,
     },
@@ -93,7 +93,7 @@ impl SceneLoader {
         // Add terrain.
         let terrain = TerrainBuilder::new(BaseBuilder::new())
             .with_layers(vec![
-                LayerDefinition {
+                Layer {
                     material: {
                         let mut material = Material::standard_terrain();
                         setup_layer_material(
@@ -106,7 +106,7 @@ impl SceneLoader {
                     },
                     mask_property_name: "maskTexture".to_string(),
                 },
-                LayerDefinition {
+                Layer {
                     material: {
                         let mut material = Material::standard_terrain();
                         setup_layer_material(

--- a/fyrox-core/src/variable.rs
+++ b/fyrox-core/src/variable.rs
@@ -204,6 +204,11 @@ impl<T> InheritableVariable<T> {
             .insert(VariableFlags::MODIFIED | VariableFlags::NEED_SYNC);
     }
 
+    /// Deconstructs the variable and returns the wrapped value.
+    pub fn take(self) -> T {
+        self.value
+    }
+
     fn mark_modified_and_need_sync(&mut self) {
         self.flags
             .get_mut()

--- a/src/renderer/batch.rs
+++ b/src/renderer/batch.rs
@@ -191,7 +191,7 @@ impl BatchStorage {
                 }
             } else if let Some(terrain) = node.cast::<Terrain>() {
                 for (layer_index, layer) in terrain.layers().iter().enumerate() {
-                    for (chunk_index, chunk) in terrain.chunks_ref().iter().enumerate() {
+                    for chunk in terrain.chunks_ref().iter() {
                         let data = chunk.data();
                         let data_key = data.key();
 
@@ -199,7 +199,7 @@ impl BatchStorage {
                         match material.set_property(
                             &ImmutableString::new(&layer.mask_property_name),
                             PropertyValue::Sampler {
-                                value: Some(layer.chunk_masks[chunk_index].clone()),
+                                value: Some(chunk.layer_masks[layer_index].clone()),
                                 fallback: Default::default(),
                             },
                         ) {

--- a/src/resource/texture.rs
+++ b/src/resource/texture.rs
@@ -1382,6 +1382,11 @@ impl TextureData {
     pub fn modify(&mut self) -> TextureDataRefMut<'_> {
         TextureDataRefMut { texture: self }
     }
+
+    /// Returns `true` if the texture is serializing its content, `false` - otherwise.
+    pub fn is_serializing_content(&self) -> bool {
+        self.serialize_content
+    }
 }
 
 /// A special reference holder that provides mutable access to content of the

--- a/src/scene/graph/physics.rs
+++ b/src/scene/graph/physics.rs
@@ -607,7 +607,11 @@ fn make_heightfield(terrain: &Terrain) -> SharedShape {
             Dyn(ncols as usize),
             data,
         )),
-        Vector3::new(terrain.chunk_size().x, 1.0, terrain.chunk_size().y),
+        Vector3::new(
+            terrain.chunk_size().x * terrain.width_chunks().len() as f32,
+            1.0,
+            terrain.chunk_size().y * terrain.length_chunks().len() as f32,
+        ),
     )
 }
 

--- a/src/scene/graph/physics.rs
+++ b/src/scene/graph/physics.rs
@@ -575,34 +575,30 @@ fn make_heightfield(terrain: &Terrain) -> SharedShape {
     assert!(!terrain.chunks_ref().is_empty());
 
     // Count rows and columns.
-    let first_chunk = terrain.chunks_ref().first().unwrap();
-    let chunk_size = Vector2::new(
-        first_chunk.width_point_count(),
-        first_chunk.length_point_count(),
-    );
-    let nrows = chunk_size.y * terrain.length_chunk_count() as u32;
-    let ncols = chunk_size.x * terrain.width_chunk_count() as u32;
+    let height_map_size = terrain.height_map_size();
+    let nrows = height_map_size.y * terrain.length_chunks().len() as u32;
+    let ncols = height_map_size.x * terrain.width_chunks().len() as u32;
 
     // Combine height map of each chunk into bigger one.
     let mut ox = 0;
     let mut oz = 0;
     let mut data = vec![0.0; (nrows * ncols) as usize];
-    for cz in 0..terrain.length_chunk_count() {
-        for cx in 0..terrain.width_chunk_count() {
-            let chunk = &terrain.chunks_ref()[cz * terrain.width_chunk_count() + cx];
+    for cz in 0..terrain.length_chunks().len() {
+        for cx in 0..terrain.width_chunks().len() {
+            let chunk = &terrain.chunks_ref()[cz * terrain.width_chunks().len() + cx];
 
-            for z in 0..chunk.length_point_count() {
-                for x in 0..chunk.width_point_count() {
-                    let value = chunk.heightmap()[(z * chunk.width_point_count() + x) as usize];
-                    data[((ox + x) * nrows + oz + z) as usize] = value;
+            for iy in 0..height_map_size.y {
+                for ix in 0..height_map_size.x {
+                    let value = chunk.heightmap()[(iy * height_map_size.x + ix) as usize];
+                    data[((ox + ix) * nrows + oz + iy) as usize] = value;
                 }
             }
 
-            ox += chunk_size.x;
+            ox += height_map_size.x;
         }
 
         ox = 0;
-        oz += chunk_size.y;
+        oz += height_map_size.y;
     }
 
     SharedShape::heightfield(
@@ -611,7 +607,7 @@ fn make_heightfield(terrain: &Terrain) -> SharedShape {
             Dyn(ncols as usize),
             data,
         )),
-        Vector3::new(terrain.width(), 1.0, terrain.length()),
+        Vector3::new(terrain.chunk_size().x, 1.0, terrain.chunk_size().y),
     )
 }
 

--- a/src/scene/terrain.rs
+++ b/src/scene/terrain.rs
@@ -324,7 +324,8 @@ impl Terrain {
         self.chunk_size
     }
 
-    pub fn set_chunk_size(&mut self, chunk_size: Vector2<f32>) {
+    pub fn set_chunk_size(&mut self, chunk_size: Vector2<f32>) -> Vector2<f32> {
+        let old = self.chunk_size;
         self.chunk_size = chunk_size;
 
         // Re-position each chunk according to its position on the grid.
@@ -342,6 +343,7 @@ impl Terrain {
                 chunk.rebuild_geometry();
             }
         }
+        old
     }
 
     pub fn width_chunks(&self) -> Range<i32> {
@@ -356,24 +358,32 @@ impl Terrain {
         self.height_map_size
     }
 
-    pub fn set_height_map_size(&mut self, height_map_size: Vector2<u32>) {
+    pub fn set_height_map_size(&mut self, height_map_size: Vector2<u32>) -> Vector2<u32> {
+        let old = self.height_map_size;
         self.resize_height_maps(height_map_size);
+        old
     }
 
     pub fn mask_size(&self) -> Vector2<u32> {
         self.mask_size
     }
 
-    pub fn set_mask_size(&mut self, mask_size: Vector2<u32>) {
+    pub fn set_mask_size(&mut self, mask_size: Vector2<u32>) -> Vector2<u32> {
+        let old = self.mask_size;
         self.resize_masks(mask_size);
+        old
     }
 
-    pub fn set_width_chunks(&mut self, chunks: Range<i32>) {
+    pub fn set_width_chunks(&mut self, chunks: Range<i32>) -> Range<i32> {
+        let old = self.width_chunks.clone();
         self.resize(chunks, self.length_chunks.clone());
+        old
     }
 
-    pub fn set_length_chunks(&mut self, chunks: Range<i32>) {
+    pub fn set_length_chunks(&mut self, chunks: Range<i32>) -> Range<i32> {
+        let old = self.length_chunks.clone();
         self.resize(self.width_chunks.clone(), chunks);
+        old
     }
 
     pub fn resize(&mut self, width_chunks: Range<i32>, length_chunks: Range<i32>) {

--- a/src/scene/terrain.rs
+++ b/src/scene/terrain.rs
@@ -957,8 +957,10 @@ impl Terrain {
                 }
             }
 
-            for height in &mut heightmap {
-                *height /= max;
+            if max != 0.0 {
+                for height in &mut heightmap {
+                    *height /= max;
+                }
             }
 
             let heightmap_image = ImageBuffer::<Luma<f32>, Vec<f32>>::from_vec(

--- a/src/scene/terrain.rs
+++ b/src/scene/terrain.rs
@@ -329,6 +329,22 @@ impl Terrain {
 
     pub fn set_chunk_size(&mut self, chunk_size: Vector2<f32>) {
         self.chunk_size = chunk_size;
+
+        // Re-position each chunk according to its position on the grid.
+        for (z, iy) in self.length_chunks.clone().zip(0..self.length_chunks.len()) {
+            for (x, ix) in self.width_chunks.clone().zip(0..self.width_chunks.len()) {
+                let position = Vector3::new(
+                    x as f32 * self.chunk_size.x,
+                    0.0,
+                    z as f32 * self.chunk_size.y,
+                );
+
+                let chunk = &mut self.chunks[iy * self.width_chunks.len() + ix];
+                chunk.position = position;
+                chunk.physical_size = chunk_size;
+                chunk.rebuild_geometry();
+            }
+        }
     }
 
     pub fn width_chunks(&self) -> Range<i32> {

--- a/src/scene/terrain.rs
+++ b/src/scene/terrain.rs
@@ -272,7 +272,8 @@ pub struct Terrain {
     #[reflect(
         min_value = 1.0,
         step = 1.0,
-        description = "Size of the blending mask per chunk, in pixels. Warning: any change to this value will result in resampling!"
+        description = "Size of the blending mask per chunk, in pixels. Warning: any change to this value will result in resampling!",
+        setter = "set_mask_size"
     )]
     mask_size: Vector2<u32>,
 

--- a/src/scene/terrain.rs
+++ b/src/scene/terrain.rs
@@ -766,12 +766,11 @@ impl Terrain {
         for chunk in self.chunks.iter_mut() {
             for mask in chunk.layer_masks.iter_mut() {
                 let mut data = mask.data_ref();
-                let mut data_mut = data.modify();
 
                 let mask_image = ImageBuffer::<Luma<u8>, Vec<u8>>::from_vec(
                     self.mask_size.x,
                     self.mask_size.y,
-                    data_mut.data().to_vec(),
+                    data.data().to_vec(),
                 )
                 .unwrap();
 
@@ -783,10 +782,19 @@ impl Terrain {
                 );
 
                 let new_mask = resampled_mask_image.into_raw();
+                let new_mask_texture = Texture::from_bytes(
+                    TextureKind::Rectangle {
+                        width: new_size.x,
+                        height: new_size.y,
+                    },
+                    data.pixel_kind(),
+                    new_mask,
+                    true,
+                )
+                .unwrap();
 
-                for (mask_pixel, new_mask_pixel) in data_mut.data_mut().iter_mut().zip(new_mask) {
-                    *mask_pixel = new_mask_pixel;
-                }
+                drop(data);
+                *mask = new_mask_texture;
             }
         }
 

--- a/src/scene/terrain.rs
+++ b/src/scene/terrain.rs
@@ -675,7 +675,7 @@ impl Terrain {
     /// in the same terrain, however it seems to not have practical usage, so try to keep
     /// equal layer count per each chunk in your terrains.
     pub fn add_layer(&mut self, layer: Layer, masks: Vec<Texture>) {
-        self.insert_layer(layer, masks, self.layers.len().saturating_sub(1))
+        self.insert_layer(layer, masks, self.layers.len())
     }
 
     pub fn remove_layer(&mut self, layer_index: usize) -> (Layer, Vec<Texture>) {

--- a/src/scene/terrain.rs
+++ b/src/scene/terrain.rs
@@ -369,7 +369,11 @@ impl Visit for Terrain {
     fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
         let mut region = visitor.enter_region(name)?;
 
-        let mut version = 0u8;
+        let mut version = if region.is_reading() {
+            0u8
+        } else {
+            self.version
+        };
         let _ = version.visit("Version", &mut region);
 
         match version {


### PR DESCRIPTION
This PR refactors terrain, so it can be resizable:

1) It is now possible to change terrain size at runtime - you can add chunks from any side. This way any terrain can be extended from any side to add new parts of your game world
2) Height map size can be changed - it will be resampled to the new size.
3) Layer blending mask size can now be changed - like the height map, it will be resampled to the new size as well.