### PR TITLE
Method to link nodes while keeping child's global position and rotation.

### DIFF
--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -450,6 +450,25 @@ impl Graph {
         self.pool[parent].children.push(child);
     }
 
+    /// Links specified child with specified parent while keeping the
+    /// child's global position and rotation.
+    #[inline]
+    pub fn link_nodes_keep_global_position_rotation (
+        &mut self,
+        child: Handle<Node>,
+        parent: Handle<Node>) {
+        let parent_transform_inv = self.pool[parent]
+            .global_transform().try_inverse().unwrap_or_default();
+        let child_transform = self.pool[child].global_transform();
+        let relative_transform = parent_transform_inv * child_transform;
+        let local_position = relative_transform.position();
+        let local_rotation = UnitQuaternion::from_matrix(
+            &relative_transform.basis());
+        self.pool[child].local_transform_mut().set_position(local_position);
+        self.pool[child].local_transform_mut().set_rotation(local_rotation);
+        self.link_nodes(child, parent);
+    }
+
     /// Unlinks specified node from its parent and attaches it to root graph node.
     #[inline]
     pub fn unlink_node(&mut self, node_handle: Handle<Node>) {

--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -464,8 +464,8 @@ impl Graph {
         let local_position = relative_transform.position();
         let local_rotation = UnitQuaternion::from_matrix(
             &relative_transform.basis());
-        self.pool[child].local_transform_mut().set_position(local_position);
-        self.pool[child].local_transform_mut().set_rotation(local_rotation);
+        self.pool[child].local_transform_mut().set_position(local_position)
+            .set_rotation(local_rotation);
         self.link_nodes(child, parent);
     }
 


### PR DESCRIPTION
This method is helpful on senerio like putting a nail into a wood, or arrow hitting a target and stuck into the target.