### PR TITLE
log location changed; fixing editor

### DIFF
--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -161,7 +161,7 @@ use fyrox::{
     gui::message::UiMessage,
     plugin::{Plugin, PluginConstructor, PluginContext, PluginRegistrationContext},
     scene::{Scene, loader::AsyncSceneLoader},
-    utils::log::Log
+    core::log::Log
 };
 
 pub struct GameConstructor;


### PR DESCRIPTION
Change made due to [logger changing location](https://github.com/FyroxEngine/Fyrox/commit/0a05c4eecd9952c208905bb6d70f936350a43a02). The editor fails without this change.