### PR TITLE
Ability to open multiple scenes in the editor

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1654,6 +1654,8 @@ impl Editor {
                 }
             }
         }
+
+        self.sync_to_model();
     }
 
     fn load_scene(&mut self, scene_path: PathBuf) {

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -403,15 +403,146 @@ impl SaveSceneConfirmationDialog {
     }
 }
 
+pub struct EditorSceneEntry {
+    pub scene: EditorScene,
+    pub command_stack: CommandStack,
+    pub interaction_modes: Vec<Box<dyn InteractionMode>>,
+    pub current_interaction_mode: Option<InteractionModeKind>,
+}
+
+impl EditorSceneEntry {
+    fn set_interaction_mode(&mut self, engine: &mut Engine, mode: Option<InteractionModeKind>) {
+        if self.current_interaction_mode != mode {
+            // Deactivate current first.
+            if let Some(current_mode) = self.current_interaction_mode {
+                self.interaction_modes[current_mode as usize].deactivate(&self.scene, engine);
+            }
+
+            self.current_interaction_mode = mode;
+
+            // Activate new.
+            if let Some(current_mode) = self.current_interaction_mode {
+                self.interaction_modes[current_mode as usize].activate(&self.scene, engine);
+            }
+        }
+    }
+
+    fn on_drop(&mut self, engine: &mut Engine) {
+        for mut interaction_mode in self.interaction_modes.drain(..) {
+            interaction_mode.on_drop(engine);
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct SceneContainer {
+    scenes: Vec<EditorSceneEntry>,
+    current_scene: Option<usize>,
+}
+
+impl SceneContainer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn current_scene_entry_ref(&self) -> Option<&EditorSceneEntry> {
+        self.current_scene.and_then(|i| self.scenes.get(i))
+    }
+
+    pub fn current_scene_entry_mut(&mut self) -> Option<&mut EditorSceneEntry> {
+        self.current_scene.and_then(|i| self.scenes.get_mut(i))
+    }
+
+    pub fn current_editor_scene_ref(&self) -> Option<&EditorScene> {
+        self.current_scene_entry_ref().map(|e| &e.scene)
+    }
+
+    pub fn current_editor_scene_mut(&mut self) -> Option<&mut EditorScene> {
+        self.current_scene_entry_mut().map(|e| &mut e.scene)
+    }
+
+    pub fn len(&self) -> usize {
+        self.scenes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.scenes.is_empty()
+    }
+
+    pub fn add_scene_and_select(
+        &mut self,
+        scene: Scene,
+        path: Option<PathBuf>,
+        engine: &mut Engine,
+        settings: &Settings,
+        message_sender: MessageSender,
+        scene_viewer: &SceneViewer,
+    ) {
+        self.current_scene = Some(self.scenes.len());
+
+        let editor_scene = EditorScene::from_native_scene(scene, engine, path, settings);
+
+        let mut entry = EditorSceneEntry {
+            interaction_modes: vec![
+                Box::new(SelectInteractionMode::new(
+                    scene_viewer.frame(),
+                    scene_viewer.selection_frame(),
+                    message_sender.clone(),
+                )),
+                Box::new(MoveInteractionMode::new(
+                    &editor_scene,
+                    engine,
+                    message_sender.clone(),
+                )),
+                Box::new(ScaleInteractionMode::new(
+                    &editor_scene,
+                    engine,
+                    message_sender.clone(),
+                )),
+                Box::new(RotateInteractionMode::new(
+                    &editor_scene,
+                    engine,
+                    message_sender.clone(),
+                )),
+                Box::new(EditNavmeshMode::new(
+                    &editor_scene,
+                    engine,
+                    message_sender.clone(),
+                )),
+                Box::new(TerrainInteractionMode::new(
+                    &editor_scene,
+                    engine,
+                    message_sender.clone(),
+                )),
+            ],
+            scene: editor_scene,
+            command_stack: CommandStack::new(false),
+            current_interaction_mode: None,
+        };
+
+        entry.set_interaction_mode(engine, Some(InteractionModeKind::Move));
+
+        self.scenes.push(entry);
+    }
+
+    pub fn take_current_scene(&mut self) -> Option<EditorSceneEntry> {
+        let scene = self.current_scene.map(|s| self.scenes.remove(s));
+        self.current_scene = if self.scenes.is_empty() {
+            None
+        } else {
+            // TODO: Maybe set it to the previous one?
+            Some(0)
+        };
+        scene
+    }
+}
+
 pub struct Editor {
     game_loop_data: GameLoopData,
     engine: Engine,
-    scene: Option<EditorScene>,
-    command_stack: CommandStack,
+    scenes: SceneContainer,
     message_sender: MessageSender,
     message_receiver: Receiver<Message>,
-    interaction_modes: Vec<Box<dyn InteractionMode>>,
-    current_interaction_mode: Option<InteractionModeKind>,
     world_viewer: WorldViewer,
     root_grid: Handle<UiNode>,
     scene_viewer: SceneViewer,
@@ -716,17 +847,14 @@ impl Editor {
 
         let material_editor = MaterialEditor::new(&mut engine);
 
-        let mut editor = Self {
+        let editor = Self {
             animation_editor,
             engine,
             navmesh_panel,
             scene_viewer,
-            scene: None,
-            command_stack: CommandStack::new(false),
+            scenes: SceneContainer::new(),
             message_sender,
             message_receiver,
-            interaction_modes: Default::default(),
-            current_interaction_mode: None,
             world_viewer: world_outliner,
             root_grid,
             menu,
@@ -761,8 +889,6 @@ impl Editor {
             audio_preview_panel,
             doc_window,
         };
-
-        editor.set_interaction_mode(Some(InteractionModeKind::Move));
 
         if let Some(data) = startup_data {
             editor.message_sender.send(Message::Configure {
@@ -829,66 +955,25 @@ impl Editor {
         }
     }
 
-    fn set_scene(&mut self, mut scene: Scene, path: Option<PathBuf>) {
+    fn add_scene(&mut self, mut scene: Scene, path: Option<PathBuf>) {
         self.try_leave_preview_mode();
 
-        // Discard previous scene.
-        if let Some(previous_editor_scene) = self.scene.as_ref() {
-            self.engine.scenes.remove(previous_editor_scene.scene);
-        }
-        self.scene = None;
         self.sync_to_model();
         self.poll_ui_messages();
-
-        for mut interaction_mode in self.interaction_modes.drain(..) {
-            interaction_mode.on_drop(&mut self.engine);
-        }
 
         // Setup new one.
         scene.render_target = Some(TextureResource::new_render_target(0, 0));
         self.scene_viewer
             .set_render_target(&self.engine.user_interface, scene.render_target.clone());
 
-        let editor_scene =
-            EditorScene::from_native_scene(scene, &mut self.engine, path.clone(), &self.settings);
-
-        self.interaction_modes = vec![
-            Box::new(SelectInteractionMode::new(
-                self.scene_viewer.frame(),
-                self.scene_viewer.selection_frame(),
-                self.message_sender.clone(),
-            )),
-            Box::new(MoveInteractionMode::new(
-                &editor_scene,
-                &mut self.engine,
-                self.message_sender.clone(),
-            )),
-            Box::new(ScaleInteractionMode::new(
-                &editor_scene,
-                &mut self.engine,
-                self.message_sender.clone(),
-            )),
-            Box::new(RotateInteractionMode::new(
-                &editor_scene,
-                &mut self.engine,
-                self.message_sender.clone(),
-            )),
-            Box::new(EditNavmeshMode::new(
-                &editor_scene,
-                &mut self.engine,
-                self.message_sender.clone(),
-            )),
-            Box::new(TerrainInteractionMode::new(
-                &editor_scene,
-                &mut self.engine,
-                self.message_sender.clone(),
-            )),
-        ];
-
-        self.command_stack = CommandStack::new(false);
-        self.scene = Some(editor_scene);
-
-        self.set_interaction_mode(Some(InteractionModeKind::Move));
+        self.scenes.add_scene_and_select(
+            scene,
+            path.clone(),
+            &mut self.engine,
+            &self.settings,
+            self.message_sender.clone(),
+            &self.scene_viewer,
+        );
 
         if let Some(path) = path.as_ref() {
             if !self.settings.recent.scenes.contains(path) {
@@ -916,25 +1001,6 @@ impl Editor {
             .as_initialized_mut()
             .renderer
             .flush();
-    }
-
-    fn set_interaction_mode(&mut self, mode: Option<InteractionModeKind>) {
-        let engine = &mut self.engine;
-        if let Some(editor_scene) = self.scene.as_ref() {
-            if self.current_interaction_mode != mode {
-                // Deactivate current first.
-                if let Some(current_mode) = self.current_interaction_mode {
-                    self.interaction_modes[current_mode as usize].deactivate(editor_scene, engine);
-                }
-
-                self.current_interaction_mode = mode;
-
-                // Activate new.
-                if let Some(current_mode) = self.current_interaction_mode {
-                    self.interaction_modes[current_mode as usize].activate(editor_scene, engine);
-                }
-            }
-        }
     }
 
     pub fn handle_hotkeys(&mut self, message: &UiMessage) {
@@ -974,8 +1040,8 @@ impl Editor {
             } else if hot_key == key_bindings.load_scene {
                 sender.send(Message::OpenLoadSceneDialog);
             } else if hot_key == key_bindings.save_scene {
-                if let Some(scene) = self.scene.as_ref() {
-                    if let Some(path) = scene.path.as_ref() {
+                if let Some(entry) = self.scenes.current_scene_entry_ref() {
+                    if let Some(path) = entry.scene.path.as_ref() {
                         self.message_sender.send(Message::SaveScene(path.clone()));
                     } else {
                         // Scene wasn't saved yet, open Save As dialog.
@@ -989,7 +1055,7 @@ impl Editor {
                     }
                 }
             } else if hot_key == key_bindings.copy_selection {
-                if let Some(editor_scene) = self.scene.as_mut() {
+                if let Some(editor_scene) = self.scenes.current_editor_scene_mut() {
                     if let Selection::Graph(graph_selection) = &editor_scene.selection {
                         editor_scene.clipboard.fill_from_selection(
                             graph_selection,
@@ -999,7 +1065,7 @@ impl Editor {
                     }
                 }
             } else if hot_key == key_bindings.paste {
-                if let Some(editor_scene) = self.scene.as_mut() {
+                if let Some(editor_scene) = self.scenes.current_editor_scene_mut() {
                     if !editor_scene.clipboard.is_empty() {
                         sender.do_scene_command(PasteCommand::new(editor_scene.scene_content_root));
                     }
@@ -1009,7 +1075,7 @@ impl Editor {
             } else if hot_key == key_bindings.close_scene {
                 sender.send(Message::CloseScene);
             } else if hot_key == key_bindings.remove_selection {
-                if let Some(editor_scene) = self.scene.as_mut() {
+                if let Some(editor_scene) = self.scenes.current_editor_scene_mut() {
                     if !editor_scene.selection.is_empty() {
                         if let Selection::Graph(_) = editor_scene.selection {
                             sender.send(Message::DoSceneCommand(make_delete_selection_command(
@@ -1020,7 +1086,7 @@ impl Editor {
                     }
                 }
             } else if hot_key == key_bindings.focus {
-                if let Some(editor_scene) = self.scene.as_mut() {
+                if let Some(editor_scene) = self.scenes.current_editor_scene_mut() {
                     if let Selection::Graph(selection) = &editor_scene.selection {
                         if let Some(first) = selection.nodes.first() {
                             sender.send(Message::FocusObject(*first));
@@ -1041,17 +1107,19 @@ impl Editor {
 
         let engine = &mut self.engine;
 
+        let mut current_scene_entry = self.scenes.current_scene_entry_mut();
+
         self.save_scene_dialog.handle_ui_message(
             message,
             &self.message_sender,
-            self.scene.as_ref(),
+            current_scene_entry.as_ref().map(|e| &e.scene),
         );
         self.configurator.handle_ui_message(message, engine);
         self.menu.handle_ui_message(
             message,
             MenuContext {
                 engine,
-                editor_scene: self.scene.as_mut(),
+                editor_scene: current_scene_entry.as_mut().map(|e| &mut e.scene),
                 panels: Panels {
                     inspector_window: self.inspector.window,
                     world_outliner_window: self.world_viewer.window,
@@ -1085,23 +1153,35 @@ impl Editor {
             engine.serialization_context.clone(),
             engine.resource_manager.clone(),
         );
-        self.scene_viewer.handle_ui_message(
-            message,
-            engine,
-            self.scene.as_mut(),
-            self.current_interaction_mode
-                .and_then(|i| self.interaction_modes.get_mut(i as usize)),
-            &self.settings,
-            &self.mode,
-        );
+        {
+            let (scene, interaction_mode) =
+                current_scene_entry.as_mut().map_or((None, None), |e| {
+                    (
+                        Some(&mut e.scene),
+                        e.current_interaction_mode
+                            .and_then(|i| e.interaction_modes.get_mut(i as usize)),
+                    )
+                });
+            self.scene_viewer.handle_ui_message(
+                message,
+                engine,
+                scene,
+                interaction_mode,
+                &self.settings,
+                &self.mode,
+            );
+        }
+
         self.animation_editor.handle_ui_message(
             message,
-            self.scene.as_mut(),
+            current_scene_entry.as_mut().map(|e| &mut e.scene),
             engine,
             &self.message_sender,
         );
 
-        if let Some(editor_scene) = self.scene.as_mut() {
+        if let Some(current_scene_entry) = current_scene_entry {
+            let editor_scene = &mut current_scene_entry.scene;
+
             self.particle_system_control_panel
                 .handle_ui_message(message, editor_scene, engine);
             self.camera_control_panel
@@ -1121,8 +1201,8 @@ impl Editor {
             self.inspector
                 .handle_ui_message(message, editor_scene, engine, &self.message_sender);
 
-            if let Some(current_im) = self.current_interaction_mode {
-                self.interaction_modes[current_im as usize].handle_ui_message(
+            if let Some(current_im) = current_scene_entry.current_interaction_mode {
+                current_scene_entry.interaction_modes[current_im as usize].handle_ui_message(
                     message,
                     editor_scene,
                     engine,
@@ -1138,27 +1218,25 @@ impl Editor {
             self.material_editor
                 .handle_ui_message(message, engine, &self.message_sender);
 
-            if let Some(MessageBoxMessage::Close(result)) = message.data::<MessageBoxMessage>() {
+            if let Some(MessageBoxMessage::Close(result)) = message.data() {
                 if message.destination() == self.exit_message_box {
                     match result {
                         MessageBoxResult::No => {
                             self.message_sender.send(Message::Exit { force: true });
                         }
                         MessageBoxResult::Yes => {
-                            if let Some(scene) = self.scene.as_ref() {
-                                if let Some(path) = scene.path.as_ref() {
-                                    self.message_sender.send(Message::SaveScene(path.clone()));
-                                    self.message_sender.send(Message::Exit { force: true });
-                                } else {
-                                    // Scene wasn't saved yet, open Save As dialog.
-                                    engine
-                                        .user_interface
-                                        .send_message(WindowMessage::open_modal(
-                                            self.save_file_selector,
-                                            MessageDirection::ToWidget,
-                                            true,
-                                        ));
-                                }
+                            if let Some(path) = editor_scene.path.as_ref() {
+                                self.message_sender.send(Message::SaveScene(path.clone()));
+                                self.message_sender.send(Message::Exit { force: true });
+                            } else {
+                                // Scene wasn't saved yet, open Save As dialog.
+                                engine
+                                    .user_interface
+                                    .send_message(WindowMessage::open_modal(
+                                        self.save_file_selector,
+                                        MessageDirection::ToWidget,
+                                        true,
+                                    ));
                             }
                         }
                         _ => {}
@@ -1178,7 +1256,7 @@ impl Editor {
     }
 
     fn set_play_mode(&mut self) {
-        if let Some(scene) = self.scene.as_ref() {
+        if let Some(scene) = self.scenes.current_editor_scene_ref() {
             if let Some(path) = scene.path.as_ref().cloned() {
                 self.save_current_scene(path.clone());
 
@@ -1227,7 +1305,7 @@ impl Editor {
 
     fn set_build_mode(&mut self) {
         if let Mode::Edit = self.mode {
-            if let Some(scene) = self.scene.as_ref() {
+            if let Some(scene) = self.scenes.current_editor_scene_ref() {
                 if scene.path.is_some() {
                     let mut process = std::process::Command::new("cargo");
                     process
@@ -1292,12 +1370,16 @@ impl Editor {
 
         let engine = &mut self.engine;
 
-        self.menu
-            .sync_to_model(self.scene.as_ref(), &mut engine.user_interface);
+        self.menu.sync_to_model(
+            self.scenes.current_editor_scene_ref(),
+            &mut engine.user_interface,
+        );
 
-        self.scene_viewer.sync_to_model(self.scene.as_ref(), engine);
+        self.scene_viewer
+            .sync_to_model(self.scenes.current_editor_scene_ref(), engine);
 
-        if let Some(editor_scene) = self.scene.as_mut() {
+        if let Some(current_scene_entry) = self.scenes.current_scene_entry_mut() {
+            let editor_scene = &mut current_scene_entry.scene;
             self.animation_editor.sync_to_model(editor_scene, engine);
             self.absm_editor.sync_to_model(editor_scene, engine);
             self.scene_settings.sync_to_model(editor_scene, engine);
@@ -1308,7 +1390,7 @@ impl Editor {
             self.audio_panel.sync_to_model(editor_scene, engine);
             self.navmesh_panel.sync_to_model(engine, editor_scene);
             self.command_stack_viewer.sync_to_model(
-                &mut self.command_stack,
+                &mut current_scene_entry.command_stack,
                 &SceneContext {
                     scene: &mut engine.scenes[editor_scene.scene],
                     message_sender: self.message_sender.clone(),
@@ -1325,7 +1407,7 @@ impl Editor {
     }
 
     fn post_update(&mut self) {
-        if let Some(scene) = self.scene.as_mut() {
+        if let Some(scene) = self.scenes.current_editor_scene_mut() {
             self.world_viewer
                 .post_update(scene, &mut self.engine, &self.settings);
         }
@@ -1333,7 +1415,7 @@ impl Editor {
 
     fn handle_resize(&mut self) {
         let engine = &mut self.engine;
-        if let Some(editor_scene) = self.scene.as_ref() {
+        if let Some(editor_scene) = self.scenes.current_editor_scene_ref() {
             let scene = &mut engine.scenes[editor_scene.scene];
 
             // Create new render target if preview frame has changed its size.
@@ -1355,8 +1437,10 @@ impl Editor {
 
     fn do_scene_command(&mut self, command: SceneCommand) -> bool {
         let engine = &mut self.engine;
-        if let Some(editor_scene) = self.scene.as_mut() {
-            self.command_stack.do_command(
+        if let Some(current_scene_entry) = self.scenes.current_scene_entry_mut() {
+            let editor_scene = &mut current_scene_entry.scene;
+
+            current_scene_entry.command_stack.do_command(
                 command.into_inner(),
                 SceneContext {
                     scene: &mut engine.scenes[editor_scene.scene],
@@ -1377,8 +1461,10 @@ impl Editor {
 
     fn undo_scene_command(&mut self) -> bool {
         let engine = &mut self.engine;
-        if let Some(editor_scene) = self.scene.as_mut() {
-            self.command_stack.undo(SceneContext {
+        if let Some(current_scene_entry) = self.scenes.current_scene_entry_mut() {
+            let editor_scene = &mut current_scene_entry.scene;
+
+            current_scene_entry.command_stack.undo(SceneContext {
                 scene: &mut engine.scenes[editor_scene.scene],
                 message_sender: self.message_sender.clone(),
                 editor_scene,
@@ -1396,8 +1482,10 @@ impl Editor {
 
     fn redo_scene_command(&mut self) -> bool {
         let engine = &mut self.engine;
-        if let Some(editor_scene) = self.scene.as_mut() {
-            self.command_stack.redo(SceneContext {
+        if let Some(current_scene_entry) = self.scenes.current_scene_entry_mut() {
+            let editor_scene = &mut current_scene_entry.scene;
+
+            current_scene_entry.command_stack.redo(SceneContext {
                 scene: &mut engine.scenes[editor_scene.scene],
                 message_sender: self.message_sender.clone(),
                 editor_scene,
@@ -1415,8 +1503,10 @@ impl Editor {
 
     fn clear_scene_command_stack(&mut self) -> bool {
         let engine = &mut self.engine;
-        if let Some(editor_scene) = self.scene.as_mut() {
-            self.command_stack.clear(SceneContext {
+        if let Some(current_scene_entry) = self.scenes.current_scene_entry_mut() {
+            let editor_scene = &mut current_scene_entry.scene;
+
+            current_scene_entry.command_stack.clear(SceneContext {
                 scene: &mut engine.scenes[editor_scene.scene],
                 message_sender: self.message_sender.clone(),
                 editor_scene,
@@ -1430,7 +1520,7 @@ impl Editor {
     }
 
     fn try_leave_preview_mode(&mut self) {
-        if let Some(editor_scene) = self.scene.as_mut() {
+        if let Some(editor_scene) = self.scenes.current_editor_scene_mut() {
             let engine = &mut self.engine;
             self.particle_system_control_panel
                 .leave_preview_mode(editor_scene, engine);
@@ -1449,7 +1539,7 @@ impl Editor {
         self.try_leave_preview_mode();
 
         let engine = &mut self.engine;
-        if let Some(editor_scene) = self.scene.as_mut() {
+        if let Some(editor_scene) = self.scenes.current_editor_scene_mut() {
             if !self.settings.recent.scenes.contains(&path) {
                 self.settings.recent.scenes.push(path.clone());
                 self.menu
@@ -1493,7 +1583,7 @@ impl Editor {
             Ok(loader) => {
                 let scene = block_on(loader.finish());
 
-                self.set_scene(scene, Some(scene_path));
+                self.add_scene(scene, Some(scene_path));
             }
             Err(e) => {
                 Log::err(e.to_string());
@@ -1505,7 +1595,7 @@ impl Editor {
         let engine = &mut self.engine;
         if force {
             self.exit = true;
-        } else if is_scene_needs_to_be_saved(self.scene.as_ref()) {
+        } else if is_scene_needs_to_be_saved(self.scenes.current_editor_scene_ref()) {
             engine.user_interface.send_message(MessageBoxMessage::open(
                 self.exit_message_box,
                 MessageDirection::ToWidget,
@@ -1521,8 +1611,8 @@ impl Editor {
         self.try_leave_preview_mode();
 
         let engine = &mut self.engine;
-        if let Some(editor_scene) = self.scene.take() {
-            engine.scenes.remove(editor_scene.scene);
+        if let Some(editor_scene_entry) = self.scenes.take_current_scene() {
+            engine.scenes.remove(editor_scene_entry.scene.scene);
 
             // Preview frame has scene frame texture assigned, it must be cleared explicitly,
             // otherwise it will show last rendered frame in preview which is not what we want.
@@ -1543,11 +1633,11 @@ impl Editor {
 
         scene.ambient_lighting_color = Color::opaque(200, 200, 200);
 
-        self.set_scene(scene, None);
+        self.add_scene(scene, None);
     }
 
     fn configure(&mut self, working_directory: PathBuf) {
-        assert!(self.scene.is_none());
+        assert!(self.scenes.is_empty());
 
         self.asset_browser.clear_preview(&mut self.engine);
 
@@ -1590,7 +1680,7 @@ impl Editor {
     }
 
     fn select_object(&mut self, type_id: TypeId, handle: ErasedHandle) {
-        if let Some(scene) = self.scene.as_ref() {
+        if let Some(scene) = self.scenes.current_editor_scene_ref() {
             let new_selection = if type_id == TypeId::of::<Node>() {
                 if self.engine.scenes[scene.scene]
                     .graph
@@ -1694,7 +1784,7 @@ impl Editor {
         self.material_editor.update(&mut self.engine);
         self.asset_browser.update(&mut self.engine);
 
-        if let Some(scene) = self.scene.as_ref() {
+        if let Some(scene) = self.scenes.current_editor_scene_ref() {
             self.animation_editor.update(scene, &self.engine);
             self.audio_preview_panel.update(scene, &self.engine);
         }
@@ -1718,7 +1808,7 @@ impl Editor {
                 self.save_scene_dialog
                     .handle_message(&message, &self.message_sender);
 
-                if let Some(editor_scene) = self.scene.as_ref() {
+                if let Some(editor_scene) = self.scenes.current_editor_scene_ref() {
                     self.inspector.handle_message(
                         &message,
                         editor_scene,
@@ -1727,7 +1817,7 @@ impl Editor {
                     );
                 }
 
-                if let Some(editor_scene) = self.scene.as_mut() {
+                if let Some(editor_scene) = self.scenes.current_editor_scene_mut() {
                     self.particle_system_control_panel.handle_message(
                         &message,
                         editor_scene,
@@ -1773,7 +1863,10 @@ impl Editor {
                         needs_sync = true;
                     }
                     Message::SetInteractionMode(mode_kind) => {
-                        self.set_interaction_mode(Some(mode_kind))
+                        if let Some(editor_scene_entry) = self.scenes.current_scene_entry_mut() {
+                            editor_scene_entry
+                                .set_interaction_mode(&mut self.engine, Some(mode_kind));
+                        }
                     }
                     Message::Exit { force } => self.exit(force),
                     Message::CloseScene => {
@@ -1810,13 +1903,13 @@ impl Editor {
                         self.select_object(type_id, handle);
                     }
                     Message::FocusObject(handle) => {
-                        if let Some(editor_scene) = self.scene.as_ref() {
+                        if let Some(editor_scene) = self.scenes.current_editor_scene_ref() {
                             let scene = &mut self.engine.scenes[editor_scene.scene];
                             editor_scene.camera_controller.fit_object(scene, handle);
                         }
                     }
                     Message::SetEditorCameraProjection(projection) => {
-                        if let Some(editor_scene) = self.scene.as_ref() {
+                        if let Some(editor_scene) = self.scenes.current_editor_scene_ref() {
                             editor_scene.camera_controller.set_projection(
                                 &mut self.engine.scenes[editor_scene.scene].graph,
                                 projection,
@@ -1848,7 +1941,7 @@ impl Editor {
                         self.try_save_selection_as_prefab(path);
                     }
                     Message::SyncNodeHandleName { view, handle } => {
-                        if let Some(editor_scene) = self.scene.as_ref() {
+                        if let Some(editor_scene) = self.scenes.current_editor_scene_ref() {
                             let scene = &self.engine.scenes[editor_scene.scene];
                             self.engine.user_interface.send_message(
                                 HandlePropertyEditorMessage::name(
@@ -1885,7 +1978,9 @@ impl Editor {
 
         self.handle_resize();
 
-        if let Some(editor_scene) = self.scene.as_mut() {
+        if let Some(editor_scene_entry) = self.scenes.current_scene_entry_mut() {
+            let editor_scene = &mut editor_scene_entry.scene;
+
             editor_scene.update(&mut self.engine, dt, &self.settings);
 
             self.absm_editor.update(editor_scene, &mut self.engine);
@@ -1911,8 +2006,8 @@ impl Editor {
                 }
             }
 
-            if let Some(mode) = self.current_interaction_mode {
-                self.interaction_modes[mode as usize].update(
+            if let Some(mode) = editor_scene_entry.current_interaction_mode {
+                editor_scene_entry.interaction_modes[mode as usize].update(
                     editor_scene,
                     editor_scene.camera_controller.camera,
                     &mut self.engine,
@@ -1923,7 +2018,7 @@ impl Editor {
     }
 
     fn try_save_selection_as_prefab(&self, path: PathBuf) {
-        if let Some(editor_scene) = self.scene.as_ref() {
+        if let Some(editor_scene) = self.scenes.current_editor_scene_ref() {
             let source_scene = &self.engine.scenes[editor_scene.scene];
             let mut dest_scene = Scene::new();
             if let Selection::Graph(ref graph_selection) = editor_scene.selection {
@@ -1994,7 +2089,7 @@ impl Editor {
                 // Temporarily disable cameras in currently edited scene. This is needed to prevent any
                 // scene camera to interfere with the editor camera.
                 let mut camera_state = Vec::new();
-                if let Some(editor_scene) = self.scene.as_ref() {
+                if let Some(editor_scene) = self.scenes.current_editor_scene_ref() {
                     let scene = &mut self.engine.scenes[editor_scene.scene];
                     let has_preview_camera =
                         scene.graph.is_valid_handle(editor_scene.preview_camera);
@@ -2015,7 +2110,7 @@ impl Editor {
                 self.engine.render().unwrap();
 
                 // Revert state of the cameras.
-                if let Some(scene) = self.scene.as_ref() {
+                if let Some(scene) = self.scenes.current_editor_scene_ref() {
                     for (handle, enabled) in camera_state {
                         self.engine.scenes[scene.scene].graph[handle]
                             .as_camera_mut()
@@ -2105,7 +2200,7 @@ fn update(editor: &mut Editor, control_flow: &mut ControlFlow) {
         editor.game_loop_data.lag -= FIXED_TIMESTEP;
 
         let mut switches = FxHashMap::default();
-        if let Some(scene) = editor.scene.as_ref() {
+        if let Some(scene) = editor.scenes.current_editor_scene_ref() {
             switches.insert(scene.scene, scene.graph_switches.clone());
         }
 

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1639,7 +1639,7 @@ impl Editor {
         self.try_leave_preview_mode();
 
         let engine = &mut self.engine;
-        if let Some(editor_scene_entry) = self.scenes.take_scene(scene) {
+        if let Some(mut editor_scene_entry) = self.scenes.take_scene(scene) {
             engine.scenes.remove(editor_scene_entry.editor_scene.scene);
 
             // Preview frame has scene frame texture assigned, it must be cleared explicitly,
@@ -1649,6 +1649,8 @@ impl Editor {
             // Set default title scene
             self.scene_viewer
                 .set_title(&engine.user_interface, "Scene Preview".to_string());
+
+            editor_scene_entry.on_drop(engine);
 
             true
         } else {

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -486,6 +486,10 @@ impl SceneContainer {
         self.scenes.get_mut(index)
     }
 
+    pub fn current_scene_index(&self) -> Option<usize> {
+        self.current_scene
+    }
+
     pub fn set_current_scene(&mut self, scene: Handle<Scene>) -> bool {
         if let Some(index) = self
             .scenes

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1022,15 +1022,6 @@ impl Editor {
             }
         }
 
-        self.scene_viewer.set_title(
-            &self.engine.user_interface,
-            format!(
-                "Scene Preview - {}",
-                path.map_or("Unnamed Scene".to_string(), |p| p
-                    .to_string_lossy()
-                    .to_string())
-            ),
-        );
         self.scene_viewer
             .reset_camera_projection(&self.engine.user_interface);
         self.engine

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -547,10 +547,10 @@ impl SceneContainer {
                 Box::new(TerrainInteractionMode::new(
                     &editor_scene,
                     engine,
-                    message_sender.clone(),
+                    message_sender,
                 )),
             ],
-            editor_scene: editor_scene,
+            editor_scene,
             command_stack: CommandStack::new(false),
             current_interaction_mode: None,
         };

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -314,20 +314,18 @@ impl SaveSceneConfirmationDialog {
         self.scene = scene;
         self.action = action;
 
-        ui.send_message(MessageBoxMessage::open(
-            self.save_message_box,
-            MessageDirection::ToWidget,
-            None,
-            Some(format!(
-                "There are unsaved changes in the {} scene. \
+        if let Some(entry) = scenes.entry_by_scene_handle(self.scene) {
+            ui.send_message(MessageBoxMessage::open(
+                self.save_message_box,
+                MessageDirection::ToWidget,
+                None,
+                Some(format!(
+                    "There are unsaved changes in the {} scene. \
                 Do you wish to save them before continue?",
-                scenes
-                    .entry_by_scene_handle(self.scene)
-                    .and_then(|s| s.editor_scene.path.as_ref().map(|p| p.as_path()))
-                    .unwrap_or_else(|| Path::new("Unnamed Scene"))
-                    .display(),
-            )),
-        ));
+                    entry.editor_scene.name(),
+                )),
+            ));
+        }
     }
 
     pub fn handle_ui_message(
@@ -1689,15 +1687,9 @@ impl Editor {
                 MessageDirection::ToWidget,
                 None,
                 Some(format!(
-                    "There are unsaved changes in the {} scene. Do you wish to save them before exit?",
-                    first_unsaved
-                        .editor_scene
-                        .path
-                        .as_ref()
-                        .map(|s| s.as_path())
-                        .unwrap_or_else(|| Path::new("Unnamed Scene"))
-                        .to_string_lossy()
-                        .to_string()
+                    "There are unsaved changes in the {} scene. \
+                    Do you wish to save them before exit?",
+                    first_unsaved.editor_scene.name()
                 )),
             ));
         } else {

--- a/editor/src/menu/file.rs
+++ b/editor/src/menu/file.rs
@@ -252,23 +252,19 @@ impl FileMenu {
                     self.open_load_file_selector(&mut engine.user_interface);
                 }
             } else if message.destination() == self.close_scene {
-                if is_scene_needs_to_be_saved(editor_scene.as_deref()) {
-                    sender.send(Message::OpenSaveSceneConfirmationDialog(
-                        SaveSceneConfirmationDialogAction::CloseScene,
-                    ));
-                } else {
-                    sender.send(Message::CloseScene);
+                if let Some(editor_scene) = editor_scene.as_ref() {
+                    if is_scene_needs_to_be_saved(Some(editor_scene)) {
+                        sender.send(Message::OpenSaveSceneConfirmationDialog(
+                            SaveSceneConfirmationDialogAction::CloseScene(editor_scene.scene),
+                        ));
+                    } else {
+                        sender.send(Message::CloseScene(editor_scene.scene));
+                    }
                 }
             } else if message.destination() == self.exit {
                 sender.send(Message::Exit { force: false });
             } else if message.destination() == self.new_scene {
-                if is_scene_needs_to_be_saved(editor_scene.as_deref()) {
-                    sender.send(Message::OpenSaveSceneConfirmationDialog(
-                        SaveSceneConfirmationDialogAction::MakeNewScene,
-                    ));
-                } else {
-                    sender.send(Message::NewScene);
-                }
+                sender.send(Message::NewScene);
             } else if message.destination() == self.configure {
                 if editor_scene.is_none() {
                     engine

--- a/editor/src/menu/file.rs
+++ b/editor/src/menu/file.rs
@@ -1,8 +1,8 @@
-use crate::message::MessageSender;
 use crate::{
     make_save_file_selector, make_scene_file_filter,
     menu::{create_menu_item, create_menu_item_shortcut, create_root_menu_item},
-    scene::{is_scene_needs_to_be_saved, EditorScene},
+    message::MessageSender,
+    scene::EditorScene,
     settings::{recent::RecentFiles, Settings, SettingsWindow},
     Engine, Message, Mode, Panels, SaveSceneConfirmationDialogAction,
 };
@@ -203,30 +203,40 @@ impl FileMenu {
 
         if let Some(FileSelectorMessage::Commit(path)) = message.data::<FileSelectorMessage>() {
             if message.destination() == self.save_file_selector {
-                sender.send(Message::SaveScene(path.to_owned()));
+                if let Some(editor_scene) = editor_scene {
+                    sender.send(Message::SaveScene {
+                        scene: editor_scene.scene,
+                        path: path.to_owned(),
+                    });
+                }
             } else if message.destination() == self.load_file_selector {
                 sender.send(Message::LoadScene(path.to_owned()));
             }
         } else if let Some(MenuItemMessage::Click) = message.data::<MenuItemMessage>() {
             if message.destination() == self.save {
-                if let Some(scene_path) = editor_scene.as_ref().and_then(|s| s.path.as_ref()) {
-                    sender.send(Message::SaveScene(scene_path.clone()));
-                } else {
-                    // If scene wasn't saved yet - open Save As window.
-                    engine
-                        .user_interface
-                        .send_message(WindowMessage::open_modal(
-                            self.save_file_selector,
-                            MessageDirection::ToWidget,
-                            true,
-                        ));
-                    engine
-                        .user_interface
-                        .send_message(FileSelectorMessage::path(
-                            self.save_file_selector,
-                            MessageDirection::ToWidget,
-                            std::env::current_dir().unwrap(),
-                        ));
+                if let Some(editor_scene) = editor_scene {
+                    if let Some(scene_path) = editor_scene.path.as_ref() {
+                        sender.send(Message::SaveScene {
+                            scene: editor_scene.scene,
+                            path: scene_path.clone(),
+                        });
+                    } else {
+                        // If scene wasn't saved yet - open Save As window.
+                        engine
+                            .user_interface
+                            .send_message(WindowMessage::open_modal(
+                                self.save_file_selector,
+                                MessageDirection::ToWidget,
+                                true,
+                            ));
+                        engine
+                            .user_interface
+                            .send_message(FileSelectorMessage::path(
+                                self.save_file_selector,
+                                MessageDirection::ToWidget,
+                                std::env::current_dir().unwrap(),
+                            ));
+                    }
                 }
             } else if message.destination() == self.save_as {
                 engine
@@ -244,19 +254,16 @@ impl FileMenu {
                         std::env::current_dir().unwrap(),
                     ));
             } else if message.destination() == self.load {
-                if is_scene_needs_to_be_saved(editor_scene.as_deref()) {
-                    sender.send(Message::OpenSaveSceneConfirmationDialog(
-                        SaveSceneConfirmationDialogAction::OpenLoadSceneDialog,
-                    ));
-                } else {
-                    self.open_load_file_selector(&mut engine.user_interface);
-                }
+                self.open_load_file_selector(&mut engine.user_interface);
             } else if message.destination() == self.close_scene {
                 if let Some(editor_scene) = editor_scene.as_ref() {
-                    if is_scene_needs_to_be_saved(Some(editor_scene)) {
-                        sender.send(Message::OpenSaveSceneConfirmationDialog(
-                            SaveSceneConfirmationDialogAction::CloseScene(editor_scene.scene),
-                        ));
+                    if editor_scene.need_save() {
+                        sender.send(Message::OpenSaveSceneConfirmationDialog {
+                            scene: editor_scene.scene,
+                            action: SaveSceneConfirmationDialogAction::CloseScene(
+                                editor_scene.scene,
+                            ),
+                        });
                     } else {
                         sender.send(Message::CloseScene(editor_scene.scene));
                     }
@@ -293,13 +300,7 @@ impl FileMenu {
                 .position(|i| *i == message.destination())
             {
                 if let Some(recent_file_path) = settings.recent.scenes.get(recent_file) {
-                    if is_scene_needs_to_be_saved(editor_scene.as_deref()) {
-                        sender.send(Message::OpenSaveSceneConfirmationDialog(
-                            SaveSceneConfirmationDialogAction::LoadScene(recent_file_path.clone()),
-                        ));
-                    } else {
-                        sender.send(Message::LoadScene(recent_file_path.clone()));
-                    }
+                    sender.send(Message::LoadScene(recent_file_path.clone()));
                 }
             }
         }

--- a/editor/src/message.rs
+++ b/editor/src/message.rs
@@ -22,7 +22,10 @@ pub enum Message {
     SelectionChanged {
         old_selection: Selection,
     },
-    SaveScene(PathBuf),
+    SaveScene {
+        scene: Handle<Scene>,
+        path: PathBuf,
+    },
     LoadScene(PathBuf),
     CloseScene(Handle<Scene>),
     SetInteractionMode(InteractionModeKind),
@@ -55,7 +58,10 @@ pub enum Message {
     SwitchMode,
     OpenLoadSceneDialog,
     OpenSaveSceneDialog,
-    OpenSaveSceneConfirmationDialog(SaveSceneConfirmationDialogAction),
+    OpenSaveSceneConfirmationDialog {
+        scene: Handle<Scene>,
+        action: SaveSceneConfirmationDialogAction,
+    },
     SetBuildProfile(BuildProfile),
     SaveSelectionAsPrefab(PathBuf),
     SyncNodeHandleName {

--- a/editor/src/message.rs
+++ b/editor/src/message.rs
@@ -9,7 +9,7 @@ use fyrox::{
     },
     gui::UiNode,
     material::SharedMaterial,
-    scene::{camera::Projection, node::Node},
+    scene::{camera::Projection, node::Node, Scene},
 };
 use std::{any::TypeId, path::PathBuf, sync::mpsc::Sender};
 
@@ -24,7 +24,7 @@ pub enum Message {
     },
     SaveScene(PathBuf),
     LoadScene(PathBuf),
-    CloseScene,
+    CloseScene(Handle<Scene>),
     SetInteractionMode(InteractionModeKind),
     Configure {
         working_directory: PathBuf,
@@ -47,6 +47,7 @@ pub enum Message {
         type_id: TypeId,
         handle: ErasedHandle,
     },
+    SetCurrentScene(Handle<Scene>),
     FocusObject(Handle<Node>),
     SetEditorCameraProjection(Projection),
     SwitchToBuildMode,

--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -109,6 +109,13 @@ impl EditorScene {
         self.has_unsaved_changes || self.path.is_none()
     }
 
+    pub fn name(&self) -> String {
+        self.path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| String::from("Unnamed Scene"))
+    }
+
     #[allow(clippy::redundant_clone)] // false positive
     pub fn save(
         &mut self,

--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -48,12 +48,6 @@ pub struct EditorScene {
     pub graph_switches: GraphUpdateSwitches,
 }
 
-pub fn is_scene_needs_to_be_saved(editor_scene: Option<&EditorScene>) -> bool {
-    editor_scene
-        .as_ref()
-        .map_or(false, |s| s.has_unsaved_changes || s.path.is_none())
-}
-
 impl EditorScene {
     pub fn from_native_scene(
         mut scene: Scene,
@@ -109,6 +103,10 @@ impl EditorScene {
             scene.clone(self.scene_content_root, &mut |node, _| node != editor_root);
 
         pure_scene
+    }
+
+    pub fn need_save(&self) -> bool {
+        self.has_unsaved_changes || self.path.is_none()
     }
 
     #[allow(clippy::redundant_clone)] // false positive

--- a/editor/src/scene_viewer.rs
+++ b/editor/src/scene_viewer.rs
@@ -1,4 +1,3 @@
-use crate::scene::is_scene_needs_to_be_saved;
 use crate::{
     camera::PickingOptions, gui::make_dropdown_list_option,
     gui::make_dropdown_list_option_with_height, load_image, message::MessageSender,
@@ -576,12 +575,13 @@ impl SceneViewer {
                 match msg {
                     TabControlMessage::CloseTab(tab_index) => {
                         if let Some(entry) = scenes.try_get(*tab_index) {
-                            if is_scene_needs_to_be_saved(Some(&entry.editor_scene)) {
-                                self.sender.send(Message::OpenSaveSceneConfirmationDialog(
-                                    SaveSceneConfirmationDialogAction::CloseScene(
+                            if entry.editor_scene.need_save() {
+                                self.sender.send(Message::OpenSaveSceneConfirmationDialog {
+                                    scene: entry.editor_scene.scene,
+                                    action: SaveSceneConfirmationDialogAction::CloseScene(
                                         entry.editor_scene.scene,
                                     ),
-                                ));
+                                });
                             } else {
                                 self.sender
                                     .send(Message::CloseScene(entry.editor_scene.scene));

--- a/editor/src/scene_viewer.rs
+++ b/editor/src/scene_viewer.rs
@@ -1,12 +1,12 @@
-use crate::message::MessageSender;
 use crate::{
     camera::PickingOptions, gui::make_dropdown_list_option,
-    gui::make_dropdown_list_option_with_height, load_image, send_sync_message,
-    settings::keys::KeyBindings, utils::enable_widget, AddModelCommand, AssetItem, AssetKind,
-    BuildProfile, ChangeSelectionCommand, CommandGroup, DropdownListBuilder, EditorScene,
-    GraphSelection, InteractionMode, InteractionModeKind, Message, Mode, SceneCommand, Selection,
-    SetMeshTextureCommand, Settings,
+    gui::make_dropdown_list_option_with_height, load_image, message::MessageSender,
+    send_sync_message, settings::keys::KeyBindings, utils::enable_widget, AddModelCommand,
+    AssetItem, AssetKind, BuildProfile, ChangeSelectionCommand, CommandGroup, DropdownListBuilder,
+    EditorScene, GraphSelection, InteractionMode, InteractionModeKind, Message, Mode, SceneCommand,
+    Selection, SetMeshTextureCommand, Settings,
 };
+use fyrox::gui::tab_control::{TabControlBuilder, TabDefinition};
 use fyrox::{
     asset::ResourceStateRef,
     core::{
@@ -78,6 +78,7 @@ pub struct SceneViewer {
     global_position_display: Handle<UiNode>,
     preview_instance: Option<PreviewInstance>,
     no_scene_reminder: Handle<UiNode>,
+    tab_control: Handle<UiNode>,
 }
 
 fn make_interaction_mode_button(
@@ -361,6 +362,7 @@ impl SceneViewer {
         .with_wrap(WrapMode::Word)
         .build(ctx);
 
+        let tab_control;
         let window = WindowBuilder::new(WidgetBuilder::new())
             .can_close(false)
             .can_minimize(false)
@@ -374,15 +376,26 @@ impl SceneViewer {
                                 WidgetBuilder::new()
                                     .on_row(1)
                                     .with_child({
-                                        frame = ImageBuilder::new(
-                                            WidgetBuilder::new()
-                                                .with_child(no_scene_reminder)
-                                                .with_child(interaction_mode_panel)
-                                                .with_allow_drop(true),
-                                        )
-                                        .with_flip(true)
-                                        .build(ctx);
-                                        frame
+                                        tab_control = TabControlBuilder::new(WidgetBuilder::new())
+                                            .with_tab(TabDefinition {
+                                                header: TextBuilder::new(WidgetBuilder::new())
+                                                    .with_text("Scene")
+                                                    .build(ctx),
+                                                content: {
+                                                    frame = ImageBuilder::new(
+                                                        WidgetBuilder::new()
+                                                            .with_child(no_scene_reminder)
+                                                            .with_child(interaction_mode_panel)
+                                                            .with_allow_drop(true),
+                                                    )
+                                                    .with_flip(true)
+                                                    .build(ctx);
+                                                    frame
+                                                },
+                                                can_be_closed: true,
+                                            })
+                                            .build(ctx);
+                                        tab_control
                                     })
                                     .with_child(
                                         CanvasBuilder::new(WidgetBuilder::new().with_child({
@@ -438,6 +451,7 @@ impl SceneViewer {
             preview_instance: None,
             stop,
             no_scene_reminder,
+            tab_control,
         }
     }
 }

--- a/editor/src/scene_viewer.rs
+++ b/editor/src/scene_viewer.rs
@@ -804,18 +804,22 @@ impl SceneViewer {
                             .unwrap()
                             != entry.editor_scene.scene
                     }) {
-                        let header = TextBuilder::new(
-                            WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
-                        )
-                        .with_text(
-                            entry
-                                .editor_scene
-                                .path
-                                .as_ref()
-                                .map(|p| p.to_string_lossy().to_string())
-                                .unwrap_or_else(|| String::from("Unnamed Scene")),
-                        )
-                        .build(&mut engine.user_interface.build_ctx());
+                        let header =
+                            TextBuilder::new(WidgetBuilder::new().with_margin(Thickness {
+                                left: 4.0,
+                                top: 2.0,
+                                right: 4.0,
+                                bottom: 2.0,
+                            }))
+                            .with_text(
+                                entry
+                                    .editor_scene
+                                    .path
+                                    .as_ref()
+                                    .map(|p| p.to_string_lossy().to_string())
+                                    .unwrap_or_else(|| String::from("Unnamed Scene")),
+                            )
+                            .build(&mut engine.user_interface.build_ctx());
 
                         send_sync_message(
                             &engine.user_interface,
@@ -874,6 +878,19 @@ impl SceneViewer {
         // Then sync to the current scene.
         if let Some(editor_scene) = scenes.current_editor_scene_ref() {
             let scene = &engine.scenes[editor_scene.scene];
+
+            self.set_title(
+                &engine.user_interface,
+                format!(
+                    "Scene Preview - {}",
+                    editor_scene
+                        .path
+                        .as_ref()
+                        .map_or("Unnamed Scene".to_string(), |p| p
+                            .to_string_lossy()
+                            .to_string())
+                ),
+            );
 
             self.set_render_target(&engine.user_interface, scene.render_target.clone());
 

--- a/fyrox-ui/src/tab_control.rs
+++ b/fyrox-ui/src/tab_control.rs
@@ -103,6 +103,8 @@ pub struct Tab {
     pub user_data: Option<TabUserData>,
     /// A handle of a node that is used to highlight tab's state.
     pub decorator: Handle<UiNode>,
+    /// Content of the tab-switching (header) button.
+    pub header_content: Handle<UiNode>,
 }
 
 /// The Tab Control handles the visibility of several tabs, only showing a single tab that the user has selected via the
@@ -322,6 +324,7 @@ impl Control for TabControl {
                             header_container: header.container,
                             user_data: definition.user_data.clone(),
                             decorator: header.decorator,
+                            header_content: header.content,
                         })
                     }
                 }
@@ -355,6 +358,7 @@ struct Header {
     button: Handle<UiNode>,
     close_button: Handle<UiNode>,
     decorator: Handle<UiNode>,
+    content: Handle<UiNode>,
 }
 
 impl Header {
@@ -404,6 +408,7 @@ impl Header {
             button,
             close_button,
             decorator,
+            content: tab_definition.header,
         }
     }
 }
@@ -501,6 +506,7 @@ impl TabControlBuilder {
                     header_container: header.container,
                     user_data: tab.user_data,
                     decorator: header.decorator,
+                    header_content: header.content,
                 })
                 .collect(),
             content_container,

--- a/fyrox-ui/src/tab_control.rs
+++ b/fyrox-ui/src/tab_control.rs
@@ -75,7 +75,10 @@ impl TabUserData {
 
 impl PartialEq for TabUserData {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq((&*self.0) as *const _, (&*other.0) as *const _)
+        std::ptr::eq(
+            (&*self.0) as *const _ as *const (),
+            (&*other.0) as *const _ as *const (),
+        )
     }
 }
 

--- a/fyrox-ui/src/tab_control.rs
+++ b/fyrox-ui/src/tab_control.rs
@@ -61,6 +61,16 @@ impl TabControlMessage {
 #[derive(Clone)]
 pub struct TabUserData(pub Rc<dyn Any>);
 
+impl TabUserData {
+    /// Creates new instance of the tab data.
+    pub fn new<T>(data: T) -> Self
+    where
+        T: Any,
+    {
+        Self(Rc::new(data))
+    }
+}
+
 impl PartialEq for TabUserData {
     fn eq(&self, other: &Self) -> bool {
         std::ptr::eq((&*self.0) as *const _, (&*other.0) as *const _)
@@ -283,6 +293,14 @@ impl Control for TabControl {
                         ));
 
                         ui.send_message(message.reverse());
+
+                        self.tabs.push(Tab {
+                            header_button: header.button,
+                            content: definition.content,
+                            close_button: header.close_button,
+                            header_container: header.container,
+                            user_data: definition.user_data.clone(),
+                        })
                     }
                 }
             }

--- a/fyrox-ui/src/tab_control.rs
+++ b/fyrox-ui/src/tab_control.rs
@@ -173,10 +173,7 @@ impl Control for TabControl {
 
         if let Some(ButtonMessage::Click) = message.data() {
             for (tab_index, tab) in self.tabs.iter().enumerate() {
-                if message.destination() == tab.header_button
-                    && tab.header_button.is_some()
-                    && tab.content.is_some()
-                {
+                if message.destination() == tab.header_button && tab.header_button.is_some() {
                     ui.send_message(TabControlMessage::active_tab(
                         self.handle,
                         MessageDirection::ToWidget,
@@ -248,7 +245,9 @@ impl TabControlBuilder {
         for (i, tab) in self.tabs.iter().enumerate() {
             // Hide everything but first tab content.
             if i > 0 {
-                ctx[tab.content].set_visibility(false);
+                if let Some(content) = ctx.try_get_node_mut(tab.content) {
+                    content.set_visibility(false);
+                }
             }
             content.push(tab.content);
         }


### PR DESCRIPTION
This PR adds an ability to open multiple scenes in the editor, each scene will have its own tab in the Scene Viewer. This should significantly improve usability in complex projects with many prefabs.