### PR TITLE
improve search in World Viewer

### DIFF
--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -21,6 +21,7 @@ toml = "0.7.0"
 strum = "0.25.0"
 strum_macros = "0.25.0"
 open = "5"
+rust-fuzzy-search = "0.1.1"
 
 [features]
 enable_profiler = ["fyrox/enable_profiler"]

--- a/editor/src/world/mod.rs
+++ b/editor/src/world/mod.rs
@@ -48,6 +48,7 @@ use fyrox::{
     },
     scene::{graph::Graph, node::Node, Scene},
 };
+use rust_fuzzy_search::fuzzy_compare;
 use std::{any::TypeId, cmp::Ordering, collections::HashMap};
 
 pub mod graph;
@@ -535,7 +536,8 @@ impl WorldViewer {
             let name = node_ref.cast::<SceneItem>().map(|i| i.name());
 
             if let Some(name) = name {
-                is_any_match |= name.to_lowercase().contains(filter);
+                is_any_match |= name.to_lowercase().contains(filter)
+                    || fuzzy_compare(filter, name.to_lowercase().as_str()) >= 0.33;
 
                 ui.send_message(WidgetMessage::visibility(
                     node,


### PR DESCRIPTION
Hi.
It fix for #372.
For example, now you get "Cylinder" for filters "cilinde", "culunder", "zylin" and so on.