### PR TITLE
Fixing Potential Double Free Issue

### DIFF
--- a/src/scene/mesh/buffer.rs
+++ b/src/scene/mesh/buffer.rs
@@ -508,7 +508,7 @@ impl Display for ValidationError {
 
 impl VertexBuffer {
     /// Creates new vertex buffer from provided data and with the given layout of the vertex type `T`.
-    pub fn new<T>(vertex_count: usize, mut data: Vec<T>) -> Result<Self, ValidationError>
+    pub fn new<T>(vertex_count: usize, data: Vec<T>) -> Result<Self, ValidationError>
     where
         T: VertexTrait,
     {

--- a/src/scene/mesh/buffer.rs
+++ b/src/scene/mesh/buffer.rs
@@ -514,7 +514,9 @@ impl VertexBuffer {
     {
         let length = data.len() * std::mem::size_of::<T>();
         let capacity = data.capacity() * std::mem::size_of::<T>();
-
+        if (length >= std::usize::MAX) || (capacity >= std::usize::MAX) {
+            return Err(ValidationError::);
+        }
         let bytes =
             unsafe { Vec::<u8>::from_raw_parts(data.as_mut_ptr() as *mut u8, length, capacity) };
 

--- a/src/scene/mesh/buffer.rs
+++ b/src/scene/mesh/buffer.rs
@@ -512,15 +512,11 @@ impl VertexBuffer {
     where
         T: VertexTrait,
     {
+        let mut data = std::mem::ManuallyDrop::new(data);
         let length = data.len() * std::mem::size_of::<T>();
         let capacity = data.capacity() * std::mem::size_of::<T>();
-        if (length >= std::usize::MAX) || (capacity >= std::usize::MAX) {
-            return Err(ValidationError::);
-        }
-        let bytes =
-            unsafe { Vec::<u8>::from_raw_parts(data.as_mut_ptr() as *mut u8, length, capacity) };
 
-        std::mem::forget(data);
+        let bytes = unsafe { Vec::<u8>::from_raw_parts(data.as_mut_ptr() as *mut u8, length, capacity) };
 
         let layout = T::layout();
 


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue. 

## Issue Description
https://github.com/FyroxEngine/Fyrox/blob/af36a53e01d3b75c203bfc33daee6f103ed0dc49/src/scene/mesh/buffer.rs#L515-L521
If a panic happens within `Vec::<u8>::from_raw_parts()`, the `std::mem::forget(data)` will create a double free vulnerability.

In Rust, `std::mem::forget` does not actually free the memory, instead it simply allows the memory to leak. This can lead to double free when the data object goes out of scope and its destructor is called automatically. The issue arises because, while `std::mem::forget(data)` prevents the destructor of data from being called, the Vec<u8> created from the raw parts still has its own destructor. When the Vec<u8> is dropped, it will free the memory, and then when data is dropped, it will attempt to free the same memory again, causing a double free.

The modification here `uses std::mem::ManuallyDrop` to wrap data. This ensures that data will not be automatically dropped when it goes out of scope, thus avoiding a double free scenario. With ManuallyDrop, we explicitly state that the data variable should not be dropped, thus avoiding any potential double free issues.