### PR TITLE
Handle<T>: Data race allowed on T

### DIFF
--- a/fyrox-core/src/pool.rs
+++ b/fyrox-core/src/pool.rs
@@ -200,8 +200,8 @@ pub struct Handle<T> {
     type_marker: PhantomData<T>,
 }
 
-unsafe impl<T> Send for Handle<T> {}
-unsafe impl<T> Sync for Handle<T> {}
+unsafe impl<T: Send> Send for Handle<T> {}
+unsafe impl<T: Sync> Sync for Handle<T> {}
 
 impl<T> Display for Handle<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`Handle<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.
https://github.com/FyroxEngine/Fyrox/blob/7f914495a85f95f9dc244c829be3ed94b2c8c098/fyrox-core/src/pool.rs#L203-L204