### PR TITLE
Add code actions on save in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,19 @@
 {
     "rust-analyzer.diagnostics.disabled": [
         "mismatched-arg-count"
-    ]
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll": true,
+        "source.organizeImports": true,
+    },
+    "files.trimTrailingWhitespace": true,
+    "files.trimFinalNewlines": true,
+    "[markdown]": {
+        "editor.formatOnSave": true,
+        "files.insertFinalNewline": true,
+    },
+    "[rust]": {
+        "editor.formatOnSave": true,
+        "files.insertFinalNewline": true,
+    }
 }


### PR DESCRIPTION
Hi.
Sometimes developers forget to format code before committing.
These settings will help avoid this problem for vscode users.