### PR TITLE
Context menu for `FileBrowser` widget

### DIFF
--- a/fyrox-ui/src/file_browser/menu.rs
+++ b/fyrox-ui/src/file_browser/menu.rs
@@ -1,0 +1,77 @@
+use crate::{
+    core::pool::Handle,
+    menu::{MenuItemBuilder, MenuItemContent},
+    message::{MessageDirection, UiMessage},
+    popup::{Placement, PopupBuilder, PopupMessage},
+    stack_panel::StackPanelBuilder,
+    widget::{WidgetBuilder, WidgetMessage},
+    BuildContext, RcUiNodeHandle, Thickness, UiNode, UserInterface,
+};
+use std::{cell::Cell, path::PathBuf};
+
+#[derive(Clone)]
+pub struct ItemContextMenu {
+    pub menu: RcUiNodeHandle,
+    pub delete: Handle<UiNode>,
+    pub make_folder: Handle<UiNode>,
+    pub placement_target: Cell<Handle<UiNode>>,
+}
+
+impl ItemContextMenu {
+    pub fn new(ctx: &mut BuildContext) -> Self {
+        let delete;
+        let make_folder;
+        let menu = PopupBuilder::new(WidgetBuilder::new().with_visibility(false))
+            .with_content(
+                StackPanelBuilder::new(
+                    WidgetBuilder::new()
+                        .with_width(120.0)
+                        .with_child({
+                            delete = MenuItemBuilder::new(
+                                WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
+                            )
+                            .with_content(MenuItemContent::text("Delete"))
+                            .build(ctx);
+                            delete
+                        })
+                        .with_child({
+                            make_folder = MenuItemBuilder::new(
+                                WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
+                            )
+                            .with_content(MenuItemContent::text("Make Folder"))
+                            .build(ctx);
+                            make_folder
+                        }),
+                )
+                .build(ctx),
+            )
+            .build(ctx);
+        let menu = RcUiNodeHandle::new(menu, ctx.sender());
+
+        Self {
+            menu,
+            delete,
+            make_folder,
+            placement_target: Default::default(),
+        }
+    }
+
+    pub fn preview_message(&self, ui: &UserInterface, message: &mut UiMessage) {
+        if let Some(PopupMessage::Placement(Placement::Cursor(target))) = message.data() {
+            if message.destination() == *self.menu {
+                self.placement_target.set(*target);
+
+                let item_path = ui
+                    .try_get_node(*target)
+                    .and_then(|n| n.user_data_ref::<PathBuf>())
+                    .unwrap();
+
+                ui.send_message(WidgetMessage::enabled(
+                    self.make_folder,
+                    MessageDirection::ToWidget,
+                    item_path.is_dir(),
+                ));
+            }
+        }
+    }
+}

--- a/fyrox-ui/src/file_browser/menu.rs
+++ b/fyrox-ui/src/file_browser/menu.rs
@@ -3,13 +3,16 @@ use crate::{
     draw::DrawingContext,
     menu::{MenuItemBuilder, MenuItemContent, MenuItemMessage},
     message::{MessageDirection, OsEvent, UiMessage},
+    messagebox::{MessageBoxBuilder, MessageBoxButtons, MessageBoxMessage, MessageBoxResult},
     popup::{Placement, Popup, PopupBuilder, PopupMessage},
     stack_panel::StackPanelBuilder,
     widget::{Widget, WidgetBuilder, WidgetMessage},
+    window::{WindowBuilder, WindowTitle},
     BuildContext, Control, NodeHandleMapping, Thickness, UiNode, UserInterface,
 };
 use std::{
     any::{Any, TypeId},
+    cell::Cell,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     sync::mpsc::Sender,
@@ -20,7 +23,7 @@ pub struct ItemContextMenu {
     pub popup: Popup,
     pub delete: Handle<UiNode>,
     pub make_folder: Handle<UiNode>,
-    pub delete_message_box: Handle<UiNode>,
+    pub delete_message_box: Cell<Handle<UiNode>>,
 }
 
 impl Deref for ItemContextMenu {
@@ -88,11 +91,25 @@ impl Control for ItemContextMenu {
         } else if let Some(MenuItemMessage::Click) = message.data() {
             if message.destination() == self.delete {
                 if let Some(item_path) = self.item_path(ui) {
-                    if item_path.is_dir() {
-                        Log::verify(std::fs::remove_dir_all(item_path));
-                    } else {
-                        Log::verify(std::fs::remove_file(item_path));
-                    }
+                    self.delete_message_box.set(
+                        MessageBoxBuilder::new(
+                            WindowBuilder::new(
+                                WidgetBuilder::new().with_width(250.0).with_height(100.0),
+                            )
+                            .with_title(WindowTitle::text("Confirm Action"))
+                            .open(false),
+                        )
+                        .with_text(format!("Delete {} file?", item_path.display()).as_str())
+                        .with_buttons(MessageBoxButtons::YesNo)
+                        .build(&mut ui.build_ctx()),
+                    );
+
+                    ui.send_message(MessageBoxMessage::open(
+                        self.delete_message_box.get(),
+                        MessageDirection::ToWidget,
+                        None,
+                        None,
+                    ));
                 }
             } else if message.destination() == self.make_folder {
                 // TODO
@@ -101,7 +118,28 @@ impl Control for ItemContextMenu {
     }
 
     fn preview_message(&self, ui: &UserInterface, message: &mut UiMessage) {
-        self.popup.preview_message(ui, message)
+        self.popup.preview_message(ui, message);
+
+        if let Some(MessageBoxMessage::Close(result)) = message.data() {
+            if message.destination() == self.delete_message_box.get() {
+                if let MessageBoxResult::Yes = *result {
+                    if let Some(item_path) = self.item_path(ui) {
+                        if item_path.is_dir() {
+                            Log::verify(std::fs::remove_dir_all(item_path));
+                        } else {
+                            Log::verify(std::fs::remove_file(item_path));
+                        }
+                    }
+                }
+
+                ui.send_message(WidgetMessage::remove(
+                    self.delete_message_box.get(),
+                    MessageDirection::ToWidget,
+                ));
+
+                self.delete_message_box.set(Handle::NONE);
+            }
+        }
     }
 
     fn handle_os_event(
@@ -118,31 +156,35 @@ impl ItemContextMenu {
     pub fn build(ctx: &mut BuildContext) -> Handle<UiNode> {
         let delete;
         let make_folder;
-        let popup = PopupBuilder::new(WidgetBuilder::new().with_visibility(false))
-            .with_content(
-                StackPanelBuilder::new(
-                    WidgetBuilder::new()
-                        .with_width(120.0)
-                        .with_child({
-                            delete = MenuItemBuilder::new(
-                                WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
-                            )
-                            .with_content(MenuItemContent::text("Delete"))
-                            .build(ctx);
-                            delete
-                        })
-                        .with_child({
-                            make_folder = MenuItemBuilder::new(
-                                WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
-                            )
-                            .with_content(MenuItemContent::text("Make Folder"))
-                            .build(ctx);
-                            make_folder
-                        }),
-                )
-                .build(ctx),
+        let popup = PopupBuilder::new(
+            WidgetBuilder::new()
+                .with_preview_messages(true)
+                .with_visibility(false),
+        )
+        .with_content(
+            StackPanelBuilder::new(
+                WidgetBuilder::new()
+                    .with_width(120.0)
+                    .with_child({
+                        delete = MenuItemBuilder::new(
+                            WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
+                        )
+                        .with_content(MenuItemContent::text("Delete"))
+                        .build(ctx);
+                        delete
+                    })
+                    .with_child({
+                        make_folder = MenuItemBuilder::new(
+                            WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
+                        )
+                        .with_content(MenuItemContent::text("Make Folder"))
+                        .build(ctx);
+                        make_folder
+                    }),
             )
-            .build_popup(ctx);
+            .build(ctx),
+        )
+        .build_popup(ctx);
 
         let menu = Self {
             popup,

--- a/fyrox-ui/src/file_browser/mod.rs
+++ b/fyrox-ui/src/file_browser/mod.rs
@@ -1014,7 +1014,7 @@ mod test {
             true,
             "./test/path1",
             "./test",
-            RcUiNodeHandle::new(Default::default(), ui.sender()),
+            RcUiNodeHandle::new(Handle::new(0, 1), ui.sender()),
             &mut ui,
         );
 

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -220,7 +220,9 @@ fn is_any_menu_item_contains_point(ui: &UserInterface, pt: Vector2<f32>) -> bool
 fn close_menu_chain(from: Handle<UiNode>, ui: &UserInterface) {
     let mut handle = from;
     while handle.is_some() {
-        if let Some((popup_handle, popup)) = ui.try_borrow_by_type_up::<Popup>(handle) {
+        let popup_handle = ui.find_by_criteria_up(handle, |n| n.has_component::<Popup>());
+
+        if let Some(popup) = ui.node(popup_handle).query_component::<Popup>() {
             ui.send_message(PopupMessage::close(
                 popup_handle,
                 MessageDirection::ToWidget,
@@ -231,6 +233,9 @@ fn close_menu_chain(from: Handle<UiNode>, ui: &UserInterface) {
                 .user_data_ref::<Handle<UiNode>>()
                 .cloned()
                 .unwrap_or_default();
+        } else {
+            // Prevent infinite loops.
+            break;
         }
     }
 }

--- a/fyrox-ui/src/popup.rs
+++ b/fyrox-ui/src/popup.rs
@@ -516,8 +516,9 @@ impl PopupBuilder {
         self
     }
 
-    /// Finishes building the [`Popup`] instance and adds to the user interface and returns its handle.
-    pub fn build(self, ctx: &mut BuildContext) -> Handle<UiNode> {
+    /// Builds the popup widget, but does not add it to the user interface. Could be useful if you're making your
+    /// own derived version of the popup.
+    pub fn build_popup(self, ctx: &mut BuildContext) -> Popup {
         let body = BorderBuilder::new(
             WidgetBuilder::new()
                 .with_background(BRUSH_PRIMARY)
@@ -527,7 +528,7 @@ impl PopupBuilder {
         .with_stroke_thickness(Thickness::uniform(1.0))
         .build(ctx);
 
-        let popup = Popup {
+        Popup {
             widget: self
                 .widget_builder
                 .with_child(body)
@@ -540,8 +541,12 @@ impl PopupBuilder {
             content: self.content,
             smart_placement: self.smart_placement,
             body,
-        };
+        }
+    }
 
+    /// Finishes building the [`Popup`] instance and adds to the user interface and returns its handle.
+    pub fn build(self, ctx: &mut BuildContext) -> Handle<UiNode> {
+        let popup = self.build_popup(ctx);
         ctx.add_node(UiNode::new(popup))
     }
 }

--- a/fyrox-ui/src/popup.rs
+++ b/fyrox-ui/src/popup.rs
@@ -94,6 +94,21 @@ pub enum Placement {
     },
 }
 
+impl Placement {
+    /// Returns a handle of the node to which this placement corresponds to.
+    pub fn target(&self) -> Handle<UiNode> {
+        match self {
+            Placement::LeftTop(target)
+            | Placement::RightTop(target)
+            | Placement::Center(target)
+            | Placement::LeftBottom(target)
+            | Placement::RightBottom(target)
+            | Placement::Cursor(target)
+            | Placement::Position { target, .. } => *target,
+        }
+    }
+}
+
 /// Popup is used to display other widgets in floating panel, that could lock input in self bounds.
 ///
 /// ## How to create


### PR DESCRIPTION
`FileBrowser` widget does not have any ability to rename/delete/make folders/etc. This PR aims to fix that by adding a context menu with the most common FS actions.