### PR TITLE
Use registered property editors to generate editors for collection items (`Vec<T>` + `[T; N]`)

### DIFF
--- a/editor/src/audio/mod.rs
+++ b/editor/src/audio/mod.rs
@@ -87,7 +87,7 @@ fn fetch_possible_parent_buses(
 fn audio_bus_effect_names(audio_bus: &AudioBus) -> Vec<String> {
     audio_bus
         .effects()
-        .map(|e| AsRef::<str>::as_ref(&**e).to_owned())
+        .map(|e| AsRef::<str>::as_ref(&*e).to_owned())
         .collect::<Vec<_>>()
 }
 

--- a/editor/src/audio/mod.rs
+++ b/editor/src/audio/mod.rs
@@ -87,7 +87,7 @@ fn fetch_possible_parent_buses(
 fn audio_bus_effect_names(audio_bus: &AudioBus) -> Vec<String> {
     audio_bus
         .effects()
-        .map(|e| AsRef::<str>::as_ref(&*e).to_owned())
+        .map(|e| AsRef::<str>::as_ref(e).to_owned())
         .collect::<Vec<_>>()
 }
 

--- a/editor/src/command/universal.rs
+++ b/editor/src/command/universal.rs
@@ -131,11 +131,11 @@ macro_rules! define_universal_commands {
                     field.as_list_mut(&mut |result| {
                         if let Some(list) = result {
                             if let Err(item) = list.reflect_push($self.item.take().unwrap()) {
-                                $self.item = Some(item);
                                 fyrox::core::log::Log::err(format!(
-                                    "Failed to push item to {} collection. Type mismatch!",
-                                    $self.path
-                                ))
+                                    "Failed to push item to {} collection. Type mismatch {} and {}!",
+                                    $self.path, item.type_name(), list.type_name()
+                                ));
+                                $self.item = Some(item);
                             }
                         } else {
                             fyrox::core::log::Log::err(format!("Property {} is not a collection!", $self.path))
@@ -208,7 +208,6 @@ macro_rules! define_universal_commands {
                                 list.reflect_insert($self.index, $self.value.take().unwrap())
                             {
                                 $self.value = Some(item);
-                            } else {
                                 fyrox::core::log::Log::err(format!(
                                     "Failed to insert item to {} collection. Type mismatch!",
                                     $self.path

--- a/editor/src/command/universal.rs
+++ b/editor/src/command/universal.rs
@@ -72,7 +72,7 @@ macro_rules! define_universal_commands {
                                 Err(current_value) => {
                                     fyrox::core::log::Log::err(format!(
                                         "Failed to set property {}! Incompatible types {}!",
-                                        $self.path, value.type_name()
+                                        $self.path, current_value.type_name()
                                     ));
                                     $self.value = Some(current_value);
                                 }

--- a/editor/src/command/universal.rs
+++ b/editor/src/command/universal.rs
@@ -56,34 +56,58 @@ macro_rules! define_universal_commands {
             }
 
             fn swap(&mut $self, $ctx_ident: &mut $ctx) {
-
-                (($entity_getter) as &mut dyn Reflect).set_field_by_path(&$self.path, $self.value.take().unwrap(), &mut |result| match result {
-                    Ok(old_value) => {
-                        $self.value = Some(old_value);
-                    }
-                    Err(result) => {
-                        let value = match result {
-                            SetFieldByPathError::InvalidPath { value, reason } => {
-                                fyrox::core::log::Log::err(format!(
-                                    "Failed to set property {}! Invalid path {:?}!",
-                                    $self.path, reason
-                                ));
-
-                                value
-                            },
-                            SetFieldByPathError::InvalidValue(value) => {
-                                fyrox::core::log::Log::err(format!(
-                                    "Failed to set property {}! Incompatible types!",
-                                    $self.path
-                                ));
-
-                                value
+                if fyrox::core::reflect::is_path_to_array_element(&$self.path) {
+                    (($entity_getter) as &mut dyn Reflect).resolve_path_mut(&$self.path, &mut |result| match result {
+                        Err(reason) => {
+                            fyrox::core::log::Log::err(format!(
+                                "Failed to set property {}! Invalid path {:?}!",
+                                $self.path, reason
+                            ));
+                        }
+                        Ok(property) => {
+                            match property.set($self.value.take().unwrap()) {
+                                Ok(old_value) => {
+                                    $self.value = Some(old_value);
+                                }
+                                Err(current_value) => {
+                                    fyrox::core::log::Log::err(format!(
+                                        "Failed to set property {}! Incompatible types {}!",
+                                        $self.path, value.type_name()
+                                    ));
+                                    $self.value = Some(current_value);
+                                }
                             }
-                        };
-                        $self.value = Some(value);
+                        }
+                    });
+                } else {
+                    (($entity_getter) as &mut dyn Reflect).set_field_by_path(&$self.path, $self.value.take().unwrap(), &mut |result| match result {
+                        Ok(old_value) => {
+                            $self.value = Some(old_value);
+                        }
+                        Err(result) => {
+                            let value = match result {
+                                SetFieldByPathError::InvalidPath { value, reason } => {
+                                    fyrox::core::log::Log::err(format!(
+                                        "Failed to set property {}! Invalid path {:?}!",
+                                        $self.path, reason
+                                    ));
 
+                                    value
+                                },
+                                SetFieldByPathError::InvalidValue(value) => {
+                                    fyrox::core::log::Log::err(format!(
+                                        "Failed to set property {}! Incompatible types {}!",
+                                        $self.path, value.type_name()
+                                    ));
+
+                                    value
+                                }
+                            };
+                            $self.value = Some(value);
+
+                        }
+                    });
                     }
-                });
             }
         }
 

--- a/editor/src/inspector/editors/mod.rs
+++ b/editor/src/inspector/editors/mod.rs
@@ -14,7 +14,6 @@ use crate::{
     },
     message::MessageSender,
 };
-use fyrox::scene::mesh::surface::BoneHandle;
 use fyrox::{
     animation::{
         machine::{
@@ -22,12 +21,12 @@ use fyrox::{
                 blendspace::{BlendSpace, BlendSpacePoint},
                 BasePoseNode,
             },
-            state::{AnimationHandleWrapper, StateAction, StateActionWrapper},
+            state::{StateAction, StateActionWrapper},
             transition::{AndNode, LogicNode, NotNode, OrNode, XorNode},
             BlendAnimations, BlendAnimationsByIndex, BlendPose, IndexedBlendInput, Machine,
             PlayAnimation, PoseNode, PoseWeight, State,
         },
-        AnimationContainer,
+        Animation, AnimationContainer,
     },
     core::{
         futures::executor::block_on,
@@ -53,9 +52,7 @@ use fyrox::{
         },
     },
     scene::{
-        base::{
-            Base, LevelOfDetail, LodControlledObject, LodGroup, Mobility, Property, PropertyValue,
-        },
+        base::{Base, LevelOfDetail, LodGroup, Mobility, Property, PropertyValue},
         camera::{
             ColorGradingLut, Exposure, OrthographicProjection, PerspectiveProjection, Projection,
             SkyBox,
@@ -76,13 +73,13 @@ use fyrox::{
             surface::{BlendShape, Surface, SurfaceSharedData},
             RenderPath,
         },
-        node::{Node, NodeHandle},
+        node::Node,
         particle_system::{
             emitter::{
                 base::BaseEmitter, cuboid::CuboidEmitter, cylinder::CylinderEmitter,
                 sphere::SphereEmitter, Emitter,
             },
-            EmitterWrapper, ParticleSystemRng,
+            ParticleSystemRng,
         },
         rigidbody::RigidBodyType,
         sound::{
@@ -92,8 +89,8 @@ use fyrox::{
                 HighShelfFilterEffect, LowPassFilterEffect, LowShelfFilterEffect,
             },
             reverb::Reverb,
-            Attenuate, AudioBus, Biquad, DistanceModel, Effect, EffectWrapper, SoundBuffer,
-            SoundBufferResource, Status,
+            Attenuate, AudioBus, Biquad, DistanceModel, Effect, SoundBuffer, SoundBufferResource,
+            Status,
         },
         terrain::{Chunk, Layer},
         transform::Transform,
@@ -143,20 +140,26 @@ pub fn make_property_editors_container(sender: MessageSender) -> PropertyEditorD
 
     container.register_inheritable_vec_collection::<Handle<Node>>();
     container.insert(NodeHandlePropertyEditorDefinition::new(sender.clone()));
-    container.register_inheritable_inspectable::<NodeHandle>();
-    container.register_inheritable_vec_collection::<NodeHandle>();
 
     container.register_inheritable_vec_collection::<Surface>();
+    container.register_inheritable_inspectable::<Surface>();
+
     container.register_inheritable_vec_collection::<Layer>();
-    container.register_inheritable_vec_collection::<EmitterWrapper>();
+    container.register_inheritable_inspectable::<Layer>();
+
+    container.register_inheritable_vec_collection::<Emitter>();
+
     container.register_inheritable_vec_collection::<LevelOfDetail>();
     container.register_inheritable_inspectable::<LevelOfDetail>();
-    container.register_inheritable_inspectable::<LodControlledObject>();
+
     container.register_inheritable_vec_collection::<ErasedHandle>();
+    container.register_inheritable_inspectable::<ErasedHandle>();
+
     container.register_inheritable_vec_collection::<Property>();
-    container.register_inheritable_vec_collection::<LodControlledObject>();
+    container.register_inheritable_inspectable::<Property>();
+
     container.register_inheritable_vec_collection::<GeometrySource>();
-    container.register_inheritable_vec_collection::<BoneHandle>();
+    container.register_inheritable_inspectable::<GeometrySource>();
 
     container.insert(make_status_enum_editor_definition());
 
@@ -211,7 +214,6 @@ pub fn make_property_editors_container(sender: MessageSender) -> PropertyEditorD
 
     container.register_inheritable_inspectable::<ColorGradingLut>();
     container.register_inheritable_inspectable::<InteractionGroups>();
-    container.register_inheritable_inspectable::<GeometrySource>();
 
     container.register_inheritable_enum::<JointParams, _>();
     container.register_inheritable_enum::<dim2::joint::JointParams, _>();
@@ -228,8 +230,8 @@ pub fn make_property_editors_container(sender: MessageSender) -> PropertyEditorD
     container.register_inheritable_inspectable::<BaseLight>();
 
     container.insert(EnumPropertyEditorDefinition::<Effect>::new());
-    container.insert(InspectablePropertyEditorDefinition::<EffectWrapper>::new());
-    container.insert(VecCollectionPropertyEditorDefinition::<EffectWrapper>::new());
+    container.insert(VecCollectionPropertyEditorDefinition::<Effect>::new());
+
     container.insert(InspectablePropertyEditorDefinition::<Attenuate>::new());
     container.insert(InspectablePropertyEditorDefinition::<LowPassFilterEffect>::new());
     container.insert(InspectablePropertyEditorDefinition::<HighPassFilterEffect>::new());
@@ -256,6 +258,7 @@ pub fn make_property_editors_container(sender: MessageSender) -> PropertyEditorD
     container.register_inheritable_vec_collection::<Chunk>();
 
     container.register_inheritable_vec_collection::<BlendShape>();
+    container.register_inheritable_inspectable::<BlendShape>();
 
     container.register_inheritable_option::<ColorGradingLut>();
     container.register_inheritable_option::<Biquad>();
@@ -322,14 +325,11 @@ pub fn make_property_editors_container(sender: MessageSender) -> PropertyEditorD
     container.insert(InspectablePropertyEditorDefinition::<BlendAnimations>::new());
     container.insert(InspectablePropertyEditorDefinition::<BlendSpace>::new());
     container.insert(InspectablePropertyEditorDefinition::<PlayAnimation>::new());
-    container.insert(InspectablePropertyEditorDefinition::<AnimationHandleWrapper>::new());
-    container.insert(VecCollectionPropertyEditorDefinition::<
-        AnimationHandleWrapper,
-    >::new());
 
     container.insert(InspectablePropertyEditorDefinition::<Handle<PoseNode>>::new());
     container.insert(InspectablePropertyEditorDefinition::<Handle<State>>::new());
 
+    container.insert(VecCollectionPropertyEditorDefinition::<Handle<Animation>>::new());
     container.insert(AnimationPropertyEditorDefinition);
 
     container.insert(AnimationContainerPropertyEditorDefinition);

--- a/editor/src/inspector/editors/mod.rs
+++ b/editor/src/inspector/editors/mod.rs
@@ -150,6 +150,8 @@ pub fn make_property_editors_container(sender: MessageSender) -> PropertyEditorD
     container.register_inheritable_vec_collection::<Layer>();
     container.register_inheritable_vec_collection::<EmitterWrapper>();
     container.register_inheritable_vec_collection::<LevelOfDetail>();
+    container.register_inheritable_inspectable::<LevelOfDetail>();
+    container.register_inheritable_inspectable::<LodControlledObject>();
     container.register_inheritable_vec_collection::<ErasedHandle>();
     container.register_inheritable_vec_collection::<Property>();
     container.register_inheritable_vec_collection::<LodControlledObject>();

--- a/editor/src/scene/property.rs
+++ b/editor/src/scene/property.rs
@@ -39,7 +39,7 @@ impl PropertySelectorMessage {
 pub struct PropertyDescriptor {
     path: String,
     display_name: String,
-    type_name: &'static str,
+    type_name: String,
     type_id: TypeId,
     read_only: bool,
     children_properties: Vec<PropertyDescriptor>,
@@ -116,7 +116,7 @@ impl PropertyDescriptor {
                     .with_text(format!(
                         "{} ({})",
                         self.display_name,
-                        make_pretty_type_name(self.type_name)
+                        make_pretty_type_name(&self.type_name)
                     ))
                     .build(ctx),
             )
@@ -147,7 +147,7 @@ pub fn object_to_property_tree(parent_path: &str, object: &dyn Reflect) -> Vec<P
                     let mut descriptor = PropertyDescriptor {
                         path: path.clone(),
                         display_name: field_info.display_name.to_owned(),
-                        type_name: field_info.type_name,
+                        type_name: field_info.type_name.to_owned(),
                         type_id: field_info.value.type_id(),
                         children_properties: Default::default(),
                         read_only: field_info.read_only,
@@ -159,7 +159,7 @@ pub fn object_to_property_tree(parent_path: &str, object: &dyn Reflect) -> Vec<P
                         descriptor.children_properties.push(PropertyDescriptor {
                             path: item_path.clone(),
                             display_name: format!("[{}]", i),
-                            type_name: item.type_name(),
+                            type_name: item.type_name().to_owned(),
                             type_id: item.type_id(),
                             read_only: field_info.read_only,
                             children_properties: object_to_property_tree(&item_path, item),
@@ -179,7 +179,7 @@ pub fn object_to_property_tree(parent_path: &str, object: &dyn Reflect) -> Vec<P
                         let mut descriptor = PropertyDescriptor {
                             path: path.clone(),
                             display_name: field_info.display_name.to_owned(),
-                            type_name: field_info.type_name,
+                            type_name: field_info.type_name.to_owned(),
                             type_id: field_info.value.type_id(),
                             children_properties: Default::default(),
                             read_only: field_info.read_only,
@@ -213,7 +213,7 @@ pub fn object_to_property_tree(parent_path: &str, object: &dyn Reflect) -> Vec<P
                             descriptor.children_properties.push(PropertyDescriptor {
                                 path: item_path.clone(),
                                 display_name: format!("[{}]", key_str),
-                                type_name: value.type_name(),
+                                type_name: value.type_name().to_owned(),
                                 type_id: value.type_id(),
                                 read_only: field_info.read_only,
                                 children_properties: object_to_property_tree(&item_path, value),
@@ -233,7 +233,7 @@ pub fn object_to_property_tree(parent_path: &str, object: &dyn Reflect) -> Vec<P
             if !processed {
                 descriptors.push(PropertyDescriptor {
                     display_name: field_info.display_name.to_owned(),
-                    type_name: field_info.type_name,
+                    type_name: field_info.type_name.to_owned(),
                     type_id: field_info.value.type_id(),
                     read_only: field_info.read_only,
                     children_properties: object_to_property_tree(&path, field_ref),

--- a/examples/lod.rs
+++ b/examples/lod.rs
@@ -31,7 +31,7 @@ use fyrox::{
     keyboard::KeyCode,
     resource::model::{Model, ModelResourceExtension},
     scene::{
-        base::{LevelOfDetail, LodControlledObject, LodGroup},
+        base::{LevelOfDetail, LodGroup},
         node::Node,
         Scene,
     },
@@ -96,35 +96,35 @@ async fn create_scene(resource_manager: ResourceManager) -> GameScene {
                 // by multiplying normalized distance to z far.
                 0.0,
                 0.33,
-                vec![LodControlledObject(
+                vec![
                     scene
                         .graph
                         .find_by_name(model_handle, "metroLOD0")
                         .unwrap()
                         .0,
-                )],
+                ],
             ),
             LevelOfDetail::new(
                 0.33,
                 0.66,
-                vec![LodControlledObject(
+                vec![
                     scene
                         .graph
                         .find_by_name(model_handle, "metroLOD1")
                         .unwrap()
                         .0,
-                )],
+                ],
             ),
             LevelOfDetail::new(
                 0.66,
                 1.0,
-                vec![LodControlledObject(
+                vec![
                     scene
                         .graph
                         .find_by_name(model_handle, "metroLOD2")
                         .unwrap()
                         .0,
-                )],
+                ],
             ),
         ],
     };

--- a/fyrox-core-derive/tests/it/reflect.rs
+++ b/fyrox-core-derive/tests/it/reflect.rs
@@ -310,7 +310,7 @@ fn reflect_fields_list_of_enum() {
     });
 }
 
-fn default_prop() -> FieldInfo<'static> {
+fn default_prop() -> FieldInfo<'static, 'static> {
     FieldInfo {
         owner_type_id: TypeId::of::<()>(),
         name: "",

--- a/fyrox-core/src/reflect.rs
+++ b/fyrox-core/src/reflect.rs
@@ -993,6 +993,10 @@ impl dyn Reflect {
     }
 }
 
+pub fn is_path_to_array_element(path: &str) -> bool {
+    path.chars().last().map_or(false, |c| c == ']')
+}
+
 // Make it a trait?
 impl dyn ReflectList {
     pub fn get_reflect_index<T: Reflect + 'static>(

--- a/fyrox-core/src/reflect.rs
+++ b/fyrox-core/src/reflect.rs
@@ -45,24 +45,24 @@ pub enum CastError {
     },
 }
 
-pub struct FieldInfo<'a> {
+pub struct FieldInfo<'a, 'b> {
     /// A type id of the owner of the property.
     pub owner_type_id: TypeId,
 
     /// A name of the property.
-    pub name: &'static str,
+    pub name: &'b str,
 
     /// A human-readable name of the property.
-    pub display_name: &'static str,
+    pub display_name: &'b str,
 
     /// Description of the property.
-    pub description: &'static str,
+    pub description: &'b str,
 
     /// Type name of the property.
-    pub type_name: &'static str,
+    pub type_name: &'b str,
 
     /// Doc comment content.
-    pub doc: &'static str,
+    pub doc: &'b str,
 
     /// An reference to the actual value of the property. This is "non-mangled" reference, which
     /// means that while `field/fields/field_mut/fields_mut` might return a reference to other value,
@@ -92,7 +92,7 @@ pub struct FieldInfo<'a> {
     pub precision: Option<usize>,
 }
 
-impl<'a> FieldInfo<'a> {
+impl<'a, 'b> FieldInfo<'a, 'b> {
     /// Tries to cast a value to a given type.
     pub fn cast_value<T: 'static>(&self) -> Result<&T, CastError> {
         match self.value.as_any().downcast_ref::<T>() {
@@ -106,7 +106,7 @@ impl<'a> FieldInfo<'a> {
     }
 }
 
-impl<'a> fmt::Debug for FieldInfo<'a> {
+impl<'a, 'b> fmt::Debug for FieldInfo<'a, 'b> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PropertyInfo")
             .field("owner_type_id", &self.owner_type_id)
@@ -123,7 +123,7 @@ impl<'a> fmt::Debug for FieldInfo<'a> {
     }
 }
 
-impl<'a> PartialEq<Self> for FieldInfo<'a> {
+impl<'a, 'b> PartialEq<Self> for FieldInfo<'a, 'b> {
     fn eq(&self, other: &Self) -> bool {
         let value_ptr_a = self.value as *const _ as *const ();
         let value_ptr_b = other.value as *const _ as *const ();

--- a/fyrox-sound/src/bus.rs
+++ b/fyrox-sound/src/bus.rs
@@ -1,7 +1,7 @@
 //! Everything related to audio buses and audio bus graphs. See docs of [`AudioBus`] and [`AudioBusGraph`]
 //! for more info and examples
 
-use crate::effects::{Effect, EffectRenderTrait, EffectWrapper};
+use crate::effects::{Effect, EffectRenderTrait};
 use fyrox_core::{
     pool::{Handle, Pool, Ticket},
     reflect::prelude::*,
@@ -83,7 +83,7 @@ impl PingPongBuffer {
 #[derive(Debug, Reflect, Visit, Clone)]
 pub struct AudioBus {
     pub(crate) name: String,
-    effects: Vec<EffectWrapper>,
+    effects: Vec<Effect>,
     gain: f32,
 
     #[reflect(hidden)]
@@ -175,7 +175,7 @@ impl AudioBus {
 
     /// Adds new effect to the effects chain.
     pub fn add_effect(&mut self, effect: Effect) {
-        self.effects.push(EffectWrapper(effect))
+        self.effects.push(effect)
     }
 
     /// Removes an effect by the given handle.
@@ -185,21 +185,21 @@ impl AudioBus {
 
     /// Returns a shared reference to an effect at the given handle.
     pub fn effect(&self, index: usize) -> Option<&Effect> {
-        self.effects.get(index).map(|w| &w.0)
+        self.effects.get(index)
     }
 
     /// Returns mutable reference to effect at given handle.
     pub fn effect_mut(&mut self, index: usize) -> Option<&mut Effect> {
-        self.effects.get_mut(index).map(|w| &mut w.0)
+        self.effects.get_mut(index)
     }
 
     /// Returns an iterator over effects used by this audio bus.
-    pub fn effects(&self) -> impl Iterator<Item = &EffectWrapper> {
+    pub fn effects(&self) -> impl Iterator<Item = &Effect> {
         self.effects.iter()
     }
 
     /// Returns an iterator over effects used by this audio bus.
-    pub fn effects_mut(&mut self) -> impl Iterator<Item = &mut EffectWrapper> {
+    pub fn effects_mut(&mut self) -> impl Iterator<Item = &mut Effect> {
         self.effects.iter_mut()
     }
 }

--- a/fyrox-sound/src/effects/mod.rs
+++ b/fyrox-sound/src/effects/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     effects::reverb::Reverb,
 };
 use fyrox_core::{reflect::prelude::*, visitor::prelude::*};
-use std::ops::{Deref, DerefMut};
 use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
 
 pub mod filter;
@@ -43,30 +42,6 @@ impl EffectRenderTrait for Attenuate {
             *output_left = *input_left * self.gain;
             *output_right = *input_right * self.gain;
         }
-    }
-}
-
-#[doc(hidden)]
-#[derive(PartialEq, Debug, Clone, Default, Reflect)]
-pub struct EffectWrapper(#[reflect(display_name = "Effect Type")] pub Effect);
-
-impl Deref for EffectWrapper {
-    type Target = Effect;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for EffectWrapper {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Visit for EffectWrapper {
-    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
-        self.0.visit(name, visitor)
     }
 }
 

--- a/fyrox-ui/src/inspector/editors/array.rs
+++ b/fyrox-ui/src/inspector/editors/array.rs
@@ -54,12 +54,14 @@ impl Control for ArrayEditor {
                 .iter()
                 .position(|i| i.inspector == message.destination())
             {
+                // FIXME!
+                /*
                 ui.send_message(CollectionChanged::item_changed(
                     self.handle,
                     MessageDirection::FromWidget,
                     index,
                     p.clone(),
-                ))
+                ))*/
             }
         }
     }

--- a/fyrox-ui/src/inspector/editors/collection.rs
+++ b/fyrox-ui/src/inspector/editors/collection.rs
@@ -12,8 +12,8 @@ use crate::{
             PropertyEditorDefinitionContainer, PropertyEditorInstance,
             PropertyEditorMessageContext, PropertyEditorTranslationContext,
         },
-        make_expander_container, CollectionChanged, FieldKind, InspectorEnvironment,
-        InspectorError, ObjectValue, PropertyChanged, PropertyFilter,
+        make_expander_container, make_property_margin, CollectionChanged, FieldKind,
+        InspectorEnvironment, InspectorError, ObjectValue, PropertyChanged, PropertyFilter,
     },
     message::{MessageDirection, UiMessage},
     stack_panel::StackPanelBuilder,
@@ -260,6 +260,10 @@ where
                 generate_property_string_values,
                 filter: filter.clone(),
             })?;
+
+            if let PropertyEditorInstance::Simple { editor } = editor {
+                ctx[editor].set_margin(make_property_margin(layer_index + 1));
+            }
 
             let remove = ButtonBuilder::new(
                 WidgetBuilder::new()

--- a/fyrox-ui/src/inspector/editors/collection.rs
+++ b/fyrox-ui/src/inspector/editors/collection.rs
@@ -259,7 +259,7 @@ where
                 environment: environment.clone(),
                 definition_container: definition_container.clone(),
                 sync_flag,
-                layer_index,
+                layer_index: layer_index + 1,
                 generate_property_string_values,
                 filter: filter.clone(),
             })?;
@@ -560,7 +560,7 @@ where
                             definition_container: definition_container.clone(),
                             sync_flag,
                             instance: item.editor_instance.editor(),
-                            layer_index,
+                            layer_index: layer_index + 1,
                             ui,
                             generate_property_string_values,
                             filter: filter.clone(),

--- a/fyrox-ui/src/inspector/editors/inherit.rs
+++ b/fyrox-ui/src/inspector/editors/inherit.rs
@@ -187,7 +187,9 @@ where
     }
 }
 
-fn make_proxy<'a, 'b, T>(property_info: &'b FieldInfo<'a>) -> Result<FieldInfo<'a>, InspectorError>
+fn make_proxy<'a, 'b, 'c, T>(
+    property_info: &'b FieldInfo<'a, 'c>,
+) -> Result<FieldInfo<'a, 'c>, InspectorError>
 where
     T: Reflect + FieldValue,
     'b: 'a,

--- a/fyrox-ui/src/inspector/editors/mod.rs
+++ b/fyrox-ui/src/inspector/editors/mod.rs
@@ -62,9 +62,9 @@ pub mod string;
 pub mod uuid;
 pub mod vec;
 
-pub struct PropertyEditorBuildContext<'a, 'b, 'c> {
+pub struct PropertyEditorBuildContext<'a, 'b, 'c, 'd> {
     pub build_context: &'a mut BuildContext<'c>,
-    pub property_info: &'b FieldInfo<'b>,
+    pub property_info: &'b FieldInfo<'b, 'd>,
     pub environment: Option<Rc<dyn InspectorEnvironment>>,
     pub definition_container: Rc<PropertyEditorDefinitionContainer>,
     pub sync_flag: u64,
@@ -73,11 +73,11 @@ pub struct PropertyEditorBuildContext<'a, 'b, 'c> {
     pub filter: PropertyFilter,
 }
 
-pub struct PropertyEditorMessageContext<'a, 'b> {
+pub struct PropertyEditorMessageContext<'a, 'b, 'c> {
     pub sync_flag: u64,
     pub instance: Handle<UiNode>,
     pub ui: &'b mut UserInterface,
-    pub property_info: &'a FieldInfo<'a>,
+    pub property_info: &'a FieldInfo<'a, 'c>,
     pub definition_container: Rc<PropertyEditorDefinitionContainer>,
     pub layer_index: usize,
     pub environment: Option<Rc<dyn InspectorEnvironment>>,
@@ -93,6 +93,7 @@ pub struct PropertyEditorTranslationContext<'b, 'c> {
     pub definition_container: Rc<PropertyEditorDefinitionContainer>,
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub enum PropertyEditorInstance {
     Simple {
         /// A property editor. Could be any widget that capable of editing a property
@@ -106,6 +107,15 @@ pub enum PropertyEditorInstance {
         /// value.
         editor: Handle<UiNode>,
     },
+}
+
+impl PropertyEditorInstance {
+    pub fn editor(&self) -> Handle<UiNode> {
+        match self {
+            PropertyEditorInstance::Simple { editor }
+            | PropertyEditorInstance::Custom { editor, .. } => *editor,
+        }
+    }
 }
 
 pub trait PropertyEditorDefinition: Debug {

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -2596,7 +2596,7 @@ mod test {
             ui.poll_message(),
             Some(TextMessage::text(
                 text_box,
-                MessageDirection::ToWidget,
+                MessageDirection::FromWidget,
                 "A".to_string()
             ))
         );

--- a/fyrox-ui/src/message.rs
+++ b/fyrox-ui/src/message.rs
@@ -323,6 +323,12 @@ impl UiMessage {
         self
     }
 
+    /// Sets the desired flags of the message.
+    pub fn with_flags(mut self, flags: u64) -> Self {
+        self.flags = flags;
+        self
+    }
+
     /// Creates a new copy of the message with reversed direction. Typical use case is to re-send messages to create "response"
     /// in a widget. For example you have a float input field and it has Value message. When the input field receives Value message
     /// with [`MessageDirection::ToWidget`] it checks if value needs to be changed and if it does, it re-sends same message, but with

--- a/src/animation/machine/state.rs
+++ b/src/animation/machine/state.rs
@@ -38,24 +38,6 @@ impl DerefMut for StateActionWrapper {
     }
 }
 
-#[doc(hidden)]
-#[derive(Default, Debug, Visit, Reflect, Clone, PartialEq)]
-pub struct AnimationHandleWrapper(pub Handle<Animation>);
-
-impl Deref for AnimationHandleWrapper {
-    type Target = Handle<Animation>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for AnimationHandleWrapper {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 /// An action, that will be executed by a state. It usually used to rewind, enable/disable animations
 /// when entering or leaving states. This is useful in situations when you have a one-shot animation
 /// and you need to rewind it before when entering some state. For example, you may have looped idle
@@ -79,7 +61,7 @@ pub enum StateAction {
     /// to your state machine. For example, you may have few melee attack animations and all of them
     /// are suitable for every situation, in this case you can add randomization to make attacks less
     /// predictable.
-    EnableRandomAnimation(Vec<AnimationHandleWrapper>),
+    EnableRandomAnimation(Vec<Handle<Animation>>),
 }
 
 impl StateAction {
@@ -104,7 +86,7 @@ impl StateAction {
             }
             StateAction::EnableRandomAnimation(animation_handles) => {
                 if let Some(animation) = animation_handles.iter().choose(&mut rand::thread_rng()) {
-                    if let Some(animation) = animations.try_get_mut(animation.0) {
+                    if let Some(animation) = animations.try_get_mut(*animation) {
                         animation.set_enabled(true);
                     }
                 }

--- a/src/renderer/batch.rs
+++ b/src/renderer/batch.rs
@@ -162,7 +162,7 @@ impl RenderDataBatchStorage {
             if let Some(lod_group) = node.lod_group() {
                 for level in lod_group.levels.iter() {
                     for &object in level.objects.iter() {
-                        if let Some(object_ref) = graph.try_get(*object) {
+                        if let Some(object_ref) = graph.try_get(object) {
                             let distance = observer_info
                                 .observer_position
                                 .metric_distance(&object_ref.global_position());

--- a/src/resource/fbx/mod.rs
+++ b/src/resource/fbx/mod.rs
@@ -10,7 +10,6 @@ mod document;
 pub mod error;
 mod scene;
 
-use crate::scene::mesh::surface::BoneHandle;
 use crate::{
     animation::{track::Track, Animation, AnimationContainer},
     asset::manager::ResourceManager,
@@ -849,7 +848,7 @@ async fn convert(
                 }
                 surface
                     .bones
-                    .set_value_silent(surface_bones.iter().map(|h| BoneHandle(*h)).collect());
+                    .set_value_silent(surface_bones.iter().map(|h| *h).collect());
 
                 let data_rc = surface.data();
                 let mut data = data_rc.lock();
@@ -865,7 +864,7 @@ async fn convert(
                             indices[k] = surface
                                 .bones
                                 .iter()
-                                .position(|bone_handle| **bone_handle == weight.effector.into())
+                                .position(|bone_handle| *bone_handle == weight.effector.into())
                                 .ok_or(FbxError::UnableToFindBone)?
                                 as u8;
                             weights[k] = weight.value;

--- a/src/resource/fbx/mod.rs
+++ b/src/resource/fbx/mod.rs
@@ -848,7 +848,7 @@ async fn convert(
                 }
                 surface
                     .bones
-                    .set_value_silent(surface_bones.iter().map(|h| *h).collect());
+                    .set_value_silent(surface_bones.iter().copied().collect());
 
                 let data_rc = surface.data();
                 let mut data = data_rc.lock();

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -19,37 +19,8 @@ use crate::{
     scene::{node::Node, transform::Transform},
     script::{Script, ScriptTrait},
 };
-use std::{
-    any::Any,
-    cell::Cell,
-    ops::{Deref, DerefMut},
-    sync::mpsc::Sender,
-};
+use std::{any::Any, cell::Cell, sync::mpsc::Sender};
 use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
-
-/// A handle to scene node that will be controlled by LOD system.
-#[derive(Reflect, Default, Debug, Clone, Copy, PartialEq, Hash, Eq)]
-pub struct LodControlledObject(pub Handle<Node>);
-
-impl Deref for LodControlledObject {
-    type Target = Handle<Node>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for LodControlledObject {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Visit for LodControlledObject {
-    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
-        self.0.visit(name, visitor)
-    }
-}
 
 /// Level of detail is a collection of objects for given normalized distance range.
 /// Objects will be rendered **only** if they're in specified range.
@@ -62,12 +33,12 @@ pub struct LevelOfDetail {
     end: f32,
     /// List of objects, where each object represents level of detail of parent's
     /// LOD group.
-    pub objects: Vec<LodControlledObject>,
+    pub objects: Vec<Handle<Node>>,
 }
 
 impl LevelOfDetail {
     /// Creates new level of detail.
-    pub fn new(begin: f32, end: f32, objects: Vec<LodControlledObject>) -> Self {
+    pub fn new(begin: f32, end: f32, objects: Vec<Handle<Node>>) -> Self {
         for object in objects.iter() {
             // Invalid handles are not allowed.
             assert!(object.is_some());

--- a/src/scene/mesh/mod.rs
+++ b/src/scene/mesh/mod.rs
@@ -266,7 +266,7 @@ impl Mesh {
                     .bones()
                     .iter()
                     .map(|&b| {
-                        let bone_node = &graph[*b];
+                        let bone_node = &graph[b];
                         bone_node.global_transform() * bone_node.inv_bind_pose_transform()
                     })
                     .collect::<Vec<Matrix4<f32>>>();
@@ -352,7 +352,7 @@ impl NodeTrait for Mesh {
             // Special case for skinned meshes.
             for surface in self.surfaces.iter() {
                 for &bone in surface.bones() {
-                    if let Some(node) = context.nodes.try_borrow(*bone) {
+                    if let Some(node) = context.nodes.try_borrow(bone) {
                         world_aabb.add_point(node.global_position())
                     }
                 }
@@ -400,7 +400,7 @@ impl NodeTrait for Mesh {
                         .bones
                         .iter()
                         .map(|bone_handle| {
-                            if let Some(bone_node) = ctx.graph.try_get(**bone_handle) {
+                            if let Some(bone_node) = ctx.graph.try_get(*bone_handle) {
                                 bone_node.global_transform() * bone_node.inv_bind_pose_transform()
                             } else {
                                 Matrix4::identity()

--- a/src/scene/mesh/surface.rs
+++ b/src/scene/mesh/surface.rs
@@ -33,7 +33,6 @@ use crate::{
 };
 use fxhash::{FxHashMap, FxHasher};
 use half::f16;
-use std::ops::{Deref, DerefMut};
 use std::{hash::Hasher, sync::Arc};
 
 /// A target shape for blending.
@@ -1160,36 +1159,6 @@ impl SurfaceSharedData {
     }
 }
 
-/// A simple bone node handle wrapper.
-#[derive(Reflect, Default, Copy, Clone, Debug, Hash, Eq, PartialEq)]
-pub struct BoneHandle(pub Handle<Node>);
-
-impl From<Handle<Node>> for BoneHandle {
-    fn from(value: Handle<Node>) -> Self {
-        Self(value)
-    }
-}
-
-impl Visit for BoneHandle {
-    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
-        self.0.visit(name, visitor)
-    }
-}
-
-impl Deref for BoneHandle {
-    type Target = Handle<Node>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for BoneHandle {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 /// Surface is a set of triangles with a single material. Such arrangement makes GPU rendering very efficient.
 ///
 /// Surfaces can use the same data source across many instances, this is a memory optimization for being able to
@@ -1275,7 +1244,7 @@ pub struct Surface {
     pub(crate) material: InheritableVariable<SharedMaterial>,
 
     /// Array of handles to scene nodes which are used as bones.
-    pub bones: InheritableVariable<Vec<BoneHandle>>,
+    pub bones: InheritableVariable<Vec<Handle<Node>>>,
 
     #[reflect(
         description = "If true, then the current material will become a unique instance when cloning the surface.\
@@ -1385,7 +1354,7 @@ impl Surface {
 
     /// Returns list of bones that affects the surface.
     #[inline]
-    pub fn bones(&self) -> &[BoneHandle] {
+    pub fn bones(&self) -> &[Handle<Node>] {
         &self.bones
     }
 
@@ -1404,7 +1373,7 @@ impl Surface {
 pub struct SurfaceBuilder {
     data: SurfaceSharedData,
     material: Option<SharedMaterial>,
-    bones: Vec<BoneHandle>,
+    bones: Vec<Handle<Node>>,
     unique_material: bool,
 }
 
@@ -1426,7 +1395,7 @@ impl SurfaceBuilder {
     }
 
     /// Sets desired bones array. Make sure your vertices has valid indices of bones!
-    pub fn with_bones(mut self, bones: Vec<BoneHandle>) -> Self {
+    pub fn with_bones(mut self, bones: Vec<Handle<Node>>) -> Self {
         self.bones = bones;
         self
     }

--- a/src/scene/node/mod.rs
+++ b/src/scene/node/mod.rs
@@ -215,32 +215,6 @@ pub trait NodeTrait: BaseNodeTrait + Reflect + Visit {
     }
 }
 
-/// A small wrapper over `Handle<Node>`. Its main purpose is to provide a convenient way
-/// to handle arrays of handles in the editor.
-#[derive(Reflect, Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[repr(transparent)]
-pub struct NodeHandle(pub Handle<Node>);
-
-impl Deref for NodeHandle {
-    type Target = Handle<Node>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for NodeHandle {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Visit for NodeHandle {
-    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
-        self.0.visit(name, visitor)
-    }
-}
-
 /// Node is the basic building block for 3D scenes. It has multiple variants, but all of them share some
 /// common functionality:
 ///

--- a/src/scene/particle_system/mod.rs
+++ b/src/scene/particle_system/mod.rs
@@ -36,30 +36,6 @@ pub(crate) mod draw;
 pub mod emitter;
 pub mod particle;
 
-#[doc(hidden)]
-#[derive(PartialEq, Debug, Clone, Default, Reflect)]
-pub struct EmitterWrapper(#[reflect(display_name = "Emitter Type")] pub Emitter);
-
-impl Deref for EmitterWrapper {
-    type Target = Emitter;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for EmitterWrapper {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Visit for EmitterWrapper {
-    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
-        self.0.visit(name, visitor)
-    }
-}
-
 /// Pseudo-random numbers generator for particle systems.
 #[derive(Debug, Clone, Reflect)]
 pub struct ParticleSystemRng {
@@ -203,7 +179,7 @@ pub struct ParticleSystem {
     base: Base,
 
     /// List of emitters of the particle system.
-    pub emitters: InheritableVariable<Vec<EmitterWrapper>>,
+    pub emitters: InheritableVariable<Vec<Emitter>>,
 
     #[reflect(setter = "set_texture")]
     texture: InheritableVariable<Option<TextureResource>>,
@@ -524,7 +500,7 @@ impl NodeTrait for ParticleSystem {
 /// This is typical implementation of Builder pattern.
 pub struct ParticleSystemBuilder {
     base_builder: BaseBuilder,
-    emitters: Vec<EmitterWrapper>,
+    emitters: Vec<Emitter>,
     texture: Option<TextureResource>,
     acceleration: Vector3<f32>,
     particles: Vec<Particle>,
@@ -552,7 +528,7 @@ impl ParticleSystemBuilder {
 
     /// Sets desired emitters for particle system.
     pub fn with_emitters(mut self, emitters: Vec<Emitter>) -> Self {
-        self.emitters = emitters.into_iter().map(EmitterWrapper).collect();
+        self.emitters = emitters;
         self
     }
 


### PR DESCRIPTION
This PR fixes #357 .