### PR TITLE
Optimize PC resources consumption in the editor

### DIFF
--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -262,6 +262,10 @@ impl AbsmEditor {
         }
     }
 
+    pub fn is_in_preview_mode(&self) -> bool {
+        self.preview_mode_data.is_some()
+    }
+
     pub fn handle_message(
         &mut self,
         message: &Message,

--- a/editor/src/animation/mod.rs
+++ b/editor/src/animation/mod.rs
@@ -510,6 +510,10 @@ impl AnimationEditor {
         }
     }
 
+    pub fn is_in_preview_mode(&self) -> bool {
+        self.preview_mode_data.is_some()
+    }
+
     pub fn handle_message(
         &mut self,
         message: &Message,

--- a/editor/src/audio/preview.rs
+++ b/editor/src/audio/preview.rs
@@ -273,6 +273,10 @@ impl AudioPreviewPanel {
         scene.graph.sound_context.state().destroy_sound_sources();
     }
 
+    pub fn is_in_preview_mode(&self) -> bool {
+        !self.sounds_state.is_empty()
+    }
+
     pub fn update(&self, editor_scene: &EditorScene, engine: &Engine) {
         let scene = &engine.scenes[editor_scene.scene];
         if let Selection::Graph(ref new_graph_selection) = editor_scene.selection {

--- a/editor/src/camera/mod.rs
+++ b/editor/src/camera/mod.rs
@@ -144,11 +144,22 @@ impl CameraController {
         }
     }
 
+    pub fn is_interacting(&self) -> bool {
+        self.move_backward
+            || self.move_forward
+            || self.move_left
+            || self.move_right
+            || self.drag
+            || self.rotate
+            || self.move_down
+            || self.move_up
+    }
+
     pub fn fit_object(&self, scene: &mut Scene, handle: Handle<Node>) {
         // Combine AABBs from the descendants.
         let mut aabb = AxisAlignedBoundingBox::default();
         for descendant in scene.graph.traverse_iter(handle) {
-            let descendant_aabb = dbg!(descendant.local_bounding_box());
+            let descendant_aabb = descendant.local_bounding_box();
             if !descendant_aabb.is_invalid_or_degenerate() {
                 aabb.add_box(descendant_aabb.transform(&descendant.global_transform()))
             }
@@ -158,8 +169,6 @@ impl CameraController {
             // To prevent the camera from flying away into abyss.
             aabb = AxisAlignedBoundingBox::from_point(scene.graph[handle].global_position());
         }
-
-        dbg!(&aabb);
 
         let fit_parameters = scene.graph[self.camera].as_camera().fit(
             &aabb,

--- a/editor/src/camera/panel.rs
+++ b/editor/src/camera/panel.rs
@@ -134,6 +134,10 @@ impl CameraPreviewControlPanel {
         );
     }
 
+    pub fn is_in_preview_mode(&self) -> bool {
+        !self.cameras_state.is_empty()
+    }
+
     pub fn handle_ui_message(
         &mut self,
         message: &UiMessage,

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1748,6 +1748,10 @@ impl Editor {
             || self.animation_editor.is_in_preview_mode()
             || self.absm_editor.is_in_preview_mode()
             || is_any_plugin_in_preview_mode
+            || self
+                .scenes
+                .current_editor_scene_ref()
+                .map_or(false, |s| s.camera_controller.is_interacting())
     }
 
     fn save_scene(&mut self, scene: Handle<Scene>, path: PathBuf) {
@@ -2599,5 +2603,7 @@ fn update(editor: &mut Editor, control_flow: &mut ControlFlow) {
     window.set_cursor_icon(translate_cursor_icon(editor.engine.user_interface.cursor()));
     window.request_redraw();
 
-    editor.update_loop_state.decrease_counter();
+    if !editor.is_in_preview_mode() {
+        editor.update_loop_state.decrease_counter();
+    }
 }

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1699,6 +1699,15 @@ impl Editor {
         }
     }
 
+    pub fn is_in_preview_mode(&self) -> bool {
+        // TODO: Include user plugins.
+        self.particle_system_control_panel.is_in_preview_mode()
+            || self.camera_control_panel.is_in_preview_mode()
+            || self.audio_preview_panel.is_in_preview_mode()
+            || self.animation_editor.is_in_preview_mode()
+            || self.absm_editor.is_in_preview_mode()
+    }
+
     fn save_scene(&mut self, scene: Handle<Scene>, path: PathBuf) {
         self.try_leave_preview_mode();
 
@@ -2528,5 +2537,5 @@ fn update(editor: &mut Editor, control_flow: &mut ControlFlow) {
     window.set_cursor_icon(translate_cursor_icon(editor.engine.user_interface.cursor()));
     window.request_redraw();
 
-    editor.need_update = false;
+    editor.need_update = editor.is_in_preview_mode();
 }

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1701,13 +1701,27 @@ impl Editor {
         }
     }
 
-    pub fn is_in_preview_mode(&self) -> bool {
-        // TODO: Include user plugins.
+    pub fn is_in_preview_mode(&mut self) -> bool {
+        let mut is_any_plugin_in_preview_mode = false;
+        let mut i = 0;
+        while i < self.plugins.len() {
+            if let Some(plugin) = self.plugins.get_mut(i).and_then(|p| p.take()) {
+                is_any_plugin_in_preview_mode |= plugin.is_in_preview_mode(self);
+
+                if let Some(entry) = self.plugins.get_mut(i) {
+                    *entry = Some(plugin);
+                }
+            }
+
+            i += 1;
+        }
+
         self.particle_system_control_panel.is_in_preview_mode()
             || self.camera_control_panel.is_in_preview_mode()
             || self.audio_preview_panel.is_in_preview_mode()
             || self.animation_editor.is_in_preview_mode()
             || self.absm_editor.is_in_preview_mode()
+            || is_any_plugin_in_preview_mode
     }
 
     fn save_scene(&mut self, scene: Handle<Scene>, path: PathBuf) {

--- a/editor/src/particle.rs
+++ b/editor/src/particle.rs
@@ -268,6 +268,10 @@ impl ParticleSystemPreviewControlPanel {
         );
     }
 
+    pub fn is_in_preview_mode(&self) -> bool {
+        !self.particle_systems_state.is_empty()
+    }
+
     pub fn handle_ui_message(
         &mut self,
         message: &UiMessage,

--- a/editor/src/plugin.rs
+++ b/editor/src/plugin.rs
@@ -62,6 +62,13 @@ pub trait EditorPlugin {
     /// about suspension.
     fn on_resumed(&mut self, #[allow(unused_variables)] editor: &mut Editor) {}
 
+    /// This method is used to tell the editor, whether your plugin is in preview mode or not. Preview mode is a special
+    /// state of the editor, when it modifies a content of some scene every frame and discards these changes when the
+    /// preview mode is disabled.
+    fn is_in_preview_mode(&self, #[allow(unused_variables)] editor: &Editor) -> bool {
+        false
+    }
+
     /// This method is called every frame at stable update rate of 60 FPS. It could be used to perform any contiguous
     /// actions.
     fn on_update(&mut self, #[allow(unused_variables)] editor: &mut Editor) {}

--- a/editor/src/plugin.rs
+++ b/editor/src/plugin.rs
@@ -47,6 +47,21 @@ pub trait EditorPlugin {
     ) {
     }
 
+    /// This method is called when the editor suspends its execution. It could happen in a few reasons, but the most
+    /// common ones are:
+    ///
+    /// 1) When the main editor's window is unfocused.
+    /// 2) When there's no messages coming from the OS to the main editor's window.
+    ///
+    /// All of these reason means, that a user does nothing with the editor and the editor just "sleeps" in this period of
+    /// time, saving precious CPU/GPU resources and keeping power consumption at lowest possible values. Which also means
+    /// that cooling fans won't spin like crazy.
+    fn on_suspended(&mut self, #[allow(unused_variables)] editor: &mut Editor) {}
+
+    /// This method is called when the editor continues its execution. See [`Self::on_suspended`] method for more info
+    /// about suspension.
+    fn on_resumed(&mut self, #[allow(unused_variables)] editor: &mut Editor) {}
+
     /// This method is called every frame at stable update rate of 60 FPS. It could be used to perform any contiguous
     /// actions.
     fn on_update(&mut self, #[allow(unused_variables)] editor: &mut Editor) {}


### PR DESCRIPTION
This PR significantly reduces PC resources consumption by the editor by stopping its update loop when there's in messages from the OS or there's no user actions. Preview mode keeps the editor updating every frame, which is acceptable since it is not used very often. 