### PR TITLE
Graphics fixes

### DIFF
--- a/src/material/shader/standard/standard-two-sides.shader
+++ b/src/material/shader/standard/standard-two-sides.shader
@@ -55,6 +55,10 @@
             name: "parallaxCenter",
             kind: Float(0.0),
         ),
+        (
+            name: "parallaxScale",
+            kind: Float(0.08),
+        ),
     ],
 
     passes: [
@@ -178,6 +182,7 @@
                 uniform vec3 emissionStrength;
                 uniform vec4 diffuseColor;
                 uniform float parallaxCenter;
+                uniform float parallaxScale;
 
                 // Define uniforms with reserved names. Fyrox will automatically provide
                 // required data to these uniforms.
@@ -203,7 +208,8 @@
                             heightTexture,
                             toFragmentTangentSpace,
                             texCoord * texCoordScale,
-                            parallaxCenter
+                            parallaxCenter,
+                            parallaxScale
                         );
                     } else {
                         tc = texCoord * texCoordScale;

--- a/src/material/shader/standard/standard-two-sides.shader
+++ b/src/material/shader/standard/standard-two-sides.shader
@@ -51,6 +51,10 @@
             name: "diffuseColor",
             kind: Color(r: 255, g: 255, b: 255, a: 255),
         ),
+        (
+            name: "parallaxCenter",
+            kind: Float(0.0),
+        ),
     ],
 
     passes: [
@@ -173,6 +177,7 @@
                 uniform uint layerIndex;
                 uniform vec3 emissionStrength;
                 uniform vec4 diffuseColor;
+                uniform float parallaxCenter;
 
                 // Define uniforms with reserved names. Fyrox will automatically provide
                 // required data to these uniforms.
@@ -194,7 +199,12 @@
                     vec2 tc;
                     if (fyrox_usePOM) {
                         vec3 toFragmentTangentSpace = normalize(transpose(tangentSpace) * toFragment);
-                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale);
+                        tc = S_ComputeParallaxTextureCoordinates(
+                            heightTexture,
+                            toFragmentTangentSpace,
+                            texCoord * texCoordScale,
+                            parallaxCenter
+                        );
                     } else {
                         tc = texCoord * texCoordScale;
                     }

--- a/src/material/shader/standard/standard-two-sides.shader
+++ b/src/material/shader/standard/standard-two-sides.shader
@@ -144,7 +144,7 @@
                     mat3 nm = mat3(fyrox_worldMatrix);
                     normal = normalize(nm * localNormal);
                     tangent = normalize(nm * localTangent);
-                    binormal = normalize(vertexTangent.w * cross(tangent, normal));
+                    binormal = normalize(vertexTangent.w * cross(normal, tangent));
                     texCoord = vertexTexCoord;
                     position = vec3(fyrox_worldMatrix * localPosition);
                     secondTexCoord = vertexSecondTexCoord;
@@ -194,7 +194,7 @@
                     vec2 tc;
                     if (fyrox_usePOM) {
                         vec3 toFragmentTangentSpace = normalize(transpose(tangentSpace) * toFragment);
-                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale, normal);
+                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale);
                     } else {
                         tc = texCoord * texCoordScale;
                     }

--- a/src/material/shader/standard/standard.shader
+++ b/src/material/shader/standard/standard.shader
@@ -55,6 +55,10 @@
             name: "parallaxCenter",
             kind: Float(0.0),
         ),
+        (
+            name: "parallaxScale",
+            kind: Float(0.08),
+        ),
     ],
 
     passes: [
@@ -191,6 +195,7 @@
                 uniform vec3 emissionStrength;
                 uniform vec4 diffuseColor;
                 uniform float parallaxCenter;
+                uniform float parallaxScale;
 
                 // Define uniforms with reserved names. Fyrox will automatically provide
                 // required data to these uniforms.
@@ -216,7 +221,8 @@
                             heightTexture,
                             toFragmentTangentSpace,
                             texCoord * texCoordScale,
-                            parallaxCenter
+                            parallaxCenter,
+                            parallaxScale
                         );
                     } else {
                         tc = texCoord * texCoordScale;

--- a/src/material/shader/standard/standard.shader
+++ b/src/material/shader/standard/standard.shader
@@ -157,7 +157,7 @@
                     mat3 nm = mat3(fyrox_worldMatrix);
                     normal = normalize(nm * localNormal);
                     tangent = normalize(nm * localTangent);
-                    binormal = normalize(vertexTangent.w * cross(tangent, normal));
+                    binormal = normalize(vertexTangent.w * cross(normal, tangent));
                     texCoord = vertexTexCoord;
                     position = vec3(fyrox_worldMatrix * localPosition);
                     secondTexCoord = vertexSecondTexCoord;
@@ -207,7 +207,7 @@
                     vec2 tc;
                     if (fyrox_usePOM) {
                         vec3 toFragmentTangentSpace = normalize(transpose(tangentSpace) * toFragment);
-                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale, normal);
+                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale);
                     } else {
                         tc = texCoord * texCoordScale;
                     }

--- a/src/material/shader/standard/standard.shader
+++ b/src/material/shader/standard/standard.shader
@@ -51,6 +51,10 @@
             name: "diffuseColor",
             kind: Color(r: 255, g: 255, b: 255, a: 255),
         ),
+        (
+            name: "parallaxCenter",
+            kind: Float(0.0),
+        ),
     ],
 
     passes: [
@@ -186,6 +190,7 @@
                 uniform uint layerIndex;
                 uniform vec3 emissionStrength;
                 uniform vec4 diffuseColor;
+                uniform float parallaxCenter;
 
                 // Define uniforms with reserved names. Fyrox will automatically provide
                 // required data to these uniforms.
@@ -207,7 +212,12 @@
                     vec2 tc;
                     if (fyrox_usePOM) {
                         vec3 toFragmentTangentSpace = normalize(transpose(tangentSpace) * toFragment);
-                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale);
+                        tc = S_ComputeParallaxTextureCoordinates(
+                            heightTexture,
+                            toFragmentTangentSpace,
+                            texCoord * texCoordScale,
+                            parallaxCenter
+                        );
                     } else {
                         tc = texCoord * texCoordScale;
                     }

--- a/src/material/shader/standard/terrain.shader
+++ b/src/material/shader/standard/terrain.shader
@@ -63,6 +63,10 @@
             name: "diffuseColor",
             kind: Color(r: 255, g: 255, b: 255, a: 255),
         ),
+        (
+            name: "parallaxCenter",
+            kind: Float(0.0),
+        ),
     ],
 
     passes: [
@@ -162,6 +166,7 @@
                 uniform vec3 emissionStrength;
                 uniform sampler2D maskTexture;
                 uniform vec4 diffuseColor;
+                uniform float parallaxCenter;
 
                 // Define uniforms with reserved names. Fyrox will automatically provide
                 // required data to these uniforms.
@@ -183,7 +188,12 @@
                     vec2 tc;
                     if (fyrox_usePOM) {
                         vec3 toFragmentTangentSpace = normalize(transpose(tangentSpace) * toFragment);
-                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale);
+                        tc = S_ComputeParallaxTextureCoordinates(
+                            heightTexture,
+                            toFragmentTangentSpace,
+                            texCoord * texCoordScale,
+                            parallaxCenter
+                        );
                     } else {
                         tc = texCoord * texCoordScale;
                     }

--- a/src/material/shader/standard/terrain.shader
+++ b/src/material/shader/standard/terrain.shader
@@ -67,6 +67,10 @@
             name: "parallaxCenter",
             kind: Float(0.0),
         ),
+        (
+            name: "parallaxScale",
+            kind: Float(0.08),
+        ),
     ],
 
     passes: [
@@ -167,6 +171,7 @@
                 uniform sampler2D maskTexture;
                 uniform vec4 diffuseColor;
                 uniform float parallaxCenter;
+                uniform float parallaxScale;
 
                 // Define uniforms with reserved names. Fyrox will automatically provide
                 // required data to these uniforms.
@@ -192,7 +197,8 @@
                             heightTexture,
                             toFragmentTangentSpace,
                             texCoord * texCoordScale,
-                            parallaxCenter
+                            parallaxCenter,
+                            parallaxScale
                         );
                     } else {
                         tc = texCoord * texCoordScale;

--- a/src/material/shader/standard/terrain.shader
+++ b/src/material/shader/standard/terrain.shader
@@ -133,7 +133,7 @@
                     mat3 nm = mat3(fyrox_worldMatrix);
                     normal = normalize(nm * vertexNormal);
                     tangent = normalize(nm * vertexTangent.xyz);
-                    binormal = normalize(vertexTangent.w * cross(tangent, normal));
+                    binormal = normalize(vertexTangent.w * cross(normal, tangent));
                     texCoord = actualTexCoords;
                     position = vec3(fyrox_worldMatrix * finalVertexPosition);
                     secondTexCoord = vertexSecondTexCoord;
@@ -183,7 +183,7 @@
                     vec2 tc;
                     if (fyrox_usePOM) {
                         vec3 toFragmentTangentSpace = normalize(transpose(tangentSpace) * toFragment);
-                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale, normal);
+                        tc = S_ComputeParallaxTextureCoordinates(heightTexture, toFragmentTangentSpace, texCoord * texCoordScale);
                     } else {
                         tc = texCoord * texCoordScale;
                     }

--- a/src/renderer/framework/shaders/shared.glsl
+++ b/src/renderer/framework/shaders/shared.glsl
@@ -297,7 +297,7 @@ vec2 S_ComputeParallaxTextureCoordinates(in sampler2D heightTexture, vec3 eyeVec
 
     for (int i = 0; i < maxIterations; i++) {
         if (currentLayerDepth < currentDepthMapValue) {
-            currentTexCoords += deltaTexCoords;
+            currentTexCoords -= deltaTexCoords;
             currentDepthMapValue = Internal_FetchHeight(heightTexture, currentTexCoords);
             currentLayerDepth += layerDepth;
         } else {
@@ -305,7 +305,7 @@ vec2 S_ComputeParallaxTextureCoordinates(in sampler2D heightTexture, vec3 eyeVec
         }
     }
 
-    vec2 prev = currentTexCoords - deltaTexCoords;
+    vec2 prev = currentTexCoords + deltaTexCoords;
     float nextH = currentDepthMapValue - currentLayerDepth;
     float prevH = Internal_FetchHeight(heightTexture, prev) - currentLayerDepth + layerDepth;
 

--- a/src/renderer/framework/shaders/shared.glsl
+++ b/src/renderer/framework/shaders/shared.glsl
@@ -279,18 +279,17 @@ float Internal_FetchHeight(in sampler2D heightTexture, vec2 texCoords, float cen
     return clamp(texture(heightTexture, texCoords).r - center, 0.0, 1.0);
 }
 
-vec2 S_ComputeParallaxTextureCoordinates(in sampler2D heightTexture, vec3 eyeVec, vec2 texCoords, float center) {
+vec2 S_ComputeParallaxTextureCoordinates(in sampler2D heightTexture, vec3 eyeVec, vec2 texCoords, float center, float scale) {
     const float minLayers = 8.0;
     const float maxLayers = 15.0;
     const int maxIterations = 15;
-    const float parallaxScale = 0.1;
 
     float t = max(0.0, abs(dot(vec3(0.0, 0.0, 1.0), eyeVec)));
     float numLayers = mix(maxLayers, minLayers, t);
     float layerDepth = 1.0 / numLayers;
     float currentLayerDepth = 0.0;
 
-    vec2 deltaTexCoords = parallaxScale * eyeVec.xy / numLayers;
+    vec2 deltaTexCoords = scale * eyeVec.xy / numLayers;
 
     vec2 currentTexCoords = texCoords;
     float currentDepthMapValue = Internal_FetchHeight(heightTexture, currentTexCoords, center);

--- a/src/renderer/framework/shaders/shared.glsl
+++ b/src/renderer/framework/shaders/shared.glsl
@@ -275,11 +275,11 @@ float S_SpotShadowFactor(
     }
 }
 
-float Internal_FetchHeight(in sampler2D heightTexture, vec2 texCoords) {
-    return texture(heightTexture, texCoords).r;
+float Internal_FetchHeight(in sampler2D heightTexture, vec2 texCoords, float center) {
+    return clamp(texture(heightTexture, texCoords).r - center, 0.0, 1.0);
 }
 
-vec2 S_ComputeParallaxTextureCoordinates(in sampler2D heightTexture, vec3 eyeVec, vec2 texCoords) {
+vec2 S_ComputeParallaxTextureCoordinates(in sampler2D heightTexture, vec3 eyeVec, vec2 texCoords, float center) {
     const float minLayers = 8.0;
     const float maxLayers = 15.0;
     const int maxIterations = 15;
@@ -293,12 +293,12 @@ vec2 S_ComputeParallaxTextureCoordinates(in sampler2D heightTexture, vec3 eyeVec
     vec2 deltaTexCoords = parallaxScale * eyeVec.xy / numLayers;
 
     vec2 currentTexCoords = texCoords;
-    float currentDepthMapValue = Internal_FetchHeight(heightTexture, currentTexCoords);
+    float currentDepthMapValue = Internal_FetchHeight(heightTexture, currentTexCoords, center);
 
     for (int i = 0; i < maxIterations; i++) {
         if (currentLayerDepth < currentDepthMapValue) {
             currentTexCoords -= deltaTexCoords;
-            currentDepthMapValue = Internal_FetchHeight(heightTexture, currentTexCoords);
+            currentDepthMapValue = Internal_FetchHeight(heightTexture, currentTexCoords, center);
             currentLayerDepth += layerDepth;
         } else {
             break;
@@ -307,7 +307,7 @@ vec2 S_ComputeParallaxTextureCoordinates(in sampler2D heightTexture, vec3 eyeVec
 
     vec2 prev = currentTexCoords + deltaTexCoords;
     float nextH = currentDepthMapValue - currentLayerDepth;
-    float prevH = Internal_FetchHeight(heightTexture, prev) - currentLayerDepth + layerDepth;
+    float prevH = Internal_FetchHeight(heightTexture, prev, center) - currentLayerDepth + layerDepth;
 
     float weight = nextH / (nextH - prevH);
 

--- a/src/scene/mesh/mod.rs
+++ b/src/scene/mesh/mod.rs
@@ -449,9 +449,9 @@ impl NodeTrait for Mesh {
                     )
                     .normalize()
                     .scale(len);
-                let binormal = tangent
+                let binormal = normal
                     .xyz()
-                    .cross(&normal)
+                    .cross(&tangent)
                     .scale(vertex_tangent.w)
                     .normalize()
                     .scale(len);


### PR DESCRIPTION
- Fixes TBN - binormal vector was facing opposite direction
- Fixes parallax mapping - normal vector was used incorrectly, because all calculations performed in TBN space, but normal vector was in world space.
- Improved parallax mapping by adding parallax scaling and parallax center. Parallax center is used for height maps that has baseline other than zero

Fixes #71 