### PR TITLE
Expose font fields publicly for manual creation

### DIFF
--- a/fyrox-ui/src/ttf.rs
+++ b/fyrox-ui/src/ttf.rs
@@ -24,13 +24,13 @@ pub struct FontGlyph {
 }
 
 pub struct Font {
-    height: f32,
-    glyphs: Vec<FontGlyph>,
-    ascender: f32,
-    descender: f32,
-    char_map: FxHashMap<u32, usize>,
-    atlas: Vec<u8>,
-    atlas_size: usize,
+    pub height: f32,
+    pub glyphs: Vec<FontGlyph>,
+    pub ascender: f32,
+    pub descender: f32,
+    pub char_map: FxHashMap<u32, usize>,
+    pub atlas: Vec<u8>,
+    pub atlas_size: usize,
     pub texture: Option<SharedTexture>,
 }
 


### PR DESCRIPTION
## Description

I am working on a game remake which uses a non-standard bitmap font format, this change makes the fields of the font structure public so that it can be created manually from its components (For custom formats that have access to all the required fields and can directly set the glyph and tex data where the texture atlas is already created)

## Changes

- Made the fields of "Font" from fyrox-ui/src/ttf.rs public so they can be created manually like "FontGlyph"

## My usage

I've attached my usage of this below where I already have the font texture atlas and just directly create the fields (Sorry about the code quality in the screenshot its basically my minimal viable product for getting fonts to render): 
![image](https://github.com/FyroxEngine/Fyrox/assets/33708767/ce466d46-b9d7-4344-85a9-0e70091c3ced)

![image](https://github.com/FyroxEngine/Fyrox/assets/33708767/408b6340-66d5-4003-94fe-2ef1e1fc87a1)


 