### PR TITLE
Feature: ResourceIo system

### DIFF
--- a/editor/src/asset/inspector/handlers/model.rs
+++ b/editor/src/asset/inspector/handlers/model.rs
@@ -1,6 +1,7 @@
 use crate::asset::inspector::handlers::ImportOptionsHandler;
 use fyrox::{
     asset::{
+        io::FsResourceIo,
         manager::ResourceManager,
         options::{try_get_import_settings, ImportOptions},
     },
@@ -19,7 +20,8 @@ impl ModelImportOptionsHandler {
     pub fn new(resource_path: &Path) -> Self {
         Self {
             resource_path: resource_path.to_owned(),
-            options: block_on(try_get_import_settings(resource_path)).unwrap_or_default(),
+            options: block_on(try_get_import_settings(resource_path, &FsResourceIo))
+                .unwrap_or_default(),
         }
     }
 }
@@ -33,7 +35,8 @@ impl ImportOptionsHandler for ModelImportOptionsHandler {
     }
 
     fn revert(&mut self) {
-        self.options = block_on(try_get_import_settings(&self.resource_path)).unwrap_or_default();
+        self.options = block_on(try_get_import_settings(&self.resource_path, &FsResourceIo))
+            .unwrap_or_default();
     }
 
     fn value(&self) -> &dyn Reflect {

--- a/editor/src/asset/inspector/handlers/sound.rs
+++ b/editor/src/asset/inspector/handlers/sound.rs
@@ -1,6 +1,7 @@
 use crate::asset::inspector::handlers::ImportOptionsHandler;
 use fyrox::{
     asset::{
+        io::FsResourceIo,
         manager::ResourceManager,
         options::{try_get_import_settings, ImportOptions},
     },
@@ -19,7 +20,8 @@ impl SoundBufferImportOptionsHandler {
     pub fn new(resource_path: &Path) -> Self {
         Self {
             resource_path: resource_path.to_owned(),
-            options: block_on(try_get_import_settings(resource_path)).unwrap_or_default(),
+            options: block_on(try_get_import_settings(resource_path, &FsResourceIo))
+                .unwrap_or_default(),
         }
     }
 }
@@ -36,7 +38,8 @@ impl ImportOptionsHandler for SoundBufferImportOptionsHandler {
     }
 
     fn revert(&mut self) {
-        self.options = block_on(try_get_import_settings(&self.resource_path)).unwrap_or_default();
+        self.options = block_on(try_get_import_settings(&self.resource_path, &FsResourceIo))
+            .unwrap_or_default();
     }
 
     fn value(&self) -> &dyn Reflect {

--- a/editor/src/asset/inspector/handlers/texture.rs
+++ b/editor/src/asset/inspector/handlers/texture.rs
@@ -1,6 +1,7 @@
 use crate::asset::inspector::handlers::ImportOptionsHandler;
 use fyrox::{
     asset::{
+        io::FsResourceIo,
         manager::ResourceManager,
         options::{try_get_import_settings, ImportOptions},
     },
@@ -19,7 +20,8 @@ impl TextureImportOptionsHandler {
     pub fn new(resource_path: &Path) -> Self {
         Self {
             resource_path: resource_path.to_owned(),
-            options: block_on(try_get_import_settings(resource_path)).unwrap_or_default(),
+            options: block_on(try_get_import_settings(resource_path, &FsResourceIo))
+                .unwrap_or_default(),
         }
     }
 }
@@ -36,7 +38,8 @@ impl ImportOptionsHandler for TextureImportOptionsHandler {
     }
 
     fn revert(&mut self) {
-        self.options = block_on(try_get_import_settings(&self.resource_path)).unwrap_or_default();
+        self.options = block_on(try_get_import_settings(&self.resource_path, &FsResourceIo))
+            .unwrap_or_default();
     }
 
     fn value(&self) -> &dyn Reflect {

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -80,7 +80,7 @@ use crate::{
     utils::{doc::DocWindow, path_fixer::PathFixer},
     world::{graph::selection::GraphSelection, WorldViewer},
 };
-use fyrox::event_loop::EventLoopWindowTarget;
+use fyrox::{asset::io::FsResourceIo, event_loop::EventLoopWindowTarget};
 use fyrox::{
     asset::manager::ResourceManager,
     core::{
@@ -1867,6 +1867,7 @@ impl Editor {
         let result = {
             block_on(SceneLoader::from_file(
                 &scene_path,
+                &FsResourceIo,
                 engine.serialization_context.clone(),
                 engine.resource_manager.clone(),
             ))

--- a/fyrox-core/src/io.rs
+++ b/fyrox-core/src/io.rs
@@ -112,3 +112,41 @@ pub async fn exists<P: AsRef<Path>>(path: P) -> bool {
         }
     }
 }
+
+pub async fn is_dir<P: AsRef<Path>>(path: P) -> bool {
+    #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
+    {
+        path.as_ref().is_dir()
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        ANDROID_APP
+            .get()
+            .map(|v| {
+                v.asset_manager()
+                    .open_dir(&std::ffi::CString::new(path.as_ref().to_str().unwrap()).unwrap())
+                    .is_some()
+            })
+            .unwrap_or_default()
+    }
+
+    // TODO: Is directory checking possible on wasm?
+    #[cfg(target_arch = "wasm32")]
+    {
+        false
+    }
+}
+
+pub async fn is_file<P: AsRef<Path>>(path: P) -> bool {
+    #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
+    {
+        path.as_ref().is_file()
+    }
+
+    // On android of wasm the default exists logic works for files
+    #[cfg(any(target_os = "android", target_arch = "wasm32"))]
+    {
+        exists(path).await
+    }
+}

--- a/fyrox-core/src/io.rs
+++ b/fyrox-core/src/io.rs
@@ -144,7 +144,7 @@ pub async fn is_file<P: AsRef<Path>>(path: P) -> bool {
         path.as_ref().is_file()
     }
 
-    // On android of wasm the default exists logic works for files
+    // On android and wasm the default exists logic works for files
     #[cfg(any(target_os = "android", target_arch = "wasm32"))]
     {
         exists(path).await

--- a/fyrox-core/src/io.rs
+++ b/fyrox-core/src/io.rs
@@ -113,7 +113,7 @@ pub async fn exists<P: AsRef<Path>>(path: P) -> bool {
     }
 }
 
-pub async fn is_dir<P: AsRef<Path>>(path: P) -> bool {
+pub async fn is_dir<P: AsRef<Path>>(#[allow(unused)] path: P) -> bool {
     #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
     {
         path.as_ref().is_dir()

--- a/fyrox-resource/Cargo.toml
+++ b/fyrox-resource/Cargo.toml
@@ -19,3 +19,4 @@ fyrox-core = { path = "../fyrox-core", version = "0.26.0" }
 fxhash = "0.2.1"
 ron = "0.8.0"
 serde = { version = "1", features = ["derive"] }
+walkdir = "2.3.2"

--- a/fyrox-resource/src/io.rs
+++ b/fyrox-resource/src/io.rs
@@ -12,17 +12,8 @@ use std::{
 };
 
 /// Trait for files readers ensuring they implement the required traits
-#[cfg(target_arch = "wasm32")]
-pub trait FileReader: Debug + Read + Seek + 'static {}
-
-#[cfg(target_arch = "wasm32")]
-impl<F> FileReader for F where F: Debug + Read + Seek + 'static {}
-
-/// Trait for files readers ensuring they implement the required traits
-#[cfg(not(target_arch = "wasm32"))]
 pub trait FileReader: Debug + Send + Read + Seek + 'static {}
 
-#[cfg(not(target_arch = "wasm32"))]
 impl<F> FileReader for F where F: Debug + Send + Read + Seek + 'static {}
 
 /// Interface wrapping IO operations for doing this like loading files

--- a/fyrox-resource/src/io.rs
+++ b/fyrox-resource/src/io.rs
@@ -1,0 +1,74 @@
+//! Provides an interface for IO operations that a resource loader will use, this facilliates
+//! things such as loading assets within archive files
+
+use std::{
+    fmt::Debug,
+    io::{Cursor, Read, Seek},
+    path::Path,
+};
+
+use fyrox_core::{futures::future::BoxFuture, io::FileLoadError};
+
+/// Trait for files readers ensuring they implement the required traits
+pub trait FileReader: Debug + Send + Read + Seek + 'static {}
+
+impl<F> FileReader for F where F: Debug + Send + Read + Seek + 'static {}
+
+/// Interface wrapping IO operations for doing this like loading files
+/// for resources
+pub trait ResourceIo: Send + Sync + 'static {
+    /// Attempts to load the file at the provided path returning
+    /// the entire byte contents of the file or an error
+    fn load_file<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, Result<Vec<u8>, FileLoadError>>;
+
+    /// Attempts to open a file reader to the proivded path for
+    /// reading its bytes
+    ///
+    /// Default implementation loads the entire file contents from `load_file`
+    /// then uses a cursor as the reader
+    fn file_reader<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> BoxFuture<'a, Result<Box<dyn FileReader>, FileLoadError>> {
+        Box::pin(async move {
+            let bytes = self.load_file(path).await?;
+            let read: Box<dyn FileReader> = Box::new(Cursor::new(bytes));
+            Ok(read)
+        })
+    }
+
+    /// Used to check whether a path exists
+    fn exists<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, bool>;
+}
+
+/// Standard resource IO provider that uses the file system to
+/// load the file bytes
+#[derive(Default)]
+pub struct FsResourceIo;
+
+impl ResourceIo for FsResourceIo {
+    fn load_file<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, Result<Vec<u8>, FileLoadError>> {
+        Box::pin(fyrox_core::io::load_file(path))
+    }
+
+    // Only use file reader when not targetting android or wasm
+    #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
+    fn file_reader<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> BoxFuture<'a, Result<Box<dyn FileReader>, FileLoadError>> {
+        Box::pin(async move {
+            let file = match std::fs::File::open(path) {
+                Ok(file) => file,
+                Err(e) => return Err(FileLoadError::Io(e)),
+            };
+
+            let read: Box<dyn FileReader> = Box::new(std::io::BufReader::new(file));
+            Ok(read)
+        })
+    }
+
+    fn exists<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, bool> {
+        Box::pin(fyrox_core::io::exists(path))
+    }
+}

--- a/fyrox-resource/src/io.rs
+++ b/fyrox-resource/src/io.rs
@@ -103,10 +103,11 @@ impl ResourceIo for FsResourceIo {
         Box::pin(fyrox_core::io::load_file(path))
     }
 
-    /// Android and wasm should fallback to the default no-op impl as im not sure if they
+    /// wasm should fallback to the default no-op impl as im not sure if they
     /// can directly read a directory
     ///
-    /// TODO: Needs an android implementation for reading a directory
+    /// Note: Android directory reading should be possible just I have not created
+    /// an implementation for this yet
     #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
     fn read_directory<'a>(
         &'a self,
@@ -119,8 +120,8 @@ impl ResourceIo for FsResourceIo {
         })
     }
 
-    /// Android and wasm should fallback to the default no-op impl as im not sure if they
-    /// can be walked
+    /// Android and wasm should fallback to the default no-op impl as they cant be
+    /// walked with WalkDir
     #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
     fn walk_directory<'a>(
         &'a self,
@@ -142,7 +143,7 @@ impl ResourceIo for FsResourceIo {
 
     /// Only use file reader when not targetting android or wasm
     ///
-    /// Note: Might be possible to using the android Asset for reading as
+    /// Note: Might be possible to use the Android Asset struct for reading as
     /// long as its Send + Sync + 'static (It already implements Debug + Read + Seek)
     #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
     fn file_reader<'a>(

--- a/fyrox-resource/src/io.rs
+++ b/fyrox-resource/src/io.rs
@@ -1,7 +1,7 @@
 //! Provides an interface for IO operations that a resource loader will use, this facilliates
 //! things such as loading assets within archive files
 
-use fyrox_core::{futures::future::BoxFuture, io::FileLoadError};
+use fyrox_core::io::FileLoadError;
 use std::future::{ready, Future};
 use std::iter::empty;
 use std::pin::Pin;

--- a/fyrox-resource/src/io.rs
+++ b/fyrox-resource/src/io.rs
@@ -3,7 +3,6 @@
 
 use std::{
     fmt::Debug,
-    future::ready,
     io::{Cursor, Read, Seek},
     path::{Path, PathBuf},
 };
@@ -73,6 +72,8 @@ impl ResourceIo for FsResourceIo {
         // I dont think directory walking works on android or wasm so this is no-op with an empty iterator
         #[cfg(any(target_os = "android", target_arch = "wasm32"))]
         {
+            use std::future::ready;
+
             let iter: Box<dyn Iterator<Item = PathBuf> + Send> = Box::new(None.into_iter());
             return Box::pin(ready(Ok(iter)));
         }

--- a/fyrox-resource/src/io.rs
+++ b/fyrox-resource/src/io.rs
@@ -3,11 +3,13 @@
 
 use std::{
     fmt::Debug,
+    future::ready,
     io::{Cursor, Read, Seek},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use fyrox_core::{futures::future::BoxFuture, io::FileLoadError};
+use walkdir::WalkDir;
 
 /// Trait for files readers ensuring they implement the required traits
 pub trait FileReader: Debug + Send + Read + Seek + 'static {}
@@ -20,6 +22,13 @@ pub trait ResourceIo: Send + Sync + 'static {
     /// Attempts to load the file at the provided path returning
     /// the entire byte contents of the file or an error
     fn load_file<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, Result<Vec<u8>, FileLoadError>>;
+
+    /// Provides an iterator over the paths present in the provided
+    /// path directory FsResourceIo uses WalkDir bu
+    fn walk_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> BoxFuture<'a, Result<Box<dyn Iterator<Item = PathBuf>>, FileLoadError>>;
 
     /// Attempts to open a file reader to the proivded path for
     /// reading its bytes
@@ -39,6 +48,12 @@ pub trait ResourceIo: Send + Sync + 'static {
 
     /// Used to check whether a path exists
     fn exists<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, bool>;
+
+    /// Used to check whether a path is a file
+    fn is_file<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, bool>;
+
+    /// Used to check whether a path is a dir
+    fn is_dir<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, bool>;
 }
 
 /// Standard resource IO provider that uses the file system to
@@ -51,7 +66,29 @@ impl ResourceIo for FsResourceIo {
         Box::pin(fyrox_core::io::load_file(path))
     }
 
-    // Only use file reader when not targetting android or wasm
+    fn walk_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> BoxFuture<'a, Result<Box<dyn Iterator<Item = PathBuf>>, FileLoadError>> {
+        Box::pin(async move {
+            // TODO: I'm not sure if WalkDir is acceptable for wasm and mobile platforms
+            // might need to be updated for those platforms
+
+            let iter = WalkDir::new(path)
+                .into_iter()
+                .flatten()
+                .map(|value| value.into_path());
+
+            let iter: Box<dyn Iterator<Item = PathBuf>> = Box::new(iter);
+
+            Ok(iter)
+        })
+    }
+
+    /// Only use file reader when not targetting android or wasm
+    ///
+    /// Note: Might be possible to using the android Asset for reading as
+    /// long as its Send + Sync + 'static (It already implements Debug + Read + Seek)
     #[cfg(all(not(target_os = "android"), not(target_arch = "wasm32")))]
     fn file_reader<'a>(
         &'a self,
@@ -70,5 +107,13 @@ impl ResourceIo for FsResourceIo {
 
     fn exists<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, bool> {
         Box::pin(fyrox_core::io::exists(path))
+    }
+
+    fn is_file<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, bool> {
+        Box::pin(fyrox_core::io::is_file(path))
+    }
+
+    fn is_dir<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, bool> {
+        Box::pin(fyrox_core::io::is_dir(path))
     }
 }

--- a/fyrox-resource/src/io.rs
+++ b/fyrox-resource/src/io.rs
@@ -10,7 +10,6 @@ use std::{
     io::{Cursor, Read, Seek},
     path::{Path, PathBuf},
 };
-use walkdir::WalkDir;
 
 /// Trait for files readers ensuring they implement the required traits
 #[cfg(target_arch = "wasm32")]
@@ -137,6 +136,8 @@ impl ResourceIo for FsResourceIo {
         path: &'a Path,
     ) -> ResourceIoFuture<'a, Result<PathIter, FileLoadError>> {
         Box::pin(async move {
+            use walkdir::WalkDir;
+
             let iter = WalkDir::new(path)
                 .into_iter()
                 .flatten()

--- a/fyrox-resource/src/lib.rs
+++ b/fyrox-resource/src/lib.rs
@@ -37,6 +37,7 @@ pub mod constructor;
 pub mod entry;
 pub mod event;
 pub mod graph;
+pub mod io;
 pub mod loader;
 pub mod manager;
 pub mod options;

--- a/fyrox-resource/src/loader.rs
+++ b/fyrox-resource/src/loader.rs
@@ -1,8 +1,8 @@
 //! Resource loader. It manages resource loading.
 
-use crate::{event::ResourceEventBroadcaster, UntypedResource};
+use crate::{event::ResourceEventBroadcaster, io::ResourceIo, UntypedResource};
 use fyrox_core::uuid::Uuid;
-use std::{any::Any, future::Future, pin::Pin};
+use std::{any::Any, future::Future, pin::Pin, sync::Arc};
 
 #[cfg(target_arch = "wasm32")]
 #[doc(hidden)]
@@ -58,6 +58,7 @@ pub trait ResourceLoader: ResourceLoaderTypeTrait {
         resource: UntypedResource,
         event_broadcaster: ResourceEventBroadcaster,
         reload: bool,
+        io: Arc<dyn ResourceIo>,
     ) -> BoxedLoaderFuture;
 }
 
@@ -184,6 +185,7 @@ mod test {
             _resource: UntypedResource,
             _event_broadcaster: ResourceEventBroadcaster,
             _reload: bool,
+            _io: Arc<dyn ResourceIo>,
         ) -> BoxedLoaderFuture {
             todo!()
         }

--- a/fyrox-resource/src/manager.rs
+++ b/fyrox-resource/src/manager.rs
@@ -61,7 +61,7 @@ pub struct ResourceManagerState {
     /// A set of built-in resources, that will be used to resolve references on deserialization.
     pub built_in_resources: FxHashMap<PathBuf, UntypedResource>,
     /// The resource acccess interface
-    pub resource_io: Arc<dyn ResourceIo>,
+    resource_io: Arc<dyn ResourceIo>,
 
     resources: Vec<TimedEntry<UntypedResource>>,
     task_pool: Arc<TaskPool>,
@@ -118,6 +118,12 @@ impl ResourceManager {
     /// Returns a guarded reference to internal state of resource manager.
     pub fn state(&self) -> MutexGuard<'_, ResourceManagerState> {
         self.state.lock()
+    }
+
+    /// Returns the ResourceIo used by this resource manager
+    pub fn resource_io(&self) -> Arc<dyn ResourceIo> {
+        let state = self.state();
+        state.resource_io.clone()
     }
 
     /// Requests a resource of the given type located at the given path. This method is non-blocking, instead

--- a/fyrox-resource/src/options.rs
+++ b/fyrox-resource/src/options.rs
@@ -1,6 +1,6 @@
 //! Resource import options common traits.
 
-use crate::core::{append_extension, io};
+use crate::{core::append_extension, io::ResourceIo};
 use fyrox_core::log::Log;
 use ron::ser::PrettyConfig;
 use serde::{de::DeserializeOwned, Serialize};
@@ -21,13 +21,13 @@ pub trait ImportOptions: Serialize + DeserializeOwned + Default + Clone {
 
 /// Tries to load import settings for a resource. It is not part of ImportOptions trait because
 /// `async fn` is not yet supported for traits.
-pub async fn try_get_import_settings<T>(resource_path: &Path) -> Option<T>
+pub async fn try_get_import_settings<T>(resource_path: &Path, io: &dyn ResourceIo) -> Option<T>
 where
     T: ImportOptions,
 {
     let settings_path = append_extension(resource_path, "options");
 
-    match io::load_file(&settings_path).await {
+    match io.load_file(settings_path.as_ref()).await {
         Ok(bytes) => match ron::de::from_bytes::<T>(&bytes) {
             Ok(options) => Some(options),
             Err(e) => {

--- a/fyrox-sound/examples/hrtf.rs
+++ b/fyrox-sound/examples/hrtf.rs
@@ -1,4 +1,5 @@
 use fyrox_core::algebra::Point3;
+use fyrox_resource::io::FsResourceIo;
 use fyrox_sound::buffer::SoundBufferResourceExtension;
 use fyrox_sound::renderer::hrtf::{HrirSphereResource, HrirSphereResourceExt};
 use fyrox_sound::{
@@ -38,7 +39,11 @@ fn main() {
 
     // Create some sounds.
     let sound_buffer = SoundBufferResource::new_generic(
-        block_on(DataSource::from_file("examples/data/door_open.wav")).unwrap(),
+        block_on(DataSource::from_file(
+            "examples/data/door_open.wav", // Load from the default resource io (File system)
+            &FsResourceIo,
+        ))
+        .unwrap(),
     )
     .unwrap();
     let source = SoundSourceBuilder::new()
@@ -49,7 +54,11 @@ fn main() {
     context.state().add_source(source);
 
     let sound_buffer = SoundBufferResource::new_generic(
-        block_on(DataSource::from_file("examples/data/helicopter.wav")).unwrap(),
+        block_on(DataSource::from_file(
+            "examples/data/helicopter.wav", // Load from the default resource io (File system)
+            &FsResourceIo,
+        ))
+        .unwrap(),
     )
     .unwrap();
     let source = SoundSourceBuilder::new()

--- a/fyrox-sound/examples/listener.rs
+++ b/fyrox-sound/examples/listener.rs
@@ -1,4 +1,5 @@
 use fyrox_core::algebra::Point3;
+use fyrox_resource::io::FsResourceIo;
 use fyrox_sound::buffer::SoundBufferResourceExtension;
 use fyrox_sound::{
     algebra::{UnitQuaternion, Vector3},
@@ -24,7 +25,11 @@ fn main() {
 
     // Load sound buffer.
     let drop_buffer = SoundBufferResource::new_generic(
-        block_on(DataSource::from_file("examples/data/drop.wav")).unwrap(),
+        block_on(DataSource::from_file(
+            "examples/data/drop.wav", // Load from the default resource io (File system)
+            &FsResourceIo,
+        ))
+        .unwrap(),
     )
     .unwrap();
 

--- a/fyrox-sound/examples/play_sound.rs
+++ b/fyrox-sound/examples/play_sound.rs
@@ -1,3 +1,4 @@
+use fyrox_resource::io::FsResourceIo;
 use fyrox_sound::buffer::SoundBufferResourceExtension;
 use fyrox_sound::{
     buffer::{DataSource, SoundBufferResource},
@@ -22,6 +23,8 @@ fn main() {
     let door_open_buffer = SoundBufferResource::new_generic(
         fyrox_sound::futures::executor::block_on(DataSource::from_file(
             "examples/data/door_open.wav",
+            // Load from the default resource io (File system)
+            &FsResourceIo,
         ))
         .unwrap(),
     )

--- a/fyrox-sound/examples/play_spatial_sound.rs
+++ b/fyrox-sound/examples/play_spatial_sound.rs
@@ -1,4 +1,5 @@
 use fyrox_core::futures::executor::block_on;
+use fyrox_resource::io::FsResourceIo;
 use fyrox_sound::buffer::SoundBufferResourceExtension;
 use fyrox_sound::{
     algebra::{Point3, UnitQuaternion, Vector3},
@@ -24,7 +25,12 @@ fn main() {
 
     // Load sound buffer.
     let drop_buffer = SoundBufferResource::new_generic(
-        block_on(DataSource::from_file("examples/data/drop.wav")).unwrap(),
+        block_on(DataSource::from_file(
+            "examples/data/drop.wav",
+            // Load from the default resource io (File system)
+            &FsResourceIo,
+        ))
+        .unwrap(),
     )
     .unwrap();
 

--- a/fyrox-sound/examples/reverb.rs
+++ b/fyrox-sound/examples/reverb.rs
@@ -1,3 +1,4 @@
+use fyrox_resource::io::FsResourceIo;
 use fyrox_sound::buffer::SoundBufferResourceExtension;
 use fyrox_sound::renderer::hrtf::{HrirSphereResource, HrirSphereResourceExt};
 use fyrox_sound::{
@@ -51,7 +52,11 @@ fn main() {
 
     // Create some sounds.
     let sound_buffer = SoundBufferResource::new_generic(
-        block_on(DataSource::from_file("examples/data/door_open.wav")).unwrap(),
+        block_on(DataSource::from_file(
+            "examples/data/door_open.wav", // Load from the default resource io (File system)
+            &FsResourceIo,
+        ))
+        .unwrap(),
     )
     .unwrap();
     let source = SoundSourceBuilder::new()
@@ -64,7 +69,12 @@ fn main() {
     context.state().add_source(source);
 
     let sound_buffer = SoundBufferResource::new_generic(
-        block_on(DataSource::from_file("examples/data/drop.wav")).unwrap(),
+        block_on(DataSource::from_file(
+            "examples/data/drop.wav",
+            // Load from the default resource io (File system)
+            &FsResourceIo,
+        ))
+        .unwrap(),
     )
     .unwrap();
     let source = SoundSourceBuilder::new()

--- a/fyrox-sound/examples/streaming.rs
+++ b/fyrox-sound/examples/streaming.rs
@@ -1,3 +1,4 @@
+use fyrox_resource::io::FsResourceIo;
 use fyrox_sound::buffer::SoundBufferResourceExtension;
 use fyrox_sound::{
     buffer::{DataSource, SoundBufferResource},
@@ -20,7 +21,12 @@ fn main() {
 
     // Load sound buffer.
     let waterfall_buffer = SoundBufferResource::new_streaming(
-        block_on(DataSource::from_file("examples/data/waterfall.ogg")).unwrap(),
+        block_on(DataSource::from_file(
+            "examples/data/waterfall.ogg",
+            // Load from the default resource io (File system)
+            &FsResourceIo,
+        ))
+        .unwrap(),
     )
     .unwrap();
 

--- a/fyrox-sound/examples/write_wav.rs
+++ b/fyrox-sound/examples/write_wav.rs
@@ -1,3 +1,4 @@
+use fyrox_resource::io::FsResourceIo;
 use fyrox_sound::buffer::SoundBufferResourceExtension;
 use fyrox_sound::engine::State;
 use fyrox_sound::{
@@ -22,6 +23,8 @@ fn main() {
     let door_open_buffer = SoundBufferResource::new_generic(
         fyrox_sound::futures::executor::block_on(DataSource::from_file(
             "examples/data/door_open.wav",
+            // Load from the default resource io (File system)
+            &FsResourceIo,
         ))
         .unwrap(),
     )

--- a/fyrox-sound/src/buffer/generic.rs
+++ b/fyrox-sound/src/buffer/generic.rs
@@ -13,9 +13,10 @@
 //! ```no_run
 //! use std::sync::{Mutex, Arc};
 //! use fyrox_sound::buffer::{SoundBufferResource, DataSource, SoundBufferResourceExtension};
+//! use fyrox_resource::io::FsResourceIo;
 //!
 //! async fn make_buffer() -> SoundBufferResource {
-//!     let data_source = DataSource::from_file("sound.wav").await.unwrap();
+//!     let data_source = DataSource::from_file("sound.wav", &FsResourceIo).await.unwrap();
 //!     SoundBufferResource::new_generic(data_source).unwrap()
 //! }
 //! ```
@@ -167,7 +168,7 @@ impl GenericBuffer {
         self.sample_rate
     }
 
-    /// Returns exact time length of the buffer.  
+    /// Returns exact time length of the buffer.
     #[inline]
     pub fn duration(&self) -> Duration {
         Duration::from_nanos(

--- a/fyrox-sound/src/buffer/streaming.rs
+++ b/fyrox-sound/src/buffer/streaming.rs
@@ -14,9 +14,10 @@
 //! ```no_run
 //! use std::sync::{Mutex, Arc};
 //! use fyrox_sound::buffer::{SoundBufferResource, DataSource, SoundBufferResourceExtension};
+//! use fyrox_resource::io::FsResourceIo;
 //!
 //! async fn make_streaming_buffer() -> SoundBufferResource {
-//!     let data_source = DataSource::from_file("some_long_sound.ogg").await.unwrap();
+//!     let data_source = DataSource::from_file("some_long_sound.ogg", &FsResourceIo).await.unwrap();
 //!     SoundBufferResource::new_streaming(data_source).unwrap()
 //! }
 //! ```

--- a/fyrox-sound/src/lib.rs
+++ b/fyrox-sound/src/lib.rs
@@ -30,10 +30,11 @@
 //!     },
 //! };
 //! use fyrox_sound::buffer::SoundBufferResourceExtension;
+//! use fyrox_resource::io::FsResourceIo;
 //!
 //!  let context = SoundContext::new();
 //!
-//!  let sound_buffer = SoundBufferResource::new_generic(fyrox_sound::futures::executor::block_on(DataSource::from_file("sound.wav")).unwrap()).unwrap();
+//!  let sound_buffer = SoundBufferResource::new_generic(fyrox_sound::futures::executor::block_on(DataSource::from_file("sound.wav", &FsResourceIo)).unwrap()).unwrap();
 //!
 //!  let source = SoundSourceBuilder::new()
 //!     .with_buffer(sound_buffer)

--- a/fyrox-sound/src/renderer/hrtf.rs
+++ b/fyrox-sound/src/renderer/hrtf.rs
@@ -67,6 +67,7 @@ use fyrox_core::{
 };
 use fyrox_resource::{
     event::ResourceEventBroadcaster,
+    io::ResourceIo,
     loader::{BoxedLoaderFuture, ResourceLoader},
     untyped::UntypedResource,
     Resource, ResourceData, ResourceStateRef,
@@ -77,8 +78,8 @@ use std::{
     borrow::Cow,
     fmt::Debug,
     fmt::Formatter,
-    io::Cursor,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 /// See module docs.
@@ -260,12 +261,13 @@ impl ResourceLoader for HrirSphereLoader {
         hrir_sphere: UntypedResource,
         event_broadcaster: ResourceEventBroadcaster,
         reload: bool,
+        io: Arc<dyn ResourceIo>,
     ) -> BoxedLoaderFuture {
         Box::pin(async move {
             let path = hrir_sphere.path().to_path_buf();
 
-            match fyrox_core::io::load_file(&path).await {
-                Ok(file) => match HrirSphere::new(Cursor::new(file), context::SAMPLE_RATE) {
+            match io.file_reader(&path).await {
+                Ok(reader) => match HrirSphere::new(reader, context::SAMPLE_RATE) {
                     Ok(sphere) => {
                         Log::info(format!("HRIR sphere {:?} is loaded!", path));
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -330,10 +330,7 @@ impl AsyncSceneLoader {
             let resource_manager = self.resource_manager.clone();
 
             // Aquire the resource IO from the resource manager
-            let io = {
-                let state = resource_manager.state();
-                state.resource_io.clone()
-            };
+            let io = resource_manager.resource_io();
 
             let future = async move {
                 match SceneLoader::from_file(

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -328,9 +328,17 @@ impl AsyncSceneLoader {
             let sender = self.sender.clone();
             let serialization_context = self.serialization_context.clone();
             let resource_manager = self.resource_manager.clone();
+
+            // Aquire the resource IO from the resource manager
+            let io = {
+                let state = resource_manager.state();
+                state.resource_io.clone()
+            };
+
             let future = async move {
                 match SceneLoader::from_file(
                     path.clone(),
+                    io.as_ref(),
                     serialization_context,
                     resource_manager.clone(),
                 )
@@ -455,14 +463,14 @@ impl ScriptMessageDispatcher {
             .or_insert_with(|| FxHashSet::from_iter([receiver]));
     }
 
-    /// Unsubscribes a node from receiving any messages of the given type `T`.  
+    /// Unsubscribes a node from receiving any messages of the given type `T`.
     pub fn unsubscribe_from<T: 'static>(&mut self, receiver: Handle<Node>) {
         if let Some(group) = self.type_groups.get_mut(&TypeId::of::<T>()) {
             group.remove(&receiver);
         }
     }
 
-    /// Unsubscribes a node from receiving any messages.  
+    /// Unsubscribes a node from receiving any messages.
     pub fn unsubscribe(&mut self, receiver: Handle<Node>) {
         for group in self.type_groups.values_mut() {
             group.remove(&receiver);
@@ -1329,7 +1337,7 @@ impl Engine {
     /// will result in the almost exact copy of the context that was made before destruction.
     ///
     /// This method should be called on [`Event::Suspended`] of your game loop, however if you do not use any graphics context
-    /// (for example - if you're making a game server), then you can ignore this method completely.   
+    /// (for example - if you're making a game server), then you can ignore this method completely.
     pub fn destroy_graphics_context(&mut self) -> Result<(), EngineError> {
         if let GraphicsContext::Initialized(ref ctx) = self.graphics_context {
             let params = &ctx.params;

--- a/src/material/shader/loader.rs
+++ b/src/material/shader/loader.rs
@@ -1,11 +1,13 @@
 //! Shader loader.
 
+use std::sync::Arc;
+
 use crate::{
     asset::loader::{BoxedLoaderFuture, ResourceLoader},
     core::{log::Log, uuid::Uuid, TypeUuidProvider},
     material::shader::Shader,
 };
-use fyrox_resource::{event::ResourceEventBroadcaster, untyped::UntypedResource};
+use fyrox_resource::{event::ResourceEventBroadcaster, io::ResourceIo, untyped::UntypedResource};
 
 /// Default implementation for shader loading.
 pub struct ShaderLoader;
@@ -24,11 +26,12 @@ impl ResourceLoader for ShaderLoader {
         shader: UntypedResource,
         event_broadcaster: ResourceEventBroadcaster,
         reload: bool,
+        io: Arc<dyn ResourceIo>,
     ) -> BoxedLoaderFuture {
         Box::pin(async move {
             let path = shader.path().to_path_buf();
 
-            match Shader::from_file(&path).await {
+            match Shader::from_file(&path, io.as_ref()).await {
                 Ok(shader_state) => {
                     Log::info(format!("Shader {:?} is loaded!", path));
 

--- a/src/material/shader/mod.rs
+++ b/src/material/shader/mod.rs
@@ -229,7 +229,7 @@ use crate::{
     asset::{Resource, ResourceData},
     core::{
         algebra::{Matrix2, Matrix3, Matrix4, Vector2, Vector3, Vector4},
-        io::{self, FileLoadError},
+        io::FileLoadError,
         reflect::prelude::*,
         sparse::AtomicIndex,
         visitor::prelude::*,
@@ -239,7 +239,7 @@ use crate::{
 };
 use fyrox_core::uuid::Uuid;
 use fyrox_core::TypeUuidProvider;
-use fyrox_resource::SHADER_RESOURCE_UUID;
+use fyrox_resource::{io::ResourceIo, SHADER_RESOURCE_UUID};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::fmt::{Display, Formatter};
@@ -500,8 +500,11 @@ impl ShaderDefinition {
 }
 
 impl Shader {
-    pub(crate) async fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, ShaderError> {
-        let content = io::load_file(path.as_ref()).await?;
+    pub(crate) async fn from_file<P: AsRef<Path>>(
+        path: P,
+        io: &dyn ResourceIo,
+    ) -> Result<Self, ShaderError> {
+        let content = io.load_file(path.as_ref()).await?;
         Ok(Self {
             path: path.as_ref().to_owned(),
             definition: ShaderDefinition::from_buf(content)?,
@@ -671,7 +674,7 @@ mod test {
         let code = r#"
             (
                 name: "TestShader",
-            
+
                 properties: [
                     (
                         name: "diffuseTexture",

--- a/src/resource/curve/loader.rs
+++ b/src/resource/curve/loader.rs
@@ -1,5 +1,9 @@
 //! Curve loader.
 
+use std::sync::Arc;
+
+use fyrox_resource::io::ResourceIo;
+
 use crate::{
     asset::{
         event::ResourceEventBroadcaster,
@@ -27,10 +31,11 @@ impl ResourceLoader for CurveLoader {
         curve: UntypedResource,
         event_broadcaster: ResourceEventBroadcaster,
         reload: bool,
+        io: Arc<dyn ResourceIo>,
     ) -> BoxedLoaderFuture {
         Box::pin(async move {
             let path = curve.path();
-            match CurveResourceState::from_file(&path).await {
+            match CurveResourceState::from_file(&path, io.as_ref()).await {
                 Ok(curve_state) => {
                     Log::info(format!("Curve {:?} is loaded!", path));
 

--- a/src/resource/curve/mod.rs
+++ b/src/resource/curve/mod.rs
@@ -7,6 +7,7 @@ use crate::{
         TypeUuidProvider,
     },
 };
+use fyrox_resource::io::ResourceIo;
 use serde::{Deserialize, Serialize};
 use std::{
     any::Any,
@@ -98,8 +99,9 @@ impl TypeUuidProvider for CurveResourceState {
 
 impl CurveResourceState {
     /// Load a curve resource from the specific file path.
-    pub async fn from_file(path: &Path) -> Result<Self, CurveResourceError> {
-        let mut visitor = Visitor::load_binary(path).await?;
+    pub async fn from_file(path: &Path, io: &dyn ResourceIo) -> Result<Self, CurveResourceError> {
+        let bytes = io.load_file(path).await?;
+        let mut visitor = Visitor::load_from_memory(&bytes)?;
         let mut curve = Curve::default();
         curve.visit("Curve", &mut visitor)?;
         Ok(Self {

--- a/src/resource/fbx/document/mod.rs
+++ b/src/resource/fbx/document/mod.rs
@@ -2,10 +2,11 @@ mod ascii;
 pub mod attribute;
 mod binary;
 
+use fyrox_resource::io::ResourceIo;
+
 use crate::{
     core::{
         algebra::Vector3,
-        io,
         pool::{Handle, Pool},
     },
     resource::fbx::{document::attribute::FbxAttribute, error::FbxError},
@@ -121,11 +122,12 @@ fn is_binary(data: &[u8]) -> bool {
 }
 
 impl FbxDocument {
-    pub async fn new<P: AsRef<Path>>(path: P) -> Result<FbxDocument, FbxError> {
-        let data = io::load_file(path).await?;
-
+    pub async fn new<P: AsRef<Path>>(
+        path: P,
+        io: &dyn ResourceIo,
+    ) -> Result<FbxDocument, FbxError> {
+        let data = io.load_file(path.as_ref()).await?;
         let is_bin = is_binary(&data);
-
         let mut reader = Cursor::new(data);
 
         if is_bin {

--- a/src/resource/fbx/mod.rs
+++ b/src/resource/fbx/mod.rs
@@ -60,6 +60,7 @@ use crate::{
     utils::{self, raw_mesh::RawMeshBuilder},
 };
 use fxhash::{FxHashMap, FxHashSet};
+use fyrox_resource::io::ResourceIo;
 use std::{
     cmp::Ordering,
     collections::hash_map::DefaultHasher,
@@ -310,6 +311,7 @@ async fn create_surfaces(
             for (name, texture_handle) in material.textures.iter() {
                 let texture = fbx_scene.get(*texture_handle).as_texture()?;
                 let path = texture.get_file_path();
+
                 if let Some(filename) = path.file_name() {
                     let texture_path = match model_import_options.material_search_options {
                         MaterialSearchOptions::MaterialsDirectory(ref directory) => {
@@ -889,6 +891,7 @@ async fn convert(
 pub async fn load_to_scene<P: AsRef<Path>>(
     scene: &mut Scene,
     resource_manager: ResourceManager,
+    io: &dyn ResourceIo,
     path: P,
     model_import_options: &ModelImportOptions,
 ) -> Result<(), FbxError> {
@@ -900,7 +903,7 @@ pub async fn load_to_scene<P: AsRef<Path>>(
     );
 
     let now = Instant::now();
-    let fbx = FbxDocument::new(path.as_ref()).await?;
+    let fbx = FbxDocument::new(path.as_ref(), io).await?;
     let parsing_time = now.elapsed().as_millis();
 
     let now = Instant::now();

--- a/src/resource/model/mod.rs
+++ b/src/resource/model/mod.rs
@@ -42,6 +42,7 @@ use crate::{
         Scene, SceneLoader,
     },
 };
+use fyrox_resource::io::ResourceIo;
 use serde::{Deserialize, Serialize};
 use std::{
     any::Any,
@@ -458,6 +459,7 @@ impl From<VisitError> for ModelLoadError {
 impl Model {
     pub(crate) async fn load<P: AsRef<Path>>(
         path: P,
+        io: &dyn ResourceIo,
         serialization_context: Arc<SerializationContext>,
         resource_manager: ResourceManager,
         model_import_options: ModelImportOptions,
@@ -479,6 +481,7 @@ impl Model {
                 fbx::load_to_scene(
                     &mut scene,
                     resource_manager,
+                    io,
                     path.as_ref(),
                     &model_import_options,
                 )
@@ -492,6 +495,7 @@ impl Model {
             "rgs" => (
                 SceneLoader::from_file(
                     path.as_ref(),
+                    io,
                     serialization_context,
                     resource_manager.clone(),
                 )

--- a/src/resource/texture/mod.rs
+++ b/src/resource/texture/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     core::{
         algebra::{Vector2, Vector3},
         futures::io::Error,
-        io::{self, FileLoadError},
+        io::FileLoadError,
         reflect::prelude::*,
         uuid::Uuid,
         visitor::{PodVecView, Visit, VisitError, VisitResult, Visitor},
@@ -36,6 +36,7 @@ use ddsfile::{Caps2, D3DFormat};
 use fast_image_resize as fr;
 use fxhash::FxHasher;
 use fyrox_core::num_traits::Bounded;
+use fyrox_resource::io::ResourceIo;
 use image::{ColorType, DynamicImage, ImageError, ImageFormat, Pixel};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -405,7 +406,7 @@ impl MipFilter {
 ///     s_wrap_mode: Repeat,
 ///     t_wrap_mode: ClampToEdge,
 ///     anisotropy: 8.0,
-///     compression: NoCompression,    
+///     compression: NoCompression,
 /// )
 /// ```
 #[derive(Clone, Deserialize, Serialize, Debug, Reflect)]
@@ -1484,9 +1485,10 @@ impl Texture {
     /// resources.
     pub(crate) async fn load_from_file<P: AsRef<Path>>(
         path: P,
+        io: &dyn ResourceIo,
         import_options: TextureImportOptions,
     ) -> Result<Self, TextureError> {
-        let data = io::load_file(path.as_ref()).await?;
+        let data = io.load_file(path.as_ref()).await?;
         let mut texture = Self::load_from_memory(&data, import_options)?;
         texture.path = path.as_ref().to_path_buf();
         Ok(texture)

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -52,8 +52,8 @@ use crate::{
     },
     utils::navmesh::Navmesh,
 };
+use asset::io::ResourceIo;
 use fxhash::FxHashSet;
-use fyrox_core::io;
 use fyrox_core::variable::InheritableVariable;
 use std::{
     fmt::{Display, Formatter},
@@ -271,10 +271,11 @@ impl SceneLoader {
     /// Such scenes can be made in rusty editor.
     pub async fn from_file<P: AsRef<Path>>(
         path: P,
+        io: &dyn ResourceIo,
         serialization_context: Arc<SerializationContext>,
         resource_manager: ResourceManager,
     ) -> Result<(Self, Vec<u8>), VisitError> {
-        let data = io::load_file(path.as_ref()).await?;
+        let data = io.load_file(path.as_ref()).await?;
         let mut visitor = Visitor::load_from_memory(&data)?;
         let loader = Self::load(
             "Scene",


### PR DESCRIPTION
## Description

> Sorry in advance for the large commit

> **Warning**
> This is a breaking change, any custom resource loaders will need to be extended as I modified the arguments for load. Things that read files such as DataSource require an additional argument for the resource_io to use (I've updated the examples, tests, and editor to just use FsResourceIo)

This is basically a virtual file system implementation

I have swapped out a majority of the resource handling code (I think there's still some code that's using WalkDir however thats in the editor code only so I don't think its nessicary to port it) with an interface that I have added to the ResourceManager named ResourceIo, this is a similar abstraction to what the Bevy engine uses and abstracts the file reading and exist checking operations away from the std::fs types.

The interface provides `load_file` which reads the entire bytes of the file, `file_reader` which opens the file for streamed reading (The fallback for android and wasm just uses a cursor wrapped around the bytes from `load_file`) and `exists` which returns whether the path exists or not, `walk_directory` which provides directory walking (Uses walkdir but is no-op for android and wasm as im not sure if that can be done easily on those platforms) , `is_file` which checks if the provided path is a file, and `is_dir` which checks if the provided path is a directory (Defaulting this to false on wasm as I don't know if that can be checked reliably) `read_directory` which provides a list of paths within a directory (currently no-op for android and wasm but an android impl is likely possible just will require some extra work)

I have created a default implementation called FsResourceIo which is just an abstraction over your existing io functions from fyrox_core::io along with some new ones that I've added
![image](https://github.com/FyroxEngine/Fyrox/assets/33708767/57edadc1-fd4f-421e-9126-053d43d559a3)

I went through and replaced most of the existing usages of the functions from fyrox_core::io with usages of the abstraction

## Reason

This abstraction allows resources to be loaded from custom and packed file formats rather than having resources only and always loaded from file system paths. My use case for this is the game uses a custom packed file format to store all of its assets so I can use this feature to seek and read within the packed file format without having to extract it. It also enables the usage of zip files for storing assets if someone wants to make a ResourceIo for that purpose.

Below is my example for the custom packed asset format ResourceIo:
![image](https://github.com/FyroxEngine/Fyrox/assets/33708767/50ed8125-10b3-4a3d-9c5d-e1904e311991)

Then swapping the default resource_io:
![image](https://github.com/FyroxEngine/Fyrox/assets/33708767/f2050c7b-0e13-4e6f-a487-02b6730dfce9)

## Changes
- Added ResourceIo trait for providing IO operations for resource loading
  - With default implementation of FsResourceIo
- Added resource_io to the resource manager state
- Added helper function on resource manager for getting an Arc to the current resource_io
- Added setter to the resource manager state for setting the current resource_io
- Modified ResourceLoader load function to add the resource_io as an argument
- Replaced the previous usages of fyrox_core::io with usages of the resource_io abstraction
- Added FileReader trait to be used as a reader abstraction for readers provided by the ResourceIo 
- Swapped compile time wasm checking in DataSource with Boxed dynamic usage of FileReader provided by ResourceIO (already has the wasm handling built in as the default impl)
- Added additional IO functions to fyrox_core::io 

## Related issues
- Closes #488 
  - This change allows implementing and loading from archive file formats

## Not implemented

I have not implemented the system fully into the editor, the editor just uses FsResourceIo for all the operations that require it as it will likely require some extra ui and such for including other formats into the editor (Not sure how youd go about that)

## Resource Loader Differences

### Previous

```rust
#[derive(Eq, PartialEq, Debug)]
struct MyResourceLoader;

impl ResourceLoader for MyResourceLoader {
    fn extensions(&self) -> &[&str] {
        &[]
    }

    fn data_type_uuid(&self) -> Uuid {
        Default::default()
    }

    fn load(
        &self,
        resource: UntypedResource,
        event_broadcaster: ResourceEventBroadcaster,
        reload: bool,
    ) -> BoxedLoaderFuture {
        Box::pin(async move {
            let bytes = fyrox_core::io::load_file(resource.path().as_ref()).await.unwrap();
            // ... do something with bytes
            Ok(())
        });
    }
}
```

### New

```rust
#[derive(Eq, PartialEq, Debug)]
struct MyResourceLoader;

impl ResourceLoader for MyResourceLoader {
    fn extensions(&self) -> &[&str] {
        &[]
    }

    fn data_type_uuid(&self) -> Uuid {
        Default::default()
    }

    fn load(
        &self,
        resource: UntypedResource,
        event_broadcaster: ResourceEventBroadcaster,
        reload: bool,
        io: Arc<dyn ResourceIo>,
    ) -> BoxedLoaderFuture {
        Box::pin(async move {
            let bytes = io.load_file(resource.path().as_ref()).await.unwrap();
            // ... do something with bytes
            Ok(())
        });
    }
}
```
