### PR TITLE
Template init exists checking

### DIFF
--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -654,7 +654,10 @@ fn main() {
             // Check the path is empty / doesn't already exist (To prevent overriding)
             if !overwrite
                 && base_path.exists()
-                && read_dir(base_path).into_iter().flatten().next().is_some()
+                && read_dir(base_path)
+                    .expect("Failed to check if path is not empty")
+                    .next()
+                    .is_some()
             {
                 println!(
                     "Non-empty folder named {} already exists, provide --overwrite to create the project anyway",


### PR DESCRIPTION
## Description

Quality of life feature that checks whether the directory a project template will be initialized in either doesn't exist or is empty so that users don't accidentally override files if they create a project with a already used name (Adding this because I accidentally did it)

## Changes
- Warn user if they try to create a project in an existing non-empty directory
- Added --overwrite flag to bypass this check and create in the directory anyway

