### PR TITLE
Enhancements in the absm editor

### DIFF
--- a/editor/src/absm/state_graph/context.rs
+++ b/editor/src/absm/state_graph/context.rs
@@ -201,7 +201,6 @@ impl NodeContextMenu {
         absm_node_handle: Handle<Node>,
         absm_node: &AnimationBlendingStateMachine,
         layer_index: usize,
-        // canvas: Handle<UiNode>,
         editor_scene: &EditorScene,
     ) {
         let machine = absm_node.machine();


### PR DESCRIPTION
This is similar to my previous pr but the problem that @mrDIMAS found were solved.

**Enhancements made in the ABSM editor:**
- There is a menu added in the node context menu of the absm editor named **Create transition to all nodes** which will create transition from the source node to all states.
- In the state graph viewer similar menu is added which will connect all nodes.

Hope that this will save time while blending animations.
If any problem is found please comment me.