### PR TITLE
Refactoring of internal structure of resources

### DIFF
--- a/editor/src/asset/dependency.rs
+++ b/editor/src/asset/dependency.rs
@@ -36,23 +36,13 @@ fn build_tree_recursively(node: &ResourceGraphNode, ctx: &mut BuildContext) -> H
         .map(|c| build_tree_recursively(c, ctx))
         .collect();
 
-    let embedded = node.resource.is_embedded();
     let data_type = if let ResourceState::Ok(ref data) = node.resource.0.lock().state {
         data.type_name().to_string()
     } else {
         "Unknown".to_string()
     };
 
-    let path = node.resource.path().to_string_lossy().to_string();
-    let name = if path.is_empty() || embedded {
-        if path.is_empty() {
-            "Embedded".to_string()
-        } else {
-            format!("Embedded (id: {})", path)
-        }
-    } else {
-        path
-    };
+    let name = node.resource.kind().to_string();
 
     TreeBuilder::new(WidgetBuilder::new())
         .with_items(children)

--- a/editor/src/asset/dependency.rs
+++ b/editor/src/asset/dependency.rs
@@ -1,10 +1,10 @@
+use fyrox::asset::state::ResourceState;
 use fyrox::{
     asset::{
         graph::{ResourceDependencyGraph, ResourceGraphNode},
-        state::ResourceState,
         untyped::UntypedResource,
     },
-    core::{log::Log, pool::Handle, reflect::Reflect},
+    core::{log::Log, pool::Handle},
     gui::{
         button::{ButtonBuilder, ButtonMessage},
         copypasta::ClipboardProvider,
@@ -36,9 +36,8 @@ fn build_tree_recursively(node: &ResourceGraphNode, ctx: &mut BuildContext) -> H
         .map(|c| build_tree_recursively(c, ctx))
         .collect();
 
-    let mut embedded = false;
-    let data_type = if let ResourceState::Ok(data) = &*node.resource.0.lock() {
-        embedded = data.is_embedded();
+    let embedded = node.resource.is_embedded();
+    let data_type = if let ResourceState::Ok(ref data) = node.resource.0.lock().state {
         data.type_name().to_string()
     } else {
         "Unknown".to_string()

--- a/editor/src/asset/mod.rs
+++ b/editor/src/asset/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     utils::window_content,
     AssetItem, Message, Mode,
 };
+use fyrox::asset::untyped::ResourceHeader;
 use fyrox::{
     asset::{manager::ResourceManager, state::ResourceState, untyped::UntypedResource},
     core::{
@@ -372,11 +373,14 @@ impl ResourceCreator {
                     .map(|c| c.create_instance())
                 {
                     let path = base_path.join(&self.name_str);
-                    instance.set_path(path.clone());
                     match instance.save(&path) {
                         Ok(_) => {
-                            let resource =
-                                UntypedResource(Arc::new(Mutex::new(ResourceState::Ok(instance))));
+                            let resource = UntypedResource(Arc::new(Mutex::new(ResourceHeader {
+                                path: path.clone(),
+                                type_uuid: instance.type_uuid(),
+                                is_embedded: false,
+                                state: ResourceState::Ok(instance),
+                            })));
 
                             drop(constructors);
                             drop(resource_manager_state);

--- a/editor/src/asset/preview.rs
+++ b/editor/src/asset/preview.rs
@@ -97,7 +97,7 @@ impl AssetPreview for TexturePreview {
                     fallback: Default::default(),
                 },
             ));
-            let material = MaterialResource::new_ok(Default::default(), material, true);
+            let material = MaterialResource::new_ok(Default::default(), material);
 
             MeshBuilder::new(BaseBuilder::new())
                 .with_surfaces(vec![SurfaceBuilder::new(SurfaceSharedData::new(
@@ -194,7 +194,6 @@ impl AssetPreview for ShaderPreview {
             let material = MaterialResource::new_ok(
                 Default::default(),
                 Material::from_shader(shader, Some(resource_manager.clone())),
-                true,
             );
 
             MeshBuilder::new(BaseBuilder::new())

--- a/editor/src/asset/preview.rs
+++ b/editor/src/asset/preview.rs
@@ -97,7 +97,7 @@ impl AssetPreview for TexturePreview {
                     fallback: Default::default(),
                 },
             ));
-            let material = MaterialResource::new_ok(material);
+            let material = MaterialResource::new_ok(Default::default(), material, true);
 
             MeshBuilder::new(BaseBuilder::new())
                 .with_surfaces(vec![SurfaceBuilder::new(SurfaceSharedData::new(
@@ -191,10 +191,11 @@ impl AssetPreview for ShaderPreview {
         scene: &mut Scene,
     ) -> Handle<Node> {
         if let Some(shader) = resource.try_cast::<Shader>() {
-            let material = MaterialResource::new_ok(Material::from_shader(
-                shader,
-                Some(resource_manager.clone()),
-            ));
+            let material = MaterialResource::new_ok(
+                Default::default(),
+                Material::from_shader(shader, Some(resource_manager.clone())),
+                true,
+            );
 
             MeshBuilder::new(BaseBuilder::new())
                 .with_surfaces(vec![SurfaceBuilder::new(SurfaceSharedData::new(

--- a/editor/src/audio/preview.rs
+++ b/editor/src/audio/preview.rs
@@ -3,7 +3,6 @@ use crate::{
     send_sync_message, Message,
 };
 use fyrox::{
-    asset::ResourceStateRef,
     core::pool::Handle,
     engine::Engine,
     gui::{
@@ -214,9 +213,8 @@ impl AudioPreviewPanel {
                 if let Some(sound) = scene.graph.try_get_of_type::<Sound>(node_handle) {
                     if !set {
                         if let Some(buffer) = sound.buffer() {
-                            let state = buffer.state();
-
-                            if let ResourceStateRef::Ok(buffer) = state.get() {
+                            let mut state = buffer.state();
+                            if let Some(buffer) = state.data() {
                                 let duration_secs = buffer.duration().as_secs_f32();
 
                                 send_sync_message(

--- a/editor/src/curve_editor.rs
+++ b/editor/src/curve_editor.rs
@@ -2,6 +2,7 @@ use crate::{
     define_command_stack, send_sync_message, utils::create_file_selector, MessageBoxButtons,
     MessageBoxMessage, MSG_SYNC_FLAG,
 };
+use fyrox::asset::untyped::ResourceKind;
 use fyrox::{
     asset::Resource,
     core::{
@@ -339,12 +340,13 @@ impl CurveEditorWindow {
 
     fn sync_title(&self, ui: &UserInterface) {
         let title = if let Some(curve_resource) = self.curve_resource.as_ref() {
-            let path = curve_resource.header().path.clone();
+            let kind = curve_resource.header().kind.clone();
 
-            if path == PathBuf::default() {
-                "Curve Editor - Unnamed Curve".to_string()
-            } else {
-                format!("Curve Editor - {}", path.display())
+            match kind {
+                ResourceKind::Embedded => "Curve Editor - Unnamed Curve".to_string(),
+                ResourceKind::External(path) => {
+                    format!("Curve Editor - {}", path.display())
+                }
             }
         } else {
             "Curve Editor".to_string()
@@ -472,7 +474,7 @@ impl CurveEditorWindow {
                 self.path = Default::default();
 
                 self.set_curve(
-                    Resource::new_ok(Default::default(), CurveResourceState::default(), false),
+                    Resource::new_ok(Default::default(), CurveResourceState::default()),
                     ui,
                 );
             } else if message.destination() == self.menu.file.save {

--- a/editor/src/curve_editor.rs
+++ b/editor/src/curve_editor.rs
@@ -2,9 +2,8 @@ use crate::{
     define_command_stack, send_sync_message, utils::create_file_selector, MessageBoxButtons,
     MessageBoxMessage, MSG_SYNC_FLAG,
 };
-use fyrox::asset::ResourceStateRefMut;
 use fyrox::{
-    asset::{Resource, ResourceData},
+    asset::Resource,
     core::{
         color::Color, curve::Curve, futures::executor::block_on, pool::Handle, visitor::prelude::*,
         visitor::Visitor,
@@ -312,7 +311,7 @@ impl CurveEditorWindow {
 
     fn save(&self) {
         if let Some(curve_resource) = self.curve_resource.as_ref() {
-            if let ResourceStateRefMut::Ok(state) = curve_resource.state().get_mut() {
+            if let Some(state) = curve_resource.state().data() {
                 let mut visitor = Visitor::new();
                 state.curve.visit("Curve", &mut visitor).unwrap();
                 visitor.save_binary(&self.path).unwrap();
@@ -340,7 +339,7 @@ impl CurveEditorWindow {
 
     fn sync_title(&self, ui: &UserInterface) {
         let title = if let Some(curve_resource) = self.curve_resource.as_ref() {
-            let path = curve_resource.data_ref().path().to_path_buf();
+            let path = curve_resource.header().path.clone();
 
             if path == PathBuf::default() {
                 "Curve Editor - Unnamed Curve".to_string()
@@ -472,7 +471,10 @@ impl CurveEditorWindow {
             } else if message.destination() == self.menu.file.new {
                 self.path = Default::default();
 
-                self.set_curve(Resource::new_ok(CurveResourceState::default()), ui);
+                self.set_curve(
+                    Resource::new_ok(Default::default(), CurveResourceState::default(), false),
+                    ui,
+                );
             } else if message.destination() == self.menu.file.save {
                 if self.path == PathBuf::default() {
                     self.open_save_file_dialog(ui);

--- a/editor/src/inspector/editors/material.rs
+++ b/editor/src/inspector/editors/material.rs
@@ -2,8 +2,9 @@ use crate::{
     asset::item::AssetItem, inspector::EditorEnvironment, message::MessageSender, Message,
     MessageDirection,
 };
+use fyrox::asset::state::ResourceState;
 use fyrox::{
-    asset::{core::pool::Handle, manager::ResourceManager, ResourceData, ResourceStateRef},
+    asset::{core::pool::Handle, manager::ResourceManager},
     core::{
         color::Color, futures::executor::block_on, make_relative_path, parking_lot::Mutex,
         reflect::prelude::*, visitor::prelude::*,
@@ -162,24 +163,24 @@ pub struct MaterialFieldEditorBuilder {
 }
 
 fn make_name(material: &MaterialResource) -> String {
-    let state = material.state();
-    match state.get() {
-        ResourceStateRef::Ok(material_data) => {
-            if material_data.is_embedded() {
+    let header = material.header();
+    match header.state {
+        ResourceState::Ok(_) => {
+            if header.is_embedded {
                 format!("Embedded - {} uses", material.use_count())
             } else {
                 format!(
                     "{} - {} uses",
-                    material_data.path().to_string_lossy().as_ref(),
+                    header.path.to_string_lossy().as_ref(),
                     material.use_count()
                 )
             }
         }
-        ResourceStateRef::LoadError { error, .. } => {
+        ResourceState::LoadError { ref error, .. } => {
             format!("Loading failed: {:?}", error)
         }
-        ResourceStateRef::Pending { path, .. } => {
-            format!("Loading {}", path.display())
+        ResourceState::Pending { .. } => {
+            format!("Loading {}", header.path.display())
         }
     }
 }

--- a/editor/src/inspector/editors/material.rs
+++ b/editor/src/inspector/editors/material.rs
@@ -166,21 +166,13 @@ fn make_name(material: &MaterialResource) -> String {
     let header = material.header();
     match header.state {
         ResourceState::Ok(_) => {
-            if header.is_embedded {
-                format!("Embedded - {} uses", material.use_count())
-            } else {
-                format!(
-                    "{} - {} uses",
-                    header.path.to_string_lossy().as_ref(),
-                    material.use_count()
-                )
-            }
+            format!("{} - {} uses", header.kind, material.use_count())
         }
         ResourceState::LoadError { ref error, .. } => {
             format!("Loading failed: {:?}", error)
         }
         ResourceState::Pending { .. } => {
-            format!("Loading {}", header.path.display())
+            format!("Loading {}", header.kind)
         }
     }
 }

--- a/editor/src/inspector/editors/resource.rs
+++ b/editor/src/inspector/editors/resource.rs
@@ -42,7 +42,7 @@ where
 {
     resource
         .as_ref()
-        .map(|m| m.path().to_string_lossy().to_string())
+        .map(|m| m.kind().to_string())
         .unwrap_or_else(|| "None".to_string())
 }
 
@@ -217,8 +217,9 @@ where
         } else if let Some(ButtonMessage::Click) = message.data() {
             if message.destination() == self.locate {
                 if let Some(resource) = self.resource.as_ref() {
-                    self.sender
-                        .send(Message::ShowInAssetBrowser(resource.path()));
+                    if let Some(path) = resource.kind().into_path() {
+                        self.sender.send(Message::ShowInAssetBrowser(path));
+                    }
                 }
             }
         }

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -160,7 +160,9 @@ pub fn send_sync_message(ui: &UserInterface, mut msg: UiMessage) {
 pub fn load_image(data: &[u8]) -> Option<draw::SharedTexture> {
     Some(into_gui_texture(
         TextureResource::load_from_memory(
+            Default::default(),
             data,
+            true,
             TextureImportOptions::default()
                 .with_compression(CompressionOptions::NoCompression)
                 .with_minification_filter(TextureMinificationFilter::Linear),
@@ -188,7 +190,7 @@ pub fn make_color_material(color: Color) -> MaterialResource {
             PropertyValue::Color(color),
         )
         .unwrap();
-    MaterialResource::new_ok(material)
+    MaterialResource::new_ok(Default::default(), material, true)
 }
 
 pub fn set_mesh_diffuse_color(mesh: &mut Mesh, color: Color) {
@@ -212,7 +214,7 @@ pub fn create_terrain_layer_material() -> MaterialResource {
             PropertyValue::Vector2(Vector2::new(10.0, 10.0)),
         )
         .unwrap();
-    MaterialResource::new_ok(material)
+    MaterialResource::new_ok(Default::default(), material, true)
 }
 
 #[derive(Debug)]
@@ -770,7 +772,9 @@ impl Editor {
         let graphics_context = engine.graphics_context.as_initialized_mut();
 
         if let Ok(icon_img) = TextureResource::load_from_memory(
+            "../resources/icon.png".into(),
             include_bytes!("../resources/icon.png"),
+            true,
             TextureImportOptions::default()
                 .with_compression(CompressionOptions::NoCompression)
                 .with_minification_filter(TextureMinificationFilter::Linear),

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -162,7 +162,6 @@ pub fn load_image(data: &[u8]) -> Option<draw::SharedTexture> {
         TextureResource::load_from_memory(
             Default::default(),
             data,
-            true,
             TextureImportOptions::default()
                 .with_compression(CompressionOptions::NoCompression)
                 .with_minification_filter(TextureMinificationFilter::Linear),
@@ -175,8 +174,7 @@ lazy_static! {
     static ref GIZMO_SHADER: ShaderResource = {
         ShaderResource::from_str(
             include_str!("../resources/shaders/gizmo.shader",),
-            PathBuf::default(),
-            false,
+            Default::default(),
         )
         .unwrap()
     };
@@ -190,7 +188,7 @@ pub fn make_color_material(color: Color) -> MaterialResource {
             PropertyValue::Color(color),
         )
         .unwrap();
-    MaterialResource::new_ok(Default::default(), material, true)
+    MaterialResource::new_ok(Default::default(), material)
 }
 
 pub fn set_mesh_diffuse_color(mesh: &mut Mesh, color: Color) {
@@ -214,7 +212,7 @@ pub fn create_terrain_layer_material() -> MaterialResource {
             PropertyValue::Vector2(Vector2::new(10.0, 10.0)),
         )
         .unwrap();
-    MaterialResource::new_ok(Default::default(), material, true)
+    MaterialResource::new_ok(Default::default(), material)
 }
 
 #[derive(Debug)]
@@ -774,7 +772,6 @@ impl Editor {
         if let Ok(icon_img) = TextureResource::load_from_memory(
             "../resources/icon.png".into(),
             include_bytes!("../resources/icon.png"),
-            true,
             TextureImportOptions::default()
                 .with_compression(CompressionOptions::NoCompression)
                 .with_minification_filter(TextureMinificationFilter::Linear),

--- a/editor/src/material.rs
+++ b/editor/src/material.rs
@@ -628,8 +628,8 @@ impl MaterialEditor {
                         .clone()
                         .and_then(|t| {
                             t.0.downcast::<Mutex<UntypedResource>>()
-                                .map(|t| t.lock().path())
                                 .ok()
+                                .and_then(|t| t.lock().kind().into_path())
                         });
 
                     if let Some(path) = path {

--- a/editor/src/overlay.rs
+++ b/editor/src/overlay.rs
@@ -71,7 +71,6 @@ impl OverlayRenderPass {
             sound_icon: TextureResource::load_from_memory(
                 "../resources/sound_source.png".into(),
                 include_bytes!("../resources/sound_source.png"),
-                true,
                 TextureImportOptions::default()
                     .with_compression(CompressionOptions::NoCompression)
                     .with_minification_filter(TextureMinificationFilter::Linear),
@@ -80,7 +79,6 @@ impl OverlayRenderPass {
             light_icon: TextureResource::load_from_memory(
                 "../resources/light_source.png".into(),
                 include_bytes!("../resources/light_source.png"),
-                true,
                 TextureImportOptions::default()
                     .with_compression(CompressionOptions::NoCompression)
                     .with_minification_filter(TextureMinificationFilter::Linear),

--- a/editor/src/overlay.rs
+++ b/editor/src/overlay.rs
@@ -69,14 +69,18 @@ impl OverlayRenderPass {
             ),
             shader: OverlayShader::new(state).unwrap(),
             sound_icon: TextureResource::load_from_memory(
+                "../resources/sound_source.png".into(),
                 include_bytes!("../resources/sound_source.png"),
+                true,
                 TextureImportOptions::default()
                     .with_compression(CompressionOptions::NoCompression)
                     .with_minification_filter(TextureMinificationFilter::Linear),
             )
             .unwrap(),
             light_icon: TextureResource::load_from_memory(
+                "../resources/light_source.png".into(),
                 include_bytes!("../resources/light_source.png"),
+                true,
                 TextureImportOptions::default()
                     .with_compression(CompressionOptions::NoCompression)
                     .with_minification_filter(TextureMinificationFilter::Linear),

--- a/editor/src/scene/commands/material.rs
+++ b/editor/src/scene/commands/material.rs
@@ -14,8 +14,7 @@ pub struct SetMaterialPropertyValueCommand {
 
 fn try_save(material: &MaterialResource) {
     let header = material.header();
-    if !header.is_embedded {
-        let path = header.path.to_path_buf();
+    if let Some(path) = header.kind.path_owned() {
         drop(header);
         Log::verify(material.data_ref().save(&path));
     }

--- a/editor/src/scene/commands/terrain.rs
+++ b/editor/src/scene/commands/terrain.rs
@@ -129,7 +129,7 @@ impl ModifyTerrainHeightCommand {
                 },
                 TexturePixelKind::R32F,
                 utils::transmute_vec_as_bytes(new.clone()),
-                true,
+                Default::default(),
             )
             .unwrap();
 

--- a/editor/src/scene_viewer/gizmo.rs
+++ b/editor/src/scene_viewer/gizmo.rs
@@ -64,7 +64,7 @@ fn make_cone(transform: Matrix4<f32>, color: Color, graph: &mut Graph) -> Handle
         .with_surfaces(vec![SurfaceBuilder::new(SurfaceSharedData::new(
             SurfaceData::make_cone(16, 0.3, 1.0, &transform),
         ))
-        .with_material(MaterialResource::new_ok(material))
+        .with_material(MaterialResource::new_ok(Default::default(), material, true))
         .build()])
         .build(graph)
 }

--- a/editor/src/scene_viewer/gizmo.rs
+++ b/editor/src/scene_viewer/gizmo.rs
@@ -64,7 +64,7 @@ fn make_cone(transform: Matrix4<f32>, color: Color, graph: &mut Graph) -> Handle
         .with_surfaces(vec![SurfaceBuilder::new(SurfaceSharedData::new(
             SurfaceData::make_cone(16, 0.3, 1.0, &transform),
         ))
-        .with_material(MaterialResource::new_ok(Default::default(), material, true))
+        .with_material(MaterialResource::new_ok(Default::default(), material))
         .build()])
         .build(graph)
 }

--- a/editor/src/scene_viewer/mod.rs
+++ b/editor/src/scene_viewer/mod.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use fyrox::core::futures::executor::block_on;
 use fyrox::{
-    asset::ResourceStateRef,
     core::{
         algebra::{Vector2, Vector3},
         color::Color,
@@ -1247,8 +1246,8 @@ impl SceneViewer {
                         only_meshes: false,
                     }) {
                         let texture = tex.clone();
-                        let texture = texture.state();
-                        if let ResourceStateRef::Ok(_) = texture.get() {
+                        let mut texture = texture.state();
+                        if let Some(_) = texture.data() {
                             let node = &mut engine.scenes[editor_scene.scene].graph[result.node];
 
                             if node.is_mesh() {

--- a/editor/src/scene_viewer/mod.rs
+++ b/editor/src/scene_viewer/mod.rs
@@ -1247,7 +1247,7 @@ impl SceneViewer {
                     }) {
                         let texture = tex.clone();
                         let mut texture = texture.state();
-                        if let Some(_) = texture.data() {
+                        if texture.data().is_some() {
                             let node = &mut engine.scenes[editor_scene.scene].graph[result.node];
 
                             if node.is_mesh() {

--- a/editor/src/world/graph/menu.rs
+++ b/editor/src/world/graph/menu.rs
@@ -53,7 +53,7 @@ fn resource_path_of_first_selected_node(
         if let Some(first) = graph_selection.nodes.first() {
             let scene = &engine.scenes[editor_scene.scene];
             if let Some(resource) = scene.graph.try_get(*first).and_then(|n| n.resource()) {
-                return Some(resource.path());
+                return resource.kind().into_path();
             }
         }
     }

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -58,7 +58,7 @@ impl SceneLoader {
                 },
             )
             .unwrap();
-        let material = MaterialResource::new_ok(Default::default(), material, true);
+        let material = MaterialResource::new_ok(Default::default(), material);
 
         // Add some sprites.
         for y in 0..10 {

--- a/examples/2d.rs
+++ b/examples/2d.rs
@@ -58,7 +58,7 @@ impl SceneLoader {
                 },
             )
             .unwrap();
-        let material = MaterialResource::new_ok(material);
+        let material = MaterialResource::new_ok(Default::default(), material, true);
 
         // Add some sprites.
         for y in 0..10 {

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -77,7 +77,11 @@ async fn create_scene(resource_manager: ResourceManager) -> GameScene {
         .with_surfaces(vec![SurfaceBuilder::new(SurfaceSharedData::new(
             SurfaceData::make_sphere(10, 10, 0.1, &Matrix4::identity()),
         ))
-        .with_material(MaterialResource::new_ok(cursor_material))
+        .with_material(MaterialResource::new_ok(
+            Default::default(),
+            cursor_material,
+            true,
+        ))
         .build()])
         .build(&mut scene.graph);
 
@@ -99,7 +103,11 @@ async fn create_scene(resource_manager: ResourceManager) -> GameScene {
     .with_surfaces(vec![SurfaceBuilder::new(SurfaceSharedData::new(
         SurfaceData::make_sphere(10, 10, 0.2, &Matrix4::identity()),
     ))
-    .with_material(MaterialResource::new_ok(agent_material))
+    .with_material(MaterialResource::new_ok(
+        Default::default(),
+        agent_material,
+        true,
+    ))
     .build()])
     .build(&mut scene.graph);
 

--- a/examples/navmesh.rs
+++ b/examples/navmesh.rs
@@ -80,7 +80,6 @@ async fn create_scene(resource_manager: ResourceManager) -> GameScene {
         .with_material(MaterialResource::new_ok(
             Default::default(),
             cursor_material,
-            true,
         ))
         .build()])
         .build(&mut scene.graph);
@@ -103,11 +102,7 @@ async fn create_scene(resource_manager: ResourceManager) -> GameScene {
     .with_surfaces(vec![SurfaceBuilder::new(SurfaceSharedData::new(
         SurfaceData::make_sphere(10, 10, 0.2, &Matrix4::identity()),
     ))
-    .with_material(MaterialResource::new_ok(
-        Default::default(),
-        agent_material,
-        true,
-    ))
+    .with_material(MaterialResource::new_ok(Default::default(), agent_material))
     .build()])
     .build(&mut scene.graph);
 

--- a/fyrox-resource/src/constructor.rs
+++ b/fyrox-resource/src/constructor.rs
@@ -85,8 +85,6 @@ impl ResourceConstructorContainer {
 
 #[cfg(test)]
 mod test {
-    use std::path::PathBuf;
-
     use fyrox_core::reflect::prelude::*;
     use fyrox_core::visitor::{Visit, VisitResult, Visitor};
 
@@ -96,28 +94,16 @@ mod test {
     struct Stub {}
 
     impl ResourceData for Stub {
-        fn path(&self) -> &std::path::Path {
-            unimplemented!()
-        }
-
-        fn set_path(&mut self, _path: std::path::PathBuf) {
-            unimplemented!()
-        }
-
         fn as_any(&self) -> &dyn std::any::Any {
-            unimplemented!()
+            self
         }
 
         fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-            unimplemented!()
+            self
         }
 
         fn type_uuid(&self) -> Uuid {
-            unimplemented!()
-        }
-
-        fn is_embedded(&self) -> bool {
-            unimplemented!()
+            Uuid::default()
         }
     }
 
@@ -163,41 +149,5 @@ mod test {
 
         let res = c.try_create(&Uuid::default());
         assert!(res.is_some());
-    }
-
-    #[test]
-    #[should_panic]
-    fn stub_path() {
-        let s = Stub {};
-        s.path();
-    }
-
-    #[test]
-    #[should_panic]
-    fn stub_set_path() {
-        let mut s = Stub {};
-        s.set_path(PathBuf::new());
-    }
-
-    #[test]
-    #[should_panic]
-    fn stub_set_as_any() {
-        let s = Stub {};
-        ResourceData::as_any(&s);
-    }
-
-    #[test]
-    #[should_panic]
-    fn stub_set_as_any_mut() {
-        let mut s = Stub {};
-        ResourceData::as_any_mut(&mut s);
-        s.type_uuid();
-    }
-
-    #[test]
-    #[should_panic]
-    fn stub_set_type_uuid() {
-        let s = Stub {};
-        s.type_uuid();
     }
 }

--- a/fyrox-resource/src/graph.rs
+++ b/fyrox-resource/src/graph.rs
@@ -20,8 +20,8 @@ impl ResourceGraphNode {
         // Look for dependent resources.
         let mut dependent_resources = FxHashSet::default();
 
-        let resource_state = resource.0.lock();
-        if let ResourceState::Ok(resource_data) = &*resource_state {
+        let header = resource.0.lock();
+        if let ResourceState::Ok(ref resource_data) = header.state {
             (**resource_data).as_reflect(&mut |entity| {
                 collect_used_resources(entity, &mut dependent_resources);
             });

--- a/fyrox-resource/src/graph.rs
+++ b/fyrox-resource/src/graph.rs
@@ -114,19 +114,17 @@ mod test {
     fn resource_graph_node_pretty_print() {
         let mut s = String::new();
         let mut node = ResourceGraphNode::new(&UntypedResource::new_pending(
-            PathBuf::from("/foo"),
+            PathBuf::from("/foo").into(),
             Uuid::default(),
-            true,
         ));
         let node2 = ResourceGraphNode::new(&UntypedResource::new_pending(
-            PathBuf::from("/bar"),
+            PathBuf::from("/bar").into(),
             Uuid::default(),
-            true,
         ));
         node.children.push(node2);
         node.pretty_print(1, &mut s);
 
-        assert_eq!(s, "\t/foo\n\t\t/bar\n".to_string());
+        assert_eq!(s, "\tExternal (/foo)\n\t\tExternal (/bar)\n".to_string());
     }
 
     #[test]
@@ -152,37 +150,33 @@ mod test {
     #[test]
     fn resource_dependency_pretty_print() {
         let mut graph = ResourceDependencyGraph::new(&UntypedResource::new_pending(
-            PathBuf::from("/foo"),
+            PathBuf::from("/foo").into(),
             Uuid::default(),
-            true,
         ));
         graph
             .root
             .children
             .push(ResourceGraphNode::new(&UntypedResource::new_pending(
-                PathBuf::from("/bar"),
+                PathBuf::from("/bar").into(),
                 Uuid::default(),
-                true,
             )));
 
         let s = graph.pretty_print();
-        assert_eq!(s, "/foo\n\t/bar\n".to_string());
+        assert_eq!(s, "External (/foo)\n\tExternal (/bar)\n".to_string());
     }
 
     #[test]
     fn resource_dependency_for_each() {
         let mut graph = ResourceDependencyGraph::new(&UntypedResource::new_pending(
-            PathBuf::from("/foo"),
+            PathBuf::from("/foo").into(),
             Uuid::default(),
-            true,
         ));
         graph
             .root
             .children
             .push(ResourceGraphNode::new(&UntypedResource::new_pending(
-                PathBuf::from("/bar"),
+                PathBuf::from("/bar").into(),
                 Uuid::default(),
-                true,
             )));
 
         let mut uuids = Vec::new();

--- a/fyrox-resource/src/graph.rs
+++ b/fyrox-resource/src/graph.rs
@@ -116,10 +116,12 @@ mod test {
         let mut node = ResourceGraphNode::new(&UntypedResource::new_pending(
             PathBuf::from("/foo"),
             Uuid::default(),
+            true,
         ));
         let node2 = ResourceGraphNode::new(&UntypedResource::new_pending(
             PathBuf::from("/bar"),
             Uuid::default(),
+            true,
         ));
         node.children.push(node2);
         node.pretty_print(1, &mut s);
@@ -152,6 +154,7 @@ mod test {
         let mut graph = ResourceDependencyGraph::new(&UntypedResource::new_pending(
             PathBuf::from("/foo"),
             Uuid::default(),
+            true,
         ));
         graph
             .root
@@ -159,6 +162,7 @@ mod test {
             .push(ResourceGraphNode::new(&UntypedResource::new_pending(
                 PathBuf::from("/bar"),
                 Uuid::default(),
+                true,
             )));
 
         let s = graph.pretty_print();
@@ -170,6 +174,7 @@ mod test {
         let mut graph = ResourceDependencyGraph::new(&UntypedResource::new_pending(
             PathBuf::from("/foo"),
             Uuid::default(),
+            true,
         ));
         graph
             .root
@@ -177,6 +182,7 @@ mod test {
             .push(ResourceGraphNode::new(&UntypedResource::new_pending(
                 PathBuf::from("/bar"),
                 Uuid::default(),
+                true,
             )));
 
         let mut uuids = Vec::new();

--- a/fyrox-resource/src/graph.rs
+++ b/fyrox-resource/src/graph.rs
@@ -45,7 +45,7 @@ impl ResourceGraphNode {
         *out += &format!(
             "{}{}\n",
             String::from('\t').repeat(level),
-            self.resource.path().to_string_lossy()
+            self.resource.kind()
         );
 
         for child in self.children.iter() {

--- a/fyrox-resource/src/loader.rs
+++ b/fyrox-resource/src/loader.rs
@@ -209,13 +209,7 @@ mod test {
             Default::default()
         }
 
-        fn load(
-            &self,
-            _resource: UntypedResource,
-            _event_broadcaster: ResourceEventBroadcaster,
-            _reload: bool,
-            _io: Arc<dyn ResourceIo>,
-        ) -> BoxedLoaderFuture {
+        fn load(&self, _path: PathBuf, _io: Arc<dyn ResourceIo>) -> BoxedLoaderFuture {
             todo!()
         }
     }

--- a/fyrox-resource/src/loader.rs
+++ b/fyrox-resource/src/loader.rs
@@ -1,8 +1,7 @@
 //! Resource loader. It manages resource loading.
 
 use crate::{
-    core::uuid::Uuid, event::ResourceEventBroadcaster, io::ResourceIo, options::BaseImportOptions,
-    UntypedResource,
+    core::uuid::Uuid, io::ResourceIo, options::BaseImportOptions, state::LoadError, ResourceData,
 };
 use std::{any::Any, future::Future, path::PathBuf, pin::Pin, sync::Arc};
 
@@ -63,13 +62,7 @@ pub trait ResourceLoader: ResourceLoaderTypeTrait {
     fn data_type_uuid(&self) -> Uuid;
 
     /// Loads or reloads a resource.
-    fn load(
-        &self,
-        resource: UntypedResource,
-        event_broadcaster: ResourceEventBroadcaster,
-        reload: bool,
-        io: Arc<dyn ResourceIo>,
-    ) -> BoxedLoaderFuture;
+    fn load(&self, path: PathBuf, io: Arc<dyn ResourceIo>) -> BoxedLoaderFuture;
 
     /// Tries to load import settings for a resource.
     fn try_load_import_settings(
@@ -86,13 +79,21 @@ pub trait ResourceLoader: ResourceLoaderTypeTrait {
     }
 }
 
+pub struct LoaderPayload(pub(crate) Box<dyn ResourceData>);
+
+impl LoaderPayload {
+    pub fn new<T: ResourceData>(data: T) -> Self {
+        Self(Box::new(data))
+    }
+}
+
 /// Future type for resource loading. See 'ResourceLoader'.
 #[cfg(target_arch = "wasm32")]
-pub type BoxedLoaderFuture = Pin<Box<dyn Future<Output = ()>>>;
+pub type BoxedLoaderFuture = Pin<Box<dyn Future<Output = Result<LoaderPayload, LoadError>>>>;
 
 /// Future type for resource loading. See 'ResourceLoader'.
 #[cfg(not(target_arch = "wasm32"))]
-pub type BoxedLoaderFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+pub type BoxedLoaderFuture = Pin<Box<dyn Future<Output = Result<LoaderPayload, LoadError>> + Send>>;
 
 /// Future type for resource import options loading.
 pub type BoxedImportOptionsLoaderFuture =

--- a/fyrox-sound/examples/hrtf.rs
+++ b/fyrox-sound/examples/hrtf.rs
@@ -34,7 +34,7 @@ fn main() {
     context
         .state()
         .set_renderer(Renderer::HrtfRenderer(HrtfRenderer::new(
-            HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path, true),
+            HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path.into()),
         )));
 
     // Create some sounds.

--- a/fyrox-sound/examples/hrtf.rs
+++ b/fyrox-sound/examples/hrtf.rs
@@ -34,7 +34,7 @@ fn main() {
     context
         .state()
         .set_renderer(Renderer::HrtfRenderer(HrtfRenderer::new(
-            HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path),
+            HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path, true),
         )));
 
     // Create some sounds.

--- a/fyrox-sound/examples/reverb.rs
+++ b/fyrox-sound/examples/reverb.rs
@@ -34,7 +34,7 @@ fn main() {
     context
         .state()
         .set_renderer(Renderer::HrtfRenderer(HrtfRenderer::new(
-            HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path),
+            HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path, true),
         )));
 
     {

--- a/fyrox-sound/examples/reverb.rs
+++ b/fyrox-sound/examples/reverb.rs
@@ -34,7 +34,7 @@ fn main() {
     context
         .state()
         .set_renderer(Renderer::HrtfRenderer(HrtfRenderer::new(
-            HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path, true),
+            HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path.into()),
         )));
 
     {

--- a/fyrox-sound/src/buffer/loader.rs
+++ b/fyrox-sound/src/buffer/loader.rs
@@ -49,7 +49,7 @@ impl ResourceLoader for SoundBufferLoader {
 
             let source = DataSource::from_file(&path, io)
                 .await
-                .map_err(|e| LoadError::new(e))?;
+                .map_err(LoadError::new)?;
 
             let result = if import_options.stream {
                 SoundBuffer::raw_streaming(source)

--- a/fyrox-sound/src/buffer/loader.rs
+++ b/fyrox-sound/src/buffer/loader.rs
@@ -1,14 +1,14 @@
 //! Sound buffer loader.
 
-use crate::buffer::{DataSource, SoundBuffer, SoundBufferResourceLoadError};
-use fyrox_core::{log::Log, reflect::prelude::*, uuid::Uuid, TypeUuidProvider};
-use fyrox_resource::options::BaseImportOptions;
+use crate::buffer::{DataSource, SoundBuffer};
+use fyrox_core::{reflect::prelude::*, uuid::Uuid, TypeUuidProvider};
 use fyrox_resource::{
-    event::ResourceEventBroadcaster,
     io::ResourceIo,
-    loader::{BoxedImportOptionsLoaderFuture, BoxedLoaderFuture, ResourceLoader},
-    options::{try_get_import_settings, try_get_import_settings_opaque, ImportOptions},
-    untyped::UntypedResource,
+    loader::{BoxedImportOptionsLoaderFuture, BoxedLoaderFuture, LoaderPayload, ResourceLoader},
+    options::{
+        try_get_import_settings, try_get_import_settings_opaque, BaseImportOptions, ImportOptions,
+    },
+    state::LoadError,
 };
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, sync::Arc};
@@ -37,51 +37,29 @@ impl ResourceLoader for SoundBufferLoader {
         SoundBuffer::type_uuid()
     }
 
-    fn load(
-        &self,
-        resource: UntypedResource,
-        event_broadcaster: ResourceEventBroadcaster,
-        reload: bool,
-        io: Arc<dyn ResourceIo>,
-    ) -> BoxedLoaderFuture {
+    fn load(&self, path: PathBuf, io: Arc<dyn ResourceIo>) -> BoxedLoaderFuture {
         let default_import_options = self.default_import_options.clone();
 
         Box::pin(async move {
             let io = io.as_ref();
 
-            let path = resource.path().to_path_buf();
-
             let import_options = try_get_import_settings(&path, io)
                 .await
                 .unwrap_or(default_import_options);
 
-            match DataSource::from_file(&path, io).await {
-                Ok(source) => {
-                    let buffer = if import_options.stream {
-                        SoundBuffer::raw_streaming(source)
-                    } else {
-                        SoundBuffer::raw_generic(source)
-                    };
-                    match buffer {
-                        Ok(sound_buffer) => {
-                            resource.commit_ok(sound_buffer);
+            let source = DataSource::from_file(&path, io)
+                .await
+                .map_err(|e| LoadError::new(e))?;
 
-                            event_broadcaster.broadcast_loaded_or_reloaded(resource, reload);
+            let result = if import_options.stream {
+                SoundBuffer::raw_streaming(source)
+            } else {
+                SoundBuffer::raw_generic(source)
+            };
 
-                            Log::info(format!("Sound buffer {:?} is loaded!", path));
-                        }
-                        Err(_) => {
-                            resource.commit_error(SoundBufferResourceLoadError::UnsupportedFormat);
-
-                            Log::info(format!("Unable to load sound buffer from {:?}!", path));
-                        }
-                    }
-                }
-                Err(e) => {
-                    Log::err(format!("Invalid data source for sound buffer: {:?}", e));
-
-                    resource.commit_error(SoundBufferResourceLoadError::Io(e));
-                }
+            match result {
+                Ok(buffer) => Ok(LoaderPayload::new(buffer)),
+                Err(_) => Err(LoadError::new("Invalid data source.")),
             }
         })
     }

--- a/fyrox-sound/src/buffer/loader.rs
+++ b/fyrox-sound/src/buffer/loader.rs
@@ -71,10 +71,7 @@ impl ResourceLoader for SoundBufferLoader {
                             Log::info(format!("Sound buffer {:?} is loaded!", path));
                         }
                         Err(_) => {
-                            resource.commit_error(
-                                path.clone(),
-                                SoundBufferResourceLoadError::UnsupportedFormat,
-                            );
+                            resource.commit_error(SoundBufferResourceLoadError::UnsupportedFormat);
 
                             Log::info(format!("Unable to load sound buffer from {:?}!", path));
                         }
@@ -83,7 +80,7 @@ impl ResourceLoader for SoundBufferLoader {
                 Err(e) => {
                     Log::err(format!("Invalid data source for sound buffer: {:?}", e));
 
-                    resource.commit_error(path.clone(), SoundBufferResourceLoadError::Io(e));
+                    resource.commit_error(SoundBufferResourceLoadError::Io(e));
                 }
             }
         })

--- a/fyrox-sound/src/buffer/mod.rs
+++ b/fyrox-sound/src/buffer/mod.rs
@@ -117,6 +117,22 @@ impl DataSource {
     pub fn from_memory(data: Vec<u8>) -> Self {
         DataSource::Memory(Cursor::new(data))
     }
+
+    /// Tries to get a path to external data source.
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            DataSource::File { path, .. } => Some(path),
+            _ => None,
+        }
+    }
+
+    /// Tries to get a path to external data source.
+    pub fn path_owned(&self) -> Option<PathBuf> {
+        match self {
+            DataSource::File { path, .. } => Some(path.clone()),
+            _ => None,
+        }
+    }
 }
 
 impl Read for DataSource {
@@ -182,15 +198,23 @@ pub trait SoundBufferResourceExtension {
 
 impl SoundBufferResourceExtension for SoundBufferResource {
     fn new_streaming(data_source: DataSource) -> Result<Resource<SoundBuffer>, DataSource> {
-        Ok(Resource::new_ok(SoundBuffer::Streaming(
-            StreamingBuffer::new(data_source)?,
-        )))
+        let path = data_source.path_owned();
+        let is_embedded = path.is_none();
+        Ok(Resource::new_ok(
+            path.unwrap_or_default(),
+            SoundBuffer::Streaming(StreamingBuffer::new(data_source)?),
+            is_embedded,
+        ))
     }
 
     fn new_generic(data_source: DataSource) -> Result<Resource<SoundBuffer>, DataSource> {
-        Ok(Resource::new_ok(SoundBuffer::Generic(GenericBuffer::new(
-            data_source,
-        )?)))
+        let path = data_source.path_owned();
+        let is_embedded = path.is_none();
+        Ok(Resource::new_ok(
+            path.unwrap_or_default(),
+            SoundBuffer::Generic(GenericBuffer::new(data_source)?),
+            is_embedded,
+        ))
     }
 }
 
@@ -245,14 +269,6 @@ impl DerefMut for SoundBuffer {
 }
 
 impl ResourceData for SoundBuffer {
-    fn path(&self) -> &Path {
-        &self.external_source_path
-    }
-
-    fn set_path(&mut self, path: PathBuf) {
-        self.external_source_path = path;
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -263,9 +279,5 @@ impl ResourceData for SoundBuffer {
 
     fn type_uuid(&self) -> Uuid {
         SOUND_BUFFER_RESOURCE_UUID
-    }
-
-    fn is_embedded(&self) -> bool {
-        self.is_embedded
     }
 }

--- a/fyrox-sound/src/buffer/mod.rs
+++ b/fyrox-sound/src/buffer/mod.rs
@@ -199,21 +199,17 @@ pub trait SoundBufferResourceExtension {
 impl SoundBufferResourceExtension for SoundBufferResource {
     fn new_streaming(data_source: DataSource) -> Result<Resource<SoundBuffer>, DataSource> {
         let path = data_source.path_owned();
-        let is_embedded = path.is_none();
         Ok(Resource::new_ok(
-            path.unwrap_or_default(),
+            path.into(),
             SoundBuffer::Streaming(StreamingBuffer::new(data_source)?),
-            is_embedded,
         ))
     }
 
     fn new_generic(data_source: DataSource) -> Result<Resource<SoundBuffer>, DataSource> {
         let path = data_source.path_owned();
-        let is_embedded = path.is_none();
         Ok(Resource::new_ok(
-            path.unwrap_or_default(),
+            path.into(),
             SoundBuffer::Generic(GenericBuffer::new(data_source)?),
-            is_embedded,
         ))
     }
 }

--- a/fyrox-sound/src/buffer/streaming.rs
+++ b/fyrox-sound/src/buffer/streaming.rs
@@ -163,12 +163,6 @@ impl StreamingBuffer {
     /// This function will return Err if data source is `Raw`. It makes no sense to stream raw data which
     /// is already loaded into memory. Use Generic source instead!
     pub fn new(source: DataSource) -> Result<Self, DataSource> {
-        let (external_source_path, is_embedded) = if let DataSource::File { path, .. } = &source {
-            (path.clone(), false)
-        } else {
-            (Default::default(), true)
-        };
-
         let mut streaming_source = StreamingSource::new(source)?;
 
         let mut samples = Vec::new();
@@ -182,8 +176,6 @@ impl StreamingBuffer {
                 sample_rate: streaming_source.sample_rate(),
                 channel_count: streaming_source.channel_count(),
                 channel_duration_in_samples: streaming_source.channel_duration_in_samples(),
-                external_source_path,
-                is_embedded,
             },
             use_count: 0,
             streaming_source,

--- a/fyrox-sound/src/renderer/hrtf.rs
+++ b/fyrox-sound/src/renderer/hrtf.rs
@@ -31,7 +31,7 @@
 //!     let hrir_path = PathBuf::from("examples/data/IRC_1002_C.bin");
 //!     let hrir_sphere = HrirSphere::from_file(&hrir_path, context::SAMPLE_RATE).unwrap();
 //!
-//!     context.state().set_renderer(Renderer::HrtfRenderer(HrtfRenderer::new(HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path, true))));
+//!     context.state().set_renderer(Renderer::HrtfRenderer(HrtfRenderer::new(HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path.into()))));
 //! }
 //! ```
 //!
@@ -227,9 +227,9 @@ impl ResourceLoader for HrirSphereLoader {
 
     fn load(&self, path: PathBuf, io: Arc<dyn ResourceIo>) -> BoxedLoaderFuture {
         Box::pin(async move {
-            let reader = io.file_reader(&path).await.map_err(|e| LoadError::new(e))?;
+            let reader = io.file_reader(&path).await.map_err(LoadError::new)?;
             let hrir_sphere =
-                HrirSphere::new(reader, context::SAMPLE_RATE).map_err(|e| LoadError::new(e))?;
+                HrirSphere::new(reader, context::SAMPLE_RATE).map_err(LoadError::new)?;
             Ok(LoaderPayload::new(HrirSphereResourceData {
                 hrir_sphere: Some(hrir_sphere),
             }))

--- a/fyrox-sound/src/renderer/hrtf.rs
+++ b/fyrox-sound/src/renderer/hrtf.rs
@@ -31,7 +31,7 @@
 //!     let hrir_path = PathBuf::from("examples/data/IRC_1002_C.bin");
 //!     let hrir_sphere = HrirSphere::from_file(&hrir_path, context::SAMPLE_RATE).unwrap();
 //!
-//!     context.state().set_renderer(Renderer::HrtfRenderer(HrtfRenderer::new(HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path))));
+//!     context.state().set_renderer(Renderer::HrtfRenderer(HrtfRenderer::new(HrirSphereResource::from_hrir_sphere(hrir_sphere, hrir_path, true))));
 //! }
 //! ```
 //!
@@ -252,7 +252,7 @@ impl ResourceLoader for HrirSphereLoader {
                             path, error
                         ));
 
-                        hrir_sphere.commit_error(path, error);
+                        hrir_sphere.commit_error(error);
                     }
                 },
                 Err(error) => {
@@ -261,7 +261,7 @@ impl ResourceLoader for HrirSphereLoader {
                         path, error
                     ));
 
-                    hrir_sphere.commit_error(path, error);
+                    hrir_sphere.commit_error(error);
                 }
             }
         })

--- a/fyrox-sound/src/renderer/hrtf.rs
+++ b/fyrox-sound/src/renderer/hrtf.rs
@@ -70,16 +70,10 @@ use fyrox_resource::{
     io::ResourceIo,
     loader::{BoxedLoaderFuture, ResourceLoader},
     untyped::UntypedResource,
-    Resource, ResourceData, ResourceStateRef,
+    Resource, ResourceData,
 };
 use hrtf::HrirSphere;
-use std::{
-    any::Any,
-    fmt::Debug,
-    fmt::Formatter,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{any::Any, fmt::Debug, fmt::Formatter, path::PathBuf, sync::Arc};
 
 /// See module docs.
 #[derive(Clone, Debug, Default, Reflect)]
@@ -138,8 +132,8 @@ impl HrtfRenderer {
         // This is a poor-man's async support for crippled OSes such as WebAssembly.
         if self.processor.is_none() {
             if let Some(resource) = self.hrir_resource.as_ref() {
-                let state = resource.state();
-                if let ResourceStateRef::Ok(hrir) = state.get() {
+                let mut header = resource.state();
+                if let Some(hrir) = header.data() {
                     self.processor = Some(hrtf::HrtfProcessor::new(
                         hrir.hrir_sphere.clone().unwrap(),
                         SoundContext::HRTF_INTERPOLATION_STEPS,
@@ -186,28 +180,16 @@ impl HrtfRenderer {
 
 /// Wrapper for [`HrirSphere`] to be able to use it in the resource manager, that will handle async resource
 /// loading automatically.
-#[derive(Reflect, Default)]
+#[derive(Reflect, Default, Visit)]
 pub struct HrirSphereResourceData {
-    path: PathBuf,
     #[reflect(hidden)]
+    #[visit(skip)]
     hrir_sphere: Option<HrirSphere>,
 }
 
 impl Debug for HrirSphereResourceData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HrirSphereResourceData")
-            .field("Path", &self.path.to_string_lossy().to_string())
-            .finish()
-    }
-}
-
-impl Visit for HrirSphereResourceData {
-    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
-        let mut guard = visitor.enter_region(name)?;
-
-        self.path.visit("Path", &mut guard)?;
-
-        Ok(())
+        f.debug_struct("HrirSphereResourceData").finish()
     }
 }
 
@@ -218,14 +200,6 @@ impl TypeUuidProvider for HrirSphereResourceData {
 }
 
 impl ResourceData for HrirSphereResourceData {
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
-    fn set_path(&mut self, path: PathBuf) {
-        self.path = path;
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -236,10 +210,6 @@ impl ResourceData for HrirSphereResourceData {
 
     fn type_uuid(&self) -> Uuid {
         <Self as TypeUuidProvider>::type_uuid()
-    }
-
-    fn is_embedded(&self) -> bool {
-        false
     }
 }
 
@@ -272,7 +242,6 @@ impl ResourceLoader for HrirSphereLoader {
 
                         hrir_sphere.commit_ok(HrirSphereResourceData {
                             hrir_sphere: Some(sphere),
-                            path,
                         });
 
                         event_broadcaster.broadcast_loaded_or_reloaded(hrir_sphere, reload);
@@ -306,14 +275,17 @@ pub type HrirSphereResource = Resource<HrirSphereResourceData>;
 pub trait HrirSphereResourceExt {
     /// Creates a new HRIR sphere resource directly from pre-loaded HRIR sphere. It could be used if you
     /// do not use a resource manager, but want to load HRIR spheres manually.
-    fn from_hrir_sphere(hrir_sphere: HrirSphere, path: PathBuf) -> Self;
+    fn from_hrir_sphere(hrir_sphere: HrirSphere, path: PathBuf, is_embedded: bool) -> Self;
 }
 
 impl HrirSphereResourceExt for HrirSphereResource {
-    fn from_hrir_sphere(hrir_sphere: HrirSphere, path: PathBuf) -> Self {
-        Resource::new_ok(HrirSphereResourceData {
-            hrir_sphere: Some(hrir_sphere),
+    fn from_hrir_sphere(hrir_sphere: HrirSphere, path: PathBuf, is_embedded: bool) -> Self {
+        Resource::new_ok(
             path,
-        })
+            HrirSphereResourceData {
+                hrir_sphere: Some(hrir_sphere),
+            },
+            is_embedded,
+        )
     }
 }

--- a/fyrox-sound/src/source.rs
+++ b/fyrox-sound/src/source.rs
@@ -40,7 +40,6 @@ use fyrox_core::{
     reflect::prelude::*,
     visitor::{Visit, VisitResult, Visitor},
 };
-use fyrox_resource::ResourceStateRefMut;
 use std::time::Duration;
 
 /// Status (state) of sound source.
@@ -216,11 +215,9 @@ impl SoundSource {
         }
 
         if let Some(buffer) = buffer.clone() {
-            match buffer.state().get_mut() {
-                ResourceStateRefMut::LoadError { .. } => {
-                    return Err(SoundError::BufferFailedToLoad)
-                }
-                ResourceStateRefMut::Ok(locked_buffer) => {
+            match buffer.state().data() {
+                None => return Err(SoundError::BufferFailedToLoad),
+                Some(locked_buffer) => {
                     // Check new buffer if streaming - it must not be used by anyone else.
                     if let SoundBuffer::Streaming(ref mut streaming) = *locked_buffer {
                         if streaming.use_count != 0 {
@@ -234,7 +231,6 @@ impl SoundSource {
                     let sample_rate = locked_buffer.sample_rate() as f64;
                     self.resampling_multiplier = sample_rate / device_sample_rate;
                 }
-                ResourceStateRefMut::Pending { .. } => unreachable!(),
             }
         }
 
@@ -497,7 +493,7 @@ impl SoundSource {
 
         if let Some(buffer) = self.buffer.clone() {
             let mut state = buffer.state();
-            if let ResourceStateRefMut::Ok(buffer) = state.get_mut() {
+            if let Some(buffer) = state.data() {
                 if self.status == Status::Playing && !buffer.is_empty() {
                     self.render_playing(buffer, amount);
                 }

--- a/src/material/loader.rs
+++ b/src/material/loader.rs
@@ -32,7 +32,7 @@ impl ResourceLoader for MaterialLoader {
         Box::pin(async move {
             let material = Material::from_file(&path, io.as_ref(), resource_manager)
                 .await
-                .map_err(|e| LoadError::new(e))?;
+                .map_err(LoadError::new)?;
             Ok(LoaderPayload::new(material))
         })
     }

--- a/src/material/loader.rs
+++ b/src/material/loader.rs
@@ -53,7 +53,7 @@ impl ResourceLoader for MaterialLoader {
                         path, error
                     ));
 
-                    material.commit_error(path, error);
+                    material.commit_error(error);
                 }
             }
         })

--- a/src/material/loader.rs
+++ b/src/material/loader.rs
@@ -2,16 +2,15 @@
 
 use crate::{
     asset::{
-        event::ResourceEventBroadcaster,
         io::ResourceIo,
-        loader::{BoxedLoaderFuture, ResourceLoader},
+        loader::{BoxedLoaderFuture, LoaderPayload, ResourceLoader},
         manager::ResourceManager,
-        untyped::UntypedResource,
     },
-    core::{log::Log, uuid::Uuid, TypeUuidProvider},
+    core::{uuid::Uuid, TypeUuidProvider},
     material::Material,
 };
-use std::sync::Arc;
+use fyrox_resource::state::LoadError;
+use std::{path::PathBuf, sync::Arc};
 
 /// Default implementation for material loading.
 pub struct MaterialLoader {
@@ -28,34 +27,13 @@ impl ResourceLoader for MaterialLoader {
         Material::type_uuid()
     }
 
-    fn load(
-        &self,
-        material: UntypedResource,
-        event_broadcaster: ResourceEventBroadcaster,
-        reload: bool,
-        io: Arc<dyn ResourceIo>,
-    ) -> BoxedLoaderFuture {
+    fn load(&self, path: PathBuf, io: Arc<dyn ResourceIo>) -> BoxedLoaderFuture {
         let resource_manager = self.resource_manager.clone();
         Box::pin(async move {
-            let path = material.path().to_path_buf();
-
-            match Material::from_file(&path, io.as_ref(), resource_manager).await {
-                Ok(shader_state) => {
-                    Log::info(format!("Material {:?} is loaded!", path));
-
-                    material.commit_ok(shader_state);
-
-                    event_broadcaster.broadcast_loaded_or_reloaded(material, reload);
-                }
-                Err(error) => {
-                    Log::err(format!(
-                        "Unable to load material from {:?}! Reason {:?}",
-                        path, error
-                    ));
-
-                    material.commit_error(error);
-                }
-            }
+            let material = Material::from_file(&path, io.as_ref(), resource_manager)
+                .await
+                .map_err(|e| LoadError::new(e))?;
+            Ok(LoaderPayload::new(material))
         })
     }
 }

--- a/src/material/shader/loader.rs
+++ b/src/material/shader/loader.rs
@@ -27,7 +27,7 @@ impl ResourceLoader for ShaderLoader {
         Box::pin(async move {
             let shader_state = Shader::from_file(&path, io.as_ref())
                 .await
-                .map_err(|e| LoadError::new(e))?;
+                .map_err(LoadError::new)?;
             Ok(LoaderPayload::new(shader_state))
         })
     }

--- a/src/material/shader/loader.rs
+++ b/src/material/shader/loader.rs
@@ -45,7 +45,7 @@ impl ResourceLoader for ShaderLoader {
                         path, error
                     ));
 
-                    shader.commit_error(path, error);
+                    shader.commit_error(error);
                 }
             }
         })

--- a/src/material/shader/mod.rs
+++ b/src/material/shader/mod.rs
@@ -315,44 +315,20 @@ pub const STANDARD_SHADER_SOURCES: [&str; 6] = [
 ///
 /// Usually you don't need to access internals of the shader, but there sometimes could be a need to
 /// read shader definition, to get supported passes and properties.
-#[derive(Default, Debug, Reflect)]
+#[derive(Default, Debug, Reflect, Visit)]
 pub struct Shader {
-    path: PathBuf,
-
     /// Shader definition contains description of properties and render passes.
+    #[visit(optional)]
     pub definition: ShaderDefinition,
 
-    is_embedded: bool,
-
     #[reflect(hidden)]
+    #[visit(skip)]
     pub(crate) cache_index: AtomicIndex,
 }
 
 impl TypeUuidProvider for Shader {
     fn type_uuid() -> Uuid {
         SHADER_RESOURCE_UUID
-    }
-}
-
-impl Visit for Shader {
-    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
-        let mut region = visitor.enter_region(name)?;
-
-        self.path.visit("Path", &mut region)?;
-        let _ = self.is_embedded.visit("IsProcedural", &mut region);
-
-        drop(region);
-
-        if visitor.is_reading() {
-            for path in STANDARD_SHADER_NAMES.iter() {
-                if self.path == Path::new(path) {
-                    self.is_embedded = false;
-                    break;
-                }
-            }
-        }
-
-        Ok(())
     }
 }
 
@@ -388,7 +364,7 @@ impl Default for SamplerFallback {
 }
 
 /// Shader property with default value.
-#[derive(Deserialize, Debug, PartialEq, Reflect)]
+#[derive(Deserialize, Debug, PartialEq, Reflect, Visit)]
 pub enum PropertyKind {
     /// Real number.
     Float(f32),
@@ -486,7 +462,7 @@ impl Default for PropertyKind {
 }
 
 /// Shader property definition.
-#[derive(Default, Deserialize, Debug, PartialEq, Reflect)]
+#[derive(Default, Deserialize, Debug, PartialEq, Reflect, Visit)]
 pub struct PropertyDefinition {
     /// A name of the property.
     pub name: String,
@@ -495,7 +471,7 @@ pub struct PropertyDefinition {
 }
 
 /// A render pass definition. See [`ShaderResource`] docs for more info about render passes.
-#[derive(Default, Deserialize, Debug, PartialEq, Eq, Reflect)]
+#[derive(Default, Deserialize, Debug, PartialEq, Eq, Reflect, Visit)]
 pub struct RenderPassDefinition {
     /// A name of render pass.
     pub name: String,
@@ -508,7 +484,7 @@ pub struct RenderPassDefinition {
 }
 
 /// A definition of the shader.
-#[derive(Default, Deserialize, Debug, PartialEq, Reflect)]
+#[derive(Default, Deserialize, Debug, PartialEq, Reflect, Visit)]
 pub struct ShaderDefinition {
     /// A name of the shader.
     pub name: String,
@@ -535,36 +511,20 @@ impl Shader {
     ) -> Result<Self, ShaderError> {
         let content = io.load_file(path.as_ref()).await?;
         Ok(Self {
-            path: path.as_ref().to_owned(),
             definition: ShaderDefinition::from_buf(content)?,
-            is_embedded: false,
             cache_index: Default::default(),
         })
     }
 
-    pub(crate) fn from_str<P: AsRef<Path>>(
-        str: &str,
-        path: P,
-        is_embedded: bool,
-    ) -> Result<Self, ShaderError> {
+    pub(crate) fn from_str(str: &str) -> Result<Self, ShaderError> {
         Ok(Self {
-            path: path.as_ref().to_owned(),
             definition: ShaderDefinition::from_str(str)?,
             cache_index: Default::default(),
-            is_embedded,
         })
     }
 }
 
 impl ResourceData for Shader {
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
-    fn set_path(&mut self, path: PathBuf) {
-        self.path = path;
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -575,10 +535,6 @@ impl ResourceData for Shader {
 
     fn type_uuid(&self) -> Uuid {
         <Self as TypeUuidProvider>::type_uuid()
-    }
-
-    fn is_embedded(&self) -> bool {
-        self.is_embedded
     }
 }
 
@@ -657,11 +613,11 @@ impl ShaderResourceExtension for ShaderResource {
         path: P,
         is_embedded: bool,
     ) -> Result<Self, ShaderError> {
-        Ok(Resource::new_ok(Shader::from_str(
-            str,
-            path.as_ref(),
+        Ok(Resource::new_ok(
+            path.as_ref().to_owned(),
+            Shader::from_str(str)?,
             is_embedded,
-        )?))
+        ))
     }
 
     /// Returns an instance of standard shader.
@@ -709,57 +665,49 @@ impl ShaderResourceExtension for ShaderResource {
 
 lazy_static! {
     static ref STANDARD: ShaderResource = ShaderResource::new_ok(
-        Shader::from_str(STANDARD_SHADER_SRC, STANDARD_SHADER_NAME, false).unwrap(),
+        STANDARD_SHADER_NAME.into(),
+        Shader::from_str(STANDARD_SHADER_SRC).unwrap(),
+        false
     );
 }
 
 lazy_static! {
     static ref STANDARD_2D: ShaderResource = ShaderResource::new_ok(
-        Shader::from_str(STANDARD_2D_SHADER_SRC, STANDARD_2D_SHADER_NAME, false).unwrap(),
+        STANDARD_2D_SHADER_NAME.into(),
+        Shader::from_str(STANDARD_2D_SHADER_SRC).unwrap(),
+        false
     );
 }
 
 lazy_static! {
     static ref STANDARD_PARTICLE_SYSTEM: ShaderResource = ShaderResource::new_ok(
-        Shader::from_str(
-            STANDARD_PARTICLE_SYSTEM_SHADER_SRC,
-            STANDARD_PARTICLE_SYSTEM_SHADER_NAME,
-            false
-        )
-        .unwrap(),
+        STANDARD_PARTICLE_SYSTEM_SHADER_NAME.into(),
+        Shader::from_str(STANDARD_PARTICLE_SYSTEM_SHADER_SRC).unwrap(),
+        false
     );
 }
 
 lazy_static! {
     static ref STANDARD_SPRITE: ShaderResource = ShaderResource::new_ok(
-        Shader::from_str(
-            STANDARD_SPRITE_SHADER_SRC,
-            STANDARD_SPRITE_SHADER_NAME,
-            false
-        )
-        .unwrap(),
+        STANDARD_SPRITE_SHADER_NAME.into(),
+        Shader::from_str(STANDARD_SPRITE_SHADER_SRC).unwrap(),
+        false
     );
 }
 
 lazy_static! {
     static ref STANDARD_TERRAIN: ShaderResource = ShaderResource::new_ok(
-        Shader::from_str(
-            STANDARD_TERRAIN_SHADER_SRC,
-            STANDARD_TERRAIN_SHADER_NAME,
-            false
-        )
-        .unwrap(),
+        STANDARD_TERRAIN_SHADER_NAME.into(),
+        Shader::from_str(STANDARD_TERRAIN_SHADER_SRC).unwrap(),
+        false
     );
 }
 
 lazy_static! {
     static ref STANDARD_TWOSIDES: ShaderResource = ShaderResource::new_ok(
-        Shader::from_str(
-            STANDARD_TWOSIDES_SHADER_SRC,
-            STANDARD_TWOSIDES_SHADER_NAME,
-            false
-        )
-        .unwrap(),
+        STANDARD_TWOSIDES_SHADER_NAME.into(),
+        Shader::from_str(STANDARD_TWOSIDES_SHADER_SRC).unwrap(),
+        false
     );
 }
 

--- a/src/material/shader/mod.rs
+++ b/src/material/shader/mod.rs
@@ -242,6 +242,7 @@ use crate::{
     lazy_static::lazy_static,
     renderer::framework::framebuffer::DrawParameters,
 };
+use fyrox_resource::untyped::ResourceKind;
 use serde::Deserialize;
 use std::{
     any::Any,
@@ -580,8 +581,7 @@ pub type ShaderResource = Resource<Shader>;
 pub trait ShaderResourceExtension: Sized {
     /// Creates new shader from given string. Input string must have the format defined in
     /// examples for [`ShaderResource`].
-    fn from_str<P: AsRef<Path>>(str: &str, path: P, is_embedded: bool)
-        -> Result<Self, ShaderError>;
+    fn from_str(str: &str, kind: ResourceKind) -> Result<Self, ShaderError>;
 
     /// Returns an instance of standard shader.
     fn standard() -> Self;
@@ -606,51 +606,34 @@ pub trait ShaderResourceExtension: Sized {
 }
 
 impl ShaderResourceExtension for ShaderResource {
-    /// Creates new shader from given string. Input string must have the format defined in
-    /// examples for [`ShaderResource`].
-    fn from_str<P: AsRef<Path>>(
-        str: &str,
-        path: P,
-        is_embedded: bool,
-    ) -> Result<Self, ShaderError> {
-        Ok(Resource::new_ok(
-            path.as_ref().to_owned(),
-            Shader::from_str(str)?,
-            is_embedded,
-        ))
+    fn from_str(str: &str, kind: ResourceKind) -> Result<Self, ShaderError> {
+        Ok(Resource::new_ok(kind, Shader::from_str(str)?))
     }
 
-    /// Returns an instance of standard shader.
     fn standard() -> Self {
         STANDARD.clone()
     }
 
-    /// Returns an instance of standard 2D shader.
     fn standard_2d() -> Self {
         STANDARD_2D.clone()
     }
 
-    /// Returns an instance of standard particle system shader.
     fn standard_particle_system() -> Self {
         STANDARD_PARTICLE_SYSTEM.clone()
     }
 
-    /// Returns an instance of standard sprite shader.
     fn standard_sprite() -> Self {
         STANDARD_SPRITE.clone()
     }
 
-    /// Returns an instance of standard terrain shader.
     fn standard_terrain() -> Self {
         STANDARD_TERRAIN.clone()
     }
 
-    /// Returns an instance of standard two-sides terrain shader.
     fn standard_twosides() -> Self {
         STANDARD_TWOSIDES.clone()
     }
 
-    /// Returns a list of standard shader.
     fn standard_shaders() -> Vec<ShaderResource> {
         vec![
             Self::standard(),
@@ -667,7 +650,6 @@ lazy_static! {
     static ref STANDARD: ShaderResource = ShaderResource::new_ok(
         STANDARD_SHADER_NAME.into(),
         Shader::from_str(STANDARD_SHADER_SRC).unwrap(),
-        false
     );
 }
 
@@ -675,7 +657,6 @@ lazy_static! {
     static ref STANDARD_2D: ShaderResource = ShaderResource::new_ok(
         STANDARD_2D_SHADER_NAME.into(),
         Shader::from_str(STANDARD_2D_SHADER_SRC).unwrap(),
-        false
     );
 }
 
@@ -683,7 +664,6 @@ lazy_static! {
     static ref STANDARD_PARTICLE_SYSTEM: ShaderResource = ShaderResource::new_ok(
         STANDARD_PARTICLE_SYSTEM_SHADER_NAME.into(),
         Shader::from_str(STANDARD_PARTICLE_SYSTEM_SHADER_SRC).unwrap(),
-        false
     );
 }
 
@@ -691,7 +671,6 @@ lazy_static! {
     static ref STANDARD_SPRITE: ShaderResource = ShaderResource::new_ok(
         STANDARD_SPRITE_SHADER_NAME.into(),
         Shader::from_str(STANDARD_SPRITE_SHADER_SRC).unwrap(),
-        false
     );
 }
 
@@ -699,7 +678,6 @@ lazy_static! {
     static ref STANDARD_TERRAIN: ShaderResource = ShaderResource::new_ok(
         STANDARD_TERRAIN_SHADER_NAME.into(),
         Shader::from_str(STANDARD_TERRAIN_SHADER_SRC).unwrap(),
-        false
     );
 }
 
@@ -707,7 +685,6 @@ lazy_static! {
     static ref STANDARD_TWOSIDES: ShaderResource = ShaderResource::new_ok(
         STANDARD_TWOSIDES_SHADER_NAME.into(),
         Shader::from_str(STANDARD_TWOSIDES_SHADER_SRC).unwrap(),
-        false
     );
 }
 

--- a/src/material/shader/mod.rs
+++ b/src/material/shader/mod.rs
@@ -737,7 +737,7 @@ mod test {
             )
             "#;
 
-        let shader = ShaderResource::from_str(code, "test", true).unwrap();
+        let shader = ShaderResource::from_str(code, "test".into()).unwrap();
         let data = shader.data_ref();
 
         let reference_definition = ShaderDefinition {

--- a/src/material/shader/mod.rs
+++ b/src/material/shader/mod.rs
@@ -760,7 +760,7 @@ mod test {
             )
             "#;
 
-        let shader = ShaderResource::from_str(code, "test").unwrap();
+        let shader = ShaderResource::from_str(code, "test", true).unwrap();
         let data = shader.data_ref();
 
         let reference_definition = ShaderDefinition {

--- a/src/renderer/cache/shader.rs
+++ b/src/renderer/cache/shader.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use fxhash::FxHashMap;
 use fyrox_resource::entry::DEFAULT_RESOURCE_LIFETIME;
-use fyrox_resource::ResourceStateRef;
 
 pub struct RenderPassData {
     pub program: GpuProgram,
@@ -68,8 +67,8 @@ pub struct ShaderCache {
 
 impl ShaderCache {
     pub fn remove(&mut self, shader: &ShaderResource) {
-        let state = shader.state();
-        if let ResourceStateRef::Ok(shader_state) = state.get() {
+        let mut state = shader.state();
+        if let Some(shader_state) = state.data() {
             self.buffer.free(&shader_state.cache_index);
         }
     }
@@ -82,9 +81,9 @@ impl ShaderCache {
         scope_profile!();
 
         let key = shader.key();
-        let shader_state = shader.state();
+        let mut shader_state = shader.state();
 
-        if let ResourceStateRef::Ok(shader_state) = shader_state.get() {
+        if let Some(shader_state) = shader_state.data() {
             if self.buffer.is_index_valid(&shader_state.cache_index) {
                 let entry = self.buffer.get_mut(&shader_state.cache_index).unwrap();
 

--- a/src/renderer/cache/texture.rs
+++ b/src/renderer/cache/texture.rs
@@ -161,7 +161,7 @@ impl TextureCache {
 
                             Log::writeln(
                                 MessageKind::Error,
-                                format!("Failed to create GPU texture from {:?} engine texture. Reason: {:?}", texture_resource.path(), e),
+                                format!("Failed to create GPU texture from {} engine texture. Reason: {:?}", texture_resource.kind(), e),
                             );
                             return None;
                         }

--- a/src/renderer/cache/texture.rs
+++ b/src/renderer/cache/texture.rs
@@ -1,5 +1,5 @@
 use crate::{
-    asset::{entry::DEFAULT_RESOURCE_LIFETIME, ResourceStateRef},
+    asset::entry::DEFAULT_RESOURCE_LIFETIME,
     core::{
         log::{Log, MessageKind},
         scope_profile,
@@ -31,9 +31,9 @@ impl TextureCache {
         texture: &TextureResource,
     ) -> Result<(), FrameworkError> {
         let key = texture.key();
-        let texture = texture.state();
+        let mut texture = texture.state();
 
-        if let ResourceStateRef::Ok(texture) = texture.get() {
+        if let Some(texture) = texture.data() {
             let gpu_texture = GpuTexture::new(
                 state,
                 texture.kind().into(),
@@ -74,9 +74,9 @@ impl TextureCache {
 
         let key = texture_resource.key();
 
-        let texture_data_guard = texture_resource.state();
+        let mut texture_data_guard = texture_resource.state();
 
-        if let ResourceStateRef::Ok(texture) = texture_data_guard.get() {
+        if let Some(texture) = texture_data_guard.data() {
             let entry = match self.map.entry(key) {
                 Entry::Occupied(e) => {
                     let entry = e.into_mut();

--- a/src/renderer/forward_renderer.rs
+++ b/src/renderer/forward_renderer.rs
@@ -33,7 +33,6 @@ use crate::{
     },
 };
 use fyrox_core::math::Matrix4Ext;
-use fyrox_resource::ResourceStateRef;
 use std::{cell::RefCell, rc::Rc};
 
 pub(crate) struct ForwardRenderer {
@@ -156,8 +155,8 @@ impl ForwardRenderer {
             .iter()
             .filter(|b| b.render_path == RenderPath::Forward)
         {
-            let material_state = batch.material.state();
-            if let ResourceStateRef::Ok(material) = material_state.get() {
+            let mut material_state = batch.material.state();
+            if let Some(material) = material_state.data() {
                 let geometry = geom_cache.get(state, &batch.data, batch.time_to_live);
                 let blend_shapes_storage = batch
                     .data

--- a/src/renderer/gbuffer/mod.rs
+++ b/src/renderer/gbuffer/mod.rs
@@ -46,7 +46,6 @@ use crate::{
     },
 };
 use fyrox_core::math::Matrix4Ext;
-use fyrox_resource::ResourceStateRef;
 use std::{cell::RefCell, rc::Rc};
 
 mod decal;
@@ -309,8 +308,8 @@ impl GBuffer {
             .iter()
             .filter(|b| b.render_path == RenderPath::Deferred)
         {
-            let material_state = batch.material.state();
-            if let ResourceStateRef::Ok(material) = material_state.get() {
+            let mut material_state = batch.material.state();
+            if let Some(material) = material_state.data() {
                 let geometry = geom_cache.get(state, &batch.data, batch.time_to_live);
                 let blend_shapes_storage = batch
                     .data

--- a/src/renderer/shadow/csm.rs
+++ b/src/renderer/shadow/csm.rs
@@ -27,7 +27,6 @@ use crate::{
 };
 use fyrox_core::color::Color;
 use fyrox_core::math::Matrix4Ext;
-use fyrox_resource::ResourceStateRef;
 use std::{cell::RefCell, rc::Rc};
 
 pub struct Cascade {
@@ -262,8 +261,8 @@ impl CsmRenderer {
             framebuffer.clear(state, viewport, None, Some(1.0), None);
 
             for batch in batches.batches.iter() {
-                let material_state = batch.material.state();
-                if let ResourceStateRef::Ok(material) = material_state.get() {
+                let mut material_state = batch.material.state();
+                if let Some(material) = material_state.data() {
                     let geometry = geom_cache.get(state, &batch.data, batch.time_to_live);
                     let blend_shapes_storage = batch
                         .data

--- a/src/renderer/shadow/point.rs
+++ b/src/renderer/shadow/point.rs
@@ -26,7 +26,6 @@ use crate::{
     scene::graph::Graph,
 };
 use fyrox_core::math::Matrix4Ext;
-use fyrox_resource::ResourceStateRef;
 use std::{cell::RefCell, rc::Rc};
 
 pub struct PointShadowMapRenderer {
@@ -255,8 +254,8 @@ impl PointShadowMapRenderer {
             );
 
             for batch in batches.batches.iter() {
-                let material_state = batch.material.state();
-                if let ResourceStateRef::Ok(material) = material_state.get() {
+                let mut material_state = batch.material.state();
+                if let Some(material) = material_state.data() {
                     let geometry = geom_cache.get(state, &batch.data, batch.time_to_live);
                     let blend_shapes_storage = batch
                         .data

--- a/src/renderer/shadow/spot.rs
+++ b/src/renderer/shadow/spot.rs
@@ -26,7 +26,6 @@ use crate::{
     scene::graph::Graph,
 };
 use fyrox_core::math::Matrix4Ext;
-use fyrox_resource::ResourceStateRef;
 use std::{cell::RefCell, rc::Rc};
 
 pub struct SpotShadowMapRenderer {
@@ -165,8 +164,8 @@ impl SpotShadowMapRenderer {
         let camera_side = inv_view.side();
 
         for batch in batches.batches.iter() {
-            let material_state = batch.material.state();
-            if let ResourceStateRef::Ok(material) = material_state.get() {
+            let mut material_state = batch.material.state();
+            if let Some(material) = material_state.data() {
                 let geometry = geom_cache.get(state, &batch.data, batch.time_to_live);
                 let blend_shapes_storage = batch
                     .data

--- a/src/renderer/ui_renderer.rs
+++ b/src/renderer/ui_renderer.rs
@@ -33,6 +33,8 @@ use crate::{
     },
     resource::texture::{Texture, TextureKind, TexturePixelKind},
 };
+use fyrox_resource::untyped::ResourceHeader;
+use fyrox_resource::ResourceData;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 struct UiShader {
@@ -272,11 +274,14 @@ impl UiRenderer {
                             },
                             TexturePixelKind::R8,
                             font.atlas_pixels().to_vec(),
-                            false,
                         ) {
-                            font.texture = Some(SharedTexture(Arc::new(Mutex::new(
-                                ResourceState::new_ok(details),
-                            ))));
+                            font.texture =
+                                Some(SharedTexture(Arc::new(Mutex::new(ResourceHeader {
+                                    path: Default::default(),
+                                    type_uuid: details.type_uuid(),
+                                    is_embedded: true,
+                                    state: ResourceState::new_ok(details),
+                                }))));
                         }
                     }
                     let tex = UntypedResource(
@@ -284,7 +289,7 @@ impl UiRenderer {
                             .clone()
                             .unwrap()
                             .0
-                            .downcast::<Mutex<ResourceState>>()
+                            .downcast::<Mutex<ResourceHeader>>()
                             .unwrap(),
                     );
                     if let Some(texture) =
@@ -295,7 +300,7 @@ impl UiRenderer {
                     is_font_texture = true;
                 }
                 CommandTexture::Texture(texture) => {
-                    if let Ok(texture) = texture.clone().0.downcast::<Mutex<ResourceState>>() {
+                    if let Ok(texture) = texture.clone().0.downcast::<Mutex<ResourceHeader>>() {
                         let resource = UntypedResource(texture).try_cast::<Texture>().unwrap();
                         if let Some(texture) = texture_cache.get(state, &resource) {
                             diffuse_texture = texture;

--- a/src/renderer/ui_renderer.rs
+++ b/src/renderer/ui_renderer.rs
@@ -277,9 +277,8 @@ impl UiRenderer {
                         ) {
                             font.texture =
                                 Some(SharedTexture(Arc::new(Mutex::new(ResourceHeader {
-                                    path: Default::default(),
+                                    kind: Default::default(),
                                     type_uuid: details.type_uuid(),
-                                    is_embedded: true,
                                     state: ResourceState::new_ok(details),
                                 }))));
                         }

--- a/src/resource/curve/loader.rs
+++ b/src/resource/curve/loader.rs
@@ -2,15 +2,14 @@
 
 use crate::{
     asset::{
-        event::ResourceEventBroadcaster,
         io::ResourceIo,
-        loader::{BoxedLoaderFuture, ResourceLoader},
-        untyped::UntypedResource,
+        loader::{BoxedLoaderFuture, LoaderPayload, ResourceLoader},
     },
-    core::{log::Log, uuid::Uuid, TypeUuidProvider},
+    core::{uuid::Uuid, TypeUuidProvider},
     resource::curve::CurveResourceState,
 };
-use std::sync::Arc;
+use fyrox_resource::state::LoadError;
+use std::{path::PathBuf, sync::Arc};
 
 /// Default implementation for curve loading.
 pub struct CurveLoader;
@@ -24,32 +23,12 @@ impl ResourceLoader for CurveLoader {
         CurveResourceState::type_uuid()
     }
 
-    fn load(
-        &self,
-        curve: UntypedResource,
-        event_broadcaster: ResourceEventBroadcaster,
-        reload: bool,
-        io: Arc<dyn ResourceIo>,
-    ) -> BoxedLoaderFuture {
+    fn load(&self, path: PathBuf, io: Arc<dyn ResourceIo>) -> BoxedLoaderFuture {
         Box::pin(async move {
-            let path = curve.path();
-            match CurveResourceState::from_file(&path, io.as_ref()).await {
-                Ok(curve_state) => {
-                    Log::info(format!("Curve {:?} is loaded!", path));
-
-                    curve.commit_ok(curve_state);
-
-                    event_broadcaster.broadcast_loaded_or_reloaded(curve, reload);
-                }
-                Err(error) => {
-                    Log::err(format!(
-                        "Unable to load curve from {:?}! Reason {:?}",
-                        path, error
-                    ));
-
-                    curve.commit_error(error);
-                }
-            }
+            let curve_state = CurveResourceState::from_file(&path, io.as_ref())
+                .await
+                .map_err(|e| LoadError::new(e))?;
+            Ok(LoaderPayload::new(curve_state))
         })
     }
 }

--- a/src/resource/curve/loader.rs
+++ b/src/resource/curve/loader.rs
@@ -27,7 +27,7 @@ impl ResourceLoader for CurveLoader {
         Box::pin(async move {
             let curve_state = CurveResourceState::from_file(&path, io.as_ref())
                 .await
-                .map_err(|e| LoadError::new(e))?;
+                .map_err(LoadError::new)?;
             Ok(LoaderPayload::new(curve_state))
         })
     }

--- a/src/resource/curve/loader.rs
+++ b/src/resource/curve/loader.rs
@@ -47,7 +47,7 @@ impl ResourceLoader for CurveLoader {
                         path, error
                     ));
 
-                    curve.commit_error(path, error);
+                    curve.commit_error(error);
                 }
             }
         })

--- a/src/resource/curve/mod.rs
+++ b/src/resource/curve/mod.rs
@@ -1,17 +1,16 @@
 //! Curve resource holds a [`Curve`]
 
 use crate::{
-    asset::{Resource, ResourceData, CURVE_RESOURCE_UUID},
+    asset::{io::ResourceIo, Resource, ResourceData, CURVE_RESOURCE_UUID},
     core::{
         curve::Curve, io::FileLoadError, reflect::prelude::*, uuid::Uuid, visitor::prelude::*,
         TypeUuidProvider,
     },
 };
-use fyrox_resource::io::ResourceIo;
 use std::{
     any::Any,
     fmt::{Display, Formatter},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 pub mod loader;
@@ -57,20 +56,11 @@ impl From<VisitError> for CurveResourceError {
 /// State of the [`CurveResource`]
 #[derive(Debug, Visit, Default, Reflect)]
 pub struct CurveResourceState {
-    pub(crate) path: PathBuf,
     /// Actual curve.
     pub curve: Curve,
 }
 
 impl ResourceData for CurveResourceState {
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
-    fn set_path(&mut self, path: PathBuf) {
-        self.path = path;
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -81,11 +71,6 @@ impl ResourceData for CurveResourceState {
 
     fn type_uuid(&self) -> Uuid {
         <Self as TypeUuidProvider>::type_uuid()
-    }
-
-    fn is_embedded(&self) -> bool {
-        // TODO: Add support for embedded curves in the future.
-        false
     }
 }
 
@@ -102,10 +87,7 @@ impl CurveResourceState {
         let mut visitor = Visitor::load_from_memory(&bytes)?;
         let mut curve = Curve::default();
         curve.visit("Curve", &mut visitor)?;
-        Ok(Self {
-            curve,
-            path: path.to_path_buf(),
-        })
+        Ok(Self { curve })
     }
 }
 

--- a/src/resource/model/loader.rs
+++ b/src/resource/model/loader.rs
@@ -77,7 +77,7 @@ impl ResourceLoader for ModelLoader {
                         path, error
                     ));
 
-                    model.commit_error(path, error);
+                    model.commit_error(error);
                 }
             }
         })

--- a/src/resource/model/loader.rs
+++ b/src/resource/model/loader.rs
@@ -56,7 +56,7 @@ impl ResourceLoader for ModelLoader {
                 import_options,
             )
             .await
-            .map_err(|e| LoadError::new(e))?;
+            .map_err(LoadError::new)?;
 
             Ok(LoaderPayload::new(model))
         })

--- a/src/resource/model/loader.rs
+++ b/src/resource/model/loader.rs
@@ -2,18 +2,18 @@
 
 use crate::{
     asset::{
-        event::ResourceEventBroadcaster,
         io::ResourceIo,
-        loader::{BoxedImportOptionsLoaderFuture, BoxedLoaderFuture, ResourceLoader},
+        loader::{
+            BoxedImportOptionsLoaderFuture, BoxedLoaderFuture, LoaderPayload, ResourceLoader,
+        },
         manager::ResourceManager,
-        options::{try_get_import_settings, try_get_import_settings_opaque},
-        untyped::UntypedResource,
+        options::{try_get_import_settings, try_get_import_settings_opaque, BaseImportOptions},
     },
-    core::{log::Log, uuid::Uuid, TypeUuidProvider},
+    core::{uuid::Uuid, TypeUuidProvider},
     engine::SerializationContext,
     resource::model::{Model, ModelImportOptions},
 };
-use fyrox_resource::options::BaseImportOptions;
+use fyrox_resource::state::LoadError;
 use std::{path::PathBuf, sync::Arc};
 
 /// Default implementation for model loading.
@@ -36,50 +36,29 @@ impl ResourceLoader for ModelLoader {
         Model::type_uuid()
     }
 
-    fn load(
-        &self,
-        model: UntypedResource,
-        event_broadcaster: ResourceEventBroadcaster,
-        reload: bool,
-        io: Arc<dyn ResourceIo>,
-    ) -> BoxedLoaderFuture {
+    fn load(&self, path: PathBuf, io: Arc<dyn ResourceIo>) -> BoxedLoaderFuture {
         let resource_manager = self.resource_manager.clone();
         let node_constructors = self.serialization_context.clone();
         let default_import_options = self.default_import_options.clone();
 
         Box::pin(async move {
             let io = io.as_ref();
-            let path = model.path().to_path_buf();
 
             let import_options = try_get_import_settings(&path, io)
                 .await
                 .unwrap_or(default_import_options);
 
-            match Model::load(
-                &path,
+            let model = Model::load(
+                path,
                 io,
                 node_constructors,
                 resource_manager,
                 import_options,
             )
             .await
-            {
-                Ok(raw_model) => {
-                    Log::info(format!("Model {:?} is loaded!", path));
+            .map_err(|e| LoadError::new(e))?;
 
-                    model.commit_ok(raw_model);
-
-                    event_broadcaster.broadcast_loaded_or_reloaded(model, reload);
-                }
-                Err(error) => {
-                    Log::err(format!(
-                        "Unable to load model from {:?}! Reason {:?}",
-                        path, error
-                    ));
-
-                    model.commit_error(error);
-                }
-            }
+            Ok(LoaderPayload::new(model))
         })
     }
 

--- a/src/resource/model/mod.rs
+++ b/src/resource/model/mod.rs
@@ -211,7 +211,7 @@ impl ModelResourceExtension for ModelResource {
         let mut retargetted_animations = Vec::new();
 
         let mut header = self.state();
-        let self_path = header.path().to_owned();
+        let self_kind = header.kind().clone();
         if let Some(model) = header.data() {
             for src_node_ref in model.scene.graph.linear_iter() {
                 if let Some(src_player) = src_node_ref.query_component_ref::<AnimationPlayer>() {
@@ -236,7 +236,7 @@ impl ModelResourceExtension for ModelResource {
                                         MessageKind::Error,
                                         format!(
                                             "Failed to retarget animation {:?} for node {}",
-                                            self_path,
+                                            self_kind,
                                             ref_node.name()
                                         ),
                                     );

--- a/src/resource/texture/loader.rs
+++ b/src/resource/texture/loader.rs
@@ -42,7 +42,7 @@ impl ResourceLoader for TextureLoader {
 
             let raw_texture = Texture::load_from_file(&path, io, import_options)
                 .await
-                .map_err(|e| LoadError::new(e))?;
+                .map_err(LoadError::new)?;
 
             Ok(LoaderPayload::new(raw_texture))
         })

--- a/src/resource/texture/loader.rs
+++ b/src/resource/texture/loader.rs
@@ -67,7 +67,7 @@ impl ResourceLoader for TextureLoader {
                         &path, &error
                     ));
 
-                    texture.commit_error(path, error);
+                    texture.commit_error(error);
                 }
             }
         })

--- a/src/resource/texture/mod.rs
+++ b/src/resource/texture/mod.rs
@@ -1735,7 +1735,7 @@ pub mod test {
             },
             TexturePixelKind::RGBA8,
             vec![1, 1, 1, 1],
-            false,
+            Default::default(),
         )
         .unwrap()
     }

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -3,7 +3,6 @@
 //! For more info see [`Base`]
 
 use crate::{
-    asset::ResourceStateRef,
     core::{
         algebra::{Matrix4, Vector3},
         log::Log,
@@ -859,8 +858,8 @@ impl Base {
     #[inline]
     pub fn root_resource(&self) -> Option<ModelResource> {
         if let Some(resource) = self.resource.as_ref() {
-            let state = resource.state();
-            if let ResourceStateRef::Ok(model) = state.get() {
+            let mut state = resource.state();
+            if let Some(model) = state.data() {
                 if let Some(ancestor_node) = model
                     .get_scene()
                     .graph

--- a/src/scene/camera.rs
+++ b/src/scene/camera.rs
@@ -27,6 +27,7 @@ use crate::{
     },
 };
 use fyrox_resource::state::LoadError;
+use fyrox_resource::untyped::ResourceKind;
 use lazy_static::lazy_static;
 use std::{
     fmt::{Display, Formatter},
@@ -859,7 +860,7 @@ impl ColorGradingLut {
                     },
                     TexturePixelKind::RGB8,
                     lut_bytes,
-                    false,
+                    ResourceKind::Embedded,
                 )
                 .unwrap();
 
@@ -911,9 +912,8 @@ pub enum SkyBoxKind {
 
 fn load_texture(data: &[u8], id: &str) -> TextureResource {
     TextureResource::load_from_memory(
-        id.into(),
+        ResourceKind::External(id.into()),
         data,
-        false,
         TextureImportOptions::default()
             .with_compression(CompressionOptions::NoCompression)
             .with_minification_filter(TextureMinificationFilter::Linear),
@@ -1388,7 +1388,7 @@ impl SkyBox {
                 TextureKind::Cube { width, height },
                 pixel_kind,
                 data,
-                false,
+                ResourceKind::Embedded,
             )
             .ok_or(SkyBoxError::UnableToBuildCubeMap)?,
         );

--- a/src/scene/camera.rs
+++ b/src/scene/camera.rs
@@ -4,7 +4,6 @@ use crate::resource::texture::{
     CompressionOptions, TextureImportOptions, TextureMinificationFilter,
 };
 use crate::{
-    asset::ResourceStateRef,
     core::{
         algebra::{Matrix4, Point3, Vector2, Vector3, Vector4},
         color::Color,
@@ -911,16 +910,16 @@ pub enum SkyBoxKind {
 }
 
 fn load_texture(data: &[u8], id: &str) -> TextureResource {
-    let texture = TextureResource::load_from_memory(
+    TextureResource::load_from_memory(
+        id.into(),
         data,
+        false,
         TextureImportOptions::default()
             .with_compression(CompressionOptions::NoCompression)
             .with_minification_filter(TextureMinificationFilter::Linear),
     )
     .ok()
-    .unwrap();
-    texture.data_ref().set_path(id);
-    texture
+    .unwrap()
 }
 
 lazy_static! {
@@ -1301,7 +1300,7 @@ impl SkyBox {
 
         for (index, texture) in self.textures().iter().enumerate() {
             if let Some(texture) = texture {
-                if let ResourceStateRef::Ok(texture) = texture.state().get() {
+                if let Some(texture) = texture.state().data() {
                     if let TextureKind::Rectangle { width, height } = texture.kind() {
                         if width != height {
                             return Err(SkyBoxError::NonSquareTexture {

--- a/src/scene/dim2/rectangle.rs
+++ b/src/scene/dim2/rectangle.rs
@@ -192,7 +192,9 @@ impl Default for Rectangle {
             color: Default::default(),
             uv_rect: InheritableVariable::new_modified(Rect::new(0.0, 0.0, 1.0, 1.0)),
             material: InheritableVariable::new_modified(MaterialResource::new_ok(
+                Default::default(),
                 Material::standard_2d(),
+                true,
             )),
         }
     }
@@ -350,7 +352,7 @@ impl RectangleBuilder {
             base_builder,
             color: Color::WHITE,
             uv_rect: Rect::new(0.0, 0.0, 1.0, 1.0),
-            material: MaterialResource::new_ok(Material::standard_2d()),
+            material: MaterialResource::new_ok(Default::default(), Material::standard_2d(), true),
         }
     }
 

--- a/src/scene/dim2/rectangle.rs
+++ b/src/scene/dim2/rectangle.rs
@@ -194,7 +194,6 @@ impl Default for Rectangle {
             material: InheritableVariable::new_modified(MaterialResource::new_ok(
                 Default::default(),
                 Material::standard_2d(),
-                true,
             )),
         }
     }
@@ -352,7 +351,7 @@ impl RectangleBuilder {
             base_builder,
             color: Color::WHITE,
             uv_rect: Rect::new(0.0, 0.0, 1.0, 1.0),
-            material: MaterialResource::new_ok(Default::default(), Material::standard_2d(), true),
+            material: MaterialResource::new_ok(Default::default(), Material::standard_2d()),
         }
     }
 

--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -885,7 +885,7 @@ impl Graph {
         for node in self.pool.iter_mut() {
             if let Some(model) = node.resource() {
                 let mut header = model.state();
-                let model_path = header.path().to_path_buf();
+                let model_kind = header.kind().clone();
                 if let Some(data) = header.data() {
                     let resource_graph = &data.get_scene().graph;
 
@@ -936,7 +936,7 @@ impl Graph {
                                         node.name(),
                                         node.self_handle.index(),
                                         node.self_handle.generation(),
-                                        model_path.display()
+                                        model_kind
                                     ));
                                 }
                             })
@@ -1047,7 +1047,7 @@ impl Graph {
             let mut nodes_to_delete = Vec::new();
             for node in self.traverse_iter(instance_root) {
                 if let Some(resource) = node.resource() {
-                    let path = resource.path();
+                    let kind = resource.kind().clone();
                     if let Some(model) = resource.state().data() {
                         if !model
                             .scene
@@ -1062,7 +1062,7 @@ impl Graph {
                                 node.name(),
                                 node.self_handle.index(),
                                 node.self_handle.generation(),
-                                path.display()
+                                kind
                             ))
                         }
                     } else {
@@ -1072,7 +1072,7 @@ impl Graph {
                             node.name(),
                             node.self_handle.index(),
                             node.self_handle.generation(),
-                            path.display()
+                            kind
                         ))
                     }
                 }
@@ -1086,7 +1086,7 @@ impl Graph {
 
             // Step 2. Look for missing nodes and create appropriate instances for them.
             let mut model = resource.state();
-            let model_path = model.path().to_owned();
+            let model_kind = model.kind().clone();
             if let Some(data) = model.data() {
                 let resource_graph = &data.get_scene().graph;
 
@@ -1099,7 +1099,7 @@ impl Graph {
                         format!(
                             "There is an instance of resource {} \
                     but original node {} cannot be found!",
-                            model_path.display(),
+                            model_kind,
                             instance.name()
                         ),
                     );

--- a/src/scene/mesh/surface.rs
+++ b/src/scene/mesh/surface.rs
@@ -1301,7 +1301,8 @@ impl Default for Surface {
     fn default() -> Self {
         Self {
             data: SurfaceSharedData::new(SurfaceData::make_cube(Matrix4::identity())).into(),
-            material: MaterialResource::new_ok(Material::standard()).into(),
+            material: MaterialResource::new_ok(Default::default(), Material::standard(), true)
+                .into(),
             vertex_weights: Default::default(),
             bones: Default::default(),
             unique_material: Default::default(),
@@ -1414,7 +1415,9 @@ impl SurfaceBuilder {
             data: self.data.into(),
             material: self
                 .material
-                .unwrap_or_else(|| MaterialResource::new_ok(Material::standard()))
+                .unwrap_or_else(|| {
+                    MaterialResource::new_ok(Default::default(), Material::standard(), true)
+                })
                 .into(),
             vertex_weights: Default::default(),
             bones: self.bones.into(),

--- a/src/scene/mesh/surface.rs
+++ b/src/scene/mesh/surface.rs
@@ -33,6 +33,7 @@ use crate::{
     },
 };
 use fxhash::{FxHashMap, FxHasher};
+use fyrox_resource::untyped::ResourceKind;
 use half::f16;
 use std::{hash::Hasher, sync::Arc};
 
@@ -177,7 +178,7 @@ impl BlendShapesContainer {
                     },
                     TexturePixelKind::RGB16F,
                     bytes,
-                    false,
+                    ResourceKind::Embedded,
                 )
                 .unwrap(),
             ),
@@ -1301,8 +1302,7 @@ impl Default for Surface {
     fn default() -> Self {
         Self {
             data: SurfaceSharedData::new(SurfaceData::make_cube(Matrix4::identity())).into(),
-            material: MaterialResource::new_ok(Default::default(), Material::standard(), true)
-                .into(),
+            material: MaterialResource::new_ok(Default::default(), Material::standard()).into(),
             vertex_weights: Default::default(),
             bones: Default::default(),
             unique_material: Default::default(),
@@ -1416,7 +1416,7 @@ impl SurfaceBuilder {
             material: self
                 .material
                 .unwrap_or_else(|| {
-                    MaterialResource::new_ok(Default::default(), Material::standard(), true)
+                    MaterialResource::new_ok(Default::default(), Material::standard())
                 })
                 .into(),
             vertex_weights: Default::default(),

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -322,7 +322,7 @@ impl SceneLoader {
         if let Some(path) = self.path {
             let exclusion_list = used_resources
                 .iter()
-                .filter(|res| res.path() == path)
+                .filter(|res| res.kind().path() == Some(&path))
                 .cloned()
                 .collect::<Vec<_>>();
 

--- a/src/scene/particle_system/mod.rs
+++ b/src/scene/particle_system/mod.rs
@@ -201,7 +201,7 @@ impl Visit for ParticleSystemRng {
 ///     )
 ///     .with_radius(0.01)
 ///     .build()])
-///     .with_material(MaterialResource::new_ok(material))
+///     .with_material(MaterialResource::new_ok(Default::default(), material, true))
 ///     .build(graph);
 /// }
 /// ```

--- a/src/scene/particle_system/mod.rs
+++ b/src/scene/particle_system/mod.rs
@@ -260,7 +260,7 @@ impl Visit for ParticleSystem {
                     },
                 )
                 .unwrap();
-            self.material = MaterialResource::new_ok(Default::default(), material, true).into();
+            self.material = MaterialResource::new_ok(Default::default(), material).into();
         } else {
             self.material.visit(name, &mut region)?;
         }
@@ -593,7 +593,6 @@ impl ParticleSystemBuilder {
             material: MaterialResource::new_ok(
                 Default::default(),
                 Material::standard_particle_system(),
-                true,
             ),
             particles: Default::default(),
             acceleration: Vector3::new(0.0, -9.81, 0.0),

--- a/src/scene/particle_system/mod.rs
+++ b/src/scene/particle_system/mod.rs
@@ -260,7 +260,7 @@ impl Visit for ParticleSystem {
                     },
                 )
                 .unwrap();
-            self.material = MaterialResource::new_ok(material).into();
+            self.material = MaterialResource::new_ok(Default::default(), material, true).into();
         } else {
             self.material.visit(name, &mut region)?;
         }
@@ -590,7 +590,11 @@ impl ParticleSystemBuilder {
         Self {
             base_builder,
             emitters: Default::default(),
-            material: MaterialResource::new_ok(Material::standard_particle_system()),
+            material: MaterialResource::new_ok(
+                Default::default(),
+                Material::standard_particle_system(),
+                true,
+            ),
             particles: Default::default(),
             acceleration: Vector3::new(0.0, -9.81, 0.0),
             color_over_lifetime: Default::default(),

--- a/src/scene/particle_system/mod.rs
+++ b/src/scene/particle_system/mod.rs
@@ -201,7 +201,7 @@ impl Visit for ParticleSystemRng {
 ///     )
 ///     .with_radius(0.01)
 ///     .build()])
-///     .with_material(MaterialResource::new_ok(Default::default(), material, true))
+///     .with_material(MaterialResource::new_ok(Default::default(), material))
 ///     .build(graph);
 /// }
 /// ```

--- a/src/scene/sound/mod.rs
+++ b/src/scene/sound/mod.rs
@@ -37,7 +37,7 @@ pub use fyrox_sound::{
 };
 
 use crate::scene::Scene;
-use fyrox_resource::ResourceStateRef;
+use fyrox_resource::state::ResourceState;
 use fyrox_sound::source::SoundSource;
 use std::{
     cell::Cell,
@@ -416,10 +416,10 @@ impl NodeTrait for Sound {
     fn validate(&self, _scene: &Scene) -> Result<(), String> {
         match self.buffer.as_ref() {
             Some(buffer) => {
-                let state = buffer.state();
-                match state.get() {
-                    ResourceStateRef::Pending { .. } | ResourceStateRef::Ok(_) => Ok(()),
-                    ResourceStateRef::LoadError { error, .. } => {
+                let header = buffer.header();
+                match header.state {
+                    ResourceState::Pending { .. } | ResourceState::Ok(_) => Ok(()),
+                    ResourceState::LoadError { ref error, .. } => {
                         match &error.0 {
                             None => Err("Sound buffer is failed to load, the reason is unknown!"
                                 .to_string()),

--- a/src/scene/sprite.rs
+++ b/src/scene/sprite.rs
@@ -360,7 +360,11 @@ impl SpriteBuilder {
     pub fn new(base_builder: BaseBuilder) -> Self {
         Self {
             base_builder,
-            material: MaterialResource::new_ok(Material::standard_sprite()),
+            material: MaterialResource::new_ok(
+                Default::default(),
+                Material::standard_sprite(),
+                true,
+            ),
             uv_rect: Rect::new(0.0, 0.0, 1.0, 1.0),
             color: Color::WHITE,
             size: 0.2,

--- a/src/scene/sprite.rs
+++ b/src/scene/sprite.rs
@@ -125,7 +125,7 @@ impl VertexTrait for SpriteVertex {
 ///         .unwrap();
 ///
 ///     SpriteBuilder::new(BaseBuilder::new())
-///         .with_material(MaterialResource::new_ok(material))
+///         .with_material(MaterialResource::new_ok(Default::default(), material, true))
 ///         .build(graph)
 /// }
 /// ```

--- a/src/scene/sprite.rs
+++ b/src/scene/sprite.rs
@@ -360,11 +360,7 @@ impl SpriteBuilder {
     pub fn new(base_builder: BaseBuilder) -> Self {
         Self {
             base_builder,
-            material: MaterialResource::new_ok(
-                Default::default(),
-                Material::standard_sprite(),
-                true,
-            ),
+            material: MaterialResource::new_ok(Default::default(), Material::standard_sprite()),
             uv_rect: Rect::new(0.0, 0.0, 1.0, 1.0),
             color: Color::WHITE,
             size: 0.2,

--- a/src/scene/sprite.rs
+++ b/src/scene/sprite.rs
@@ -125,7 +125,7 @@ impl VertexTrait for SpriteVertex {
 ///         .unwrap();
 ///
 ///     SpriteBuilder::new(BaseBuilder::new())
-///         .with_material(MaterialResource::new_ok(Default::default(), material, true))
+///         .with_material(MaterialResource::new_ok(Default::default(), material))
 ///         .build(graph)
 /// }
 /// ```

--- a/src/scene/terrain/mod.rs
+++ b/src/scene/terrain/mod.rs
@@ -37,6 +37,7 @@ use crate::{
     },
     utils::{self},
 };
+use fyrox_resource::untyped::ResourceKind;
 use half::f16;
 use image::{imageops::FilterType, ImageBuffer, Luma};
 use std::{
@@ -75,11 +76,7 @@ pub struct Layer {
 impl Default for Layer {
     fn default() -> Self {
         Self {
-            material: MaterialResource::new_ok(
-                Default::default(),
-                Material::standard_terrain(),
-                true,
-            ),
+            material: MaterialResource::new_ok(Default::default(), Material::standard_terrain()),
             mask_property_name: "maskTexture".to_string(),
             height_map_property_name: "heightMapTexture".to_string(),
             node_uv_offsets_property_name: "nodeUvOffsets".to_string(),
@@ -113,7 +110,7 @@ fn make_height_map_texture_internal(
     data.set_t_wrap_mode(TextureWrapMode::ClampToEdge);
     data.set_s_wrap_mode(TextureWrapMode::ClampToEdge);
 
-    Some(Resource::new_ok(Default::default(), data, true))
+    Some(Resource::new_ok(Default::default(), data))
 }
 
 fn make_height_map_texture(height_map: Vec<f32>, size: Vector2<u32>) -> TextureResource {
@@ -665,11 +662,7 @@ struct OldLayer {
 impl Default for OldLayer {
     fn default() -> Self {
         Self {
-            material: MaterialResource::new_ok(
-                Default::default(),
-                Material::standard_terrain(),
-                true,
-            ),
+            material: MaterialResource::new_ok(Default::default(), Material::standard_terrain()),
             mask_property_name: "maskTexture".to_string(),
             chunk_masks: Default::default(),
         }
@@ -753,7 +746,7 @@ impl Visit for Terrain {
                     }
 
                     self.layers.push(Layer {
-                        material: MaterialResource::new_ok(Default::default(), new_material, true),
+                        material: MaterialResource::new_ok(Default::default(), new_material),
                         mask_property_name: layer.mask_property_name,
                         ..Default::default()
                     });
@@ -1329,7 +1322,7 @@ impl Terrain {
                     },
                     data.pixel_kind(),
                     new_mask,
-                    true,
+                    ResourceKind::Embedded,
                 )
                 .unwrap();
 
@@ -1526,8 +1519,7 @@ impl NodeTrait for Terrain {
                         "Unable to set node uv offsets for terrain material.",
                     );
 
-                    let material =
-                        MaterialResource::new_ok(Default::default(), material.clone(), true);
+                    let material = MaterialResource::new_ok(Default::default(), material.clone());
 
                     let node_transform = chunk_transform
                         * Matrix4::new_translation(&Vector3::new(
@@ -1685,8 +1677,7 @@ fn create_layer_mask(width: u32, height: u32, value: u8) -> TextureResource {
         TextureKind::Rectangle { width, height },
         TexturePixelKind::R8,
         vec![value; (width * height) as usize],
-        // Content of mask will be explicitly serialized.
-        true,
+        ResourceKind::Embedded,
     )
     .unwrap();
 

--- a/src/utils/lightmap.rs
+++ b/src/utils/lightmap.rs
@@ -508,7 +508,7 @@ impl Lightmap {
 
             let lightmap = generate_lightmap(instance, &instances, &lights, texels_per_unit);
             map.entry(instance.owner).or_default().push(LightmapEntry {
-                texture: Some(TextureResource::new_ok(Default::default(), lightmap, false)),
+                texture: Some(TextureResource::new_ok(Default::default(), lightmap)),
                 lights: lights.iter().map(|light| light.handle()).collect(),
             });
 

--- a/src/utils/lightmap.rs
+++ b/src/utils/lightmap.rs
@@ -979,6 +979,8 @@ mod test {
         },
         utils::lightmap::{Lightmap, LightmapInputData},
     };
+    use fyrox_resource::ResourceData;
+    use std::path::Path;
 
     #[test]
     fn test_generate_lightmap() {
@@ -1022,8 +1024,7 @@ mod test {
         for entry_set in lightmap.map.values() {
             for entry in entry_set {
                 let mut data = entry.texture.as_ref().unwrap().data_ref();
-                data.set_path(format!("{}.png", counter));
-                data.save().unwrap();
+                data.save(Path::new(&format!("{}.png", counter))).unwrap();
                 counter += 1;
             }
         }

--- a/src/utils/lightmap.rs
+++ b/src/utils/lightmap.rs
@@ -10,10 +10,7 @@
 #![forbid(unsafe_code)]
 
 use crate::{
-    asset::{
-        manager::{ResourceManager, ResourceRegistrationError},
-        ResourceData,
-    },
+    asset::manager::{ResourceManager, ResourceRegistrationError},
     core::{
         algebra::{Matrix3, Matrix4, Point3, Vector2, Vector3, Vector4},
         arrayvec::ArrayVec,
@@ -39,7 +36,6 @@ use crate::{
     utils::{uvgen, uvgen::SurfaceDataPatch},
 };
 use fxhash::FxHashMap;
-use fyrox_resource::ResourceStateRef;
 use rayon::prelude::*;
 use std::{
     fmt::{Display, Formatter},
@@ -362,8 +358,8 @@ impl LightmapInputData {
                 'surface_loop: for surface in mesh.surfaces() {
                     // Check material for compatibility.
 
-                    let material_state = surface.material().state();
-                    if let ResourceStateRef::Ok(material) = material_state.get() {
+                    let mut material_state = surface.material().state();
+                    if let Some(material) = material_state.data() {
                         if !material
                             .properties()
                             .get(&ImmutableString::new("lightmapTexture"))
@@ -512,7 +508,7 @@ impl Lightmap {
 
             let lightmap = generate_lightmap(instance, &instances, &lights, texels_per_unit);
             map.entry(instance.owner).or_default().push(LightmapEntry {
-                texture: Some(TextureResource::new_ok(lightmap)),
+                texture: Some(TextureResource::new_ok(Default::default(), lightmap, false)),
                 lights: lights.iter().map(|light| light.handle()).collect(),
             });
 
@@ -541,13 +537,7 @@ impl Lightmap {
                 resource_manager.register(
                     texture.into_untyped(),
                     base_path.as_ref().join(file_path),
-                    |texture, _| {
-                        ResourceData::as_any(texture)
-                            .downcast_ref::<Texture>()
-                            .unwrap()
-                            .save()
-                            .is_ok()
-                    },
+                    |texture, path| texture.save(path).is_ok(),
                 )?;
             }
         }
@@ -968,9 +958,6 @@ fn generate_lightmap(
         },
         TexturePixelKind::RGB8,
         bytes,
-        // Do not serialize content because lightmap is saved as a series of images in
-        // a common format.
-        false,
     )
     .unwrap()
 }


### PR DESCRIPTION
All resource related data is now stored in `ResourceHeader` instead of being scattered all around in `ResourceState` variants and even in resource data itself. Backward compatibility is preserved. This PR is mostly to remove clutter and to make the resource system more flexible. `ResourceHeader` now allows to add new fields (such as UUID per resource) without breaking existing code.