### PR TITLE
Dynamic font atlas

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -611,12 +611,7 @@ impl Editor {
         let message_sender = MessageSender(message_sender);
 
         engine.user_interface.default_font.set(
-            Font::from_memory(
-                include_bytes!("../resources/arial.ttf").as_slice(),
-                14.0,
-                Font::default_char_set(),
-            )
-            .unwrap(),
+            Font::from_memory(include_bytes!("../resources/arial.ttf").as_slice(), 1024).unwrap(),
         );
 
         let configurator = Configurator::new(

--- a/editor/src/world/mod.rs
+++ b/editor/src/world/mod.rs
@@ -31,7 +31,6 @@ use fyrox::{
             TreeBuilder, TreeExpansionStrategy, TreeMessage, TreeRoot, TreeRootBuilder,
             TreeRootMessage,
         },
-        ttf::{FontBuilder, SharedFont},
         widget::{WidgetBuilder, WidgetMessage},
         window::{WindowBuilder, WindowTitle},
         wrap_panel::WrapPanelBuilder,

--- a/editor/src/world/mod.rs
+++ b/editor/src/world/mod.rs
@@ -98,7 +98,6 @@ pub struct WorldViewer {
     scroll_view: Handle<UiNode>,
     item_context_menu: Rc<RefCell<dyn WorldViewerItemContextMenu>>,
     node_to_view_map: HashMap<ErasedHandle, Handle<UiNode>>,
-    small_font: SharedFont,
 }
 
 fn make_graph_node_item(
@@ -190,13 +189,6 @@ impl WorldViewer {
         settings: &Settings,
         item_context_menu: Rc<RefCell<dyn WorldViewerItemContextMenu>>,
     ) -> Self {
-        let small_font = SharedFont::new(
-            FontBuilder::new()
-                .with_height(11.0)
-                .build_builtin()
-                .unwrap(),
-        );
-
         let tree_root;
         let node_path;
         let collapse_all;
@@ -328,7 +320,6 @@ impl WorldViewer {
             item_context_menu,
             node_to_view_map: Default::default(),
             filter: Default::default(),
-            small_font,
         }
     }
 
@@ -367,7 +358,7 @@ impl WorldViewer {
                     } else {
                         format!("{} >", name)
                     })
-                    .with_font(self.small_font.clone())
+                    .with_height(11.0)
                     .build(ctx),
             )
             .build(ctx);

--- a/fyrox-ui/src/formatted_text.rs
+++ b/fyrox-ui/src/formatted_text.rs
@@ -8,18 +8,9 @@ use std::ops::Range;
 
 #[derive(Debug, Clone)]
 pub struct TextGlyph {
-    bounds: Rect<f32>,
-    tex_coords: [Vector2<f32>; 4],
-}
-
-impl TextGlyph {
-    pub fn get_bounds(&self) -> Rect<f32> {
-        self.bounds
-    }
-
-    pub fn get_tex_coords(&self) -> &[Vector2<f32>; 4] {
-        &self.tex_coords
-    }
+    pub bounds: Rect<f32>,
+    pub tex_coords: [Vector2<f32>; 4],
+    pub atlas_page_index: usize,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -441,6 +432,7 @@ impl FormattedText {
                         let text_glyph = TextGlyph {
                             bounds: rect,
                             tex_coords: glyph.tex_coords,
+                            atlas_page_index: glyph.page_index,
                         };
                         self.glyphs.push(text_glyph);
 
@@ -457,6 +449,7 @@ impl FormattedText {
                         self.glyphs.push(TextGlyph {
                             bounds: rect,
                             tex_coords: [Vector2::default(); 4],
+                            atlas_page_index: 0,
                         });
                         cursor.x += rect.w();
                     }
@@ -508,7 +501,7 @@ impl FormattedTextBuilder {
             shadow_brush: Brush::Solid(Color::BLACK),
             shadow_dilation: 1.0,
             shadow_offset: Vector2::new(1.0, 1.0),
-            height: 16.0,
+            height: 14.0,
         }
     }
 

--- a/fyrox-ui/src/formatted_text.rs
+++ b/fyrox-ui/src/formatted_text.rs
@@ -2,7 +2,7 @@ use crate::{
     brush::Brush,
     core::{algebra::Vector2, color::Color, math::Rect},
     ttf::SharedFont,
-    Font, HorizontalAlignment, VerticalAlignment,
+    HorizontalAlignment, VerticalAlignment,
 };
 use std::ops::Range;
 
@@ -73,32 +73,10 @@ pub enum WrapMode {
     Word,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct Character {
-    pub char_code: u32,
-    pub glyph_index: u32,
-}
-
-impl Character {
-    pub fn from_char_with_font(char_code: u32, font: &Font) -> Self {
-        Self {
-            char_code,
-            glyph_index: font.glyph_index(char_code).unwrap_or_default() as u32,
-        }
-    }
-
-    #[inline]
-    pub fn is_whitespace(&self) -> bool {
-        char::from_u32(self.char_code)
-            .unwrap_or_default()
-            .is_whitespace()
-    }
-}
-
 #[derive(Default, Clone, Debug)]
 pub struct FormattedText {
     font: SharedFont,
-    text: Vec<Character>,
+    text: Vec<char>,
     // Temporary buffer used to split text on lines. We need it to reduce memory allocations
     // when we changing text too frequently, here we sacrifice some memory in order to get
     // more performance.
@@ -110,7 +88,8 @@ pub struct FormattedText {
     brush: Brush,
     constraint: Vector2<f32>,
     wrap: WrapMode,
-    mask_char: Option<Character>,
+    mask_char: Option<char>,
+    height: f32,
     pub shadow: bool,
     pub shadow_brush: Brush,
     pub shadow_dilation: f32,
@@ -134,6 +113,15 @@ impl FormattedText {
 
     pub fn set_font(&mut self, font: SharedFont) -> &mut Self {
         self.font = font;
+        self
+    }
+
+    pub fn height(&self) -> f32 {
+        self.height
+    }
+
+    pub fn set_height(&mut self, height: f32) -> &mut Self {
+        self.height = height;
         self
     }
 
@@ -176,41 +164,28 @@ impl FormattedText {
         self
     }
 
-    pub fn get_raw_text(&self) -> &[Character] {
+    pub fn get_raw_text(&self) -> &[char] {
         &self.text
     }
 
     pub fn text(&self) -> String {
-        self.text
-            .iter()
-            .filter_map(|c| std::char::from_u32(c.char_code))
-            .collect()
+        self.text.iter().collect()
     }
 
     pub fn get_range_width<T: IntoIterator<Item = usize>>(&self, range: T) -> f32 {
         let mut width = 0.0;
-        let font = self.font.0.lock();
+        let mut font = self.font.0.lock();
         for index in range {
             // We can't trust the range values, check to prevent panic.
             if let Some(glyph) = self.text.get(index) {
-                width += font.glyph_advance(glyph.char_code);
+                width += font.glyph_advance(*glyph, self.height);
             }
         }
         width
     }
 
     pub fn set_text<P: AsRef<str>>(&mut self, text: P) -> &mut Self {
-        // Convert text to UTF32.
-        self.text.clear();
-
-        let font = self.font.0.lock();
-
-        for code in text.as_ref().chars().map(|c| c as u32) {
-            self.text.push(Character::from_char_with_font(code, &font));
-        }
-
-        drop(font);
-
+        self.text = text.as_ref().chars().collect();
         self
     }
 
@@ -249,13 +224,7 @@ impl FormattedText {
     }
 
     pub fn insert_char(&mut self, code: char, index: usize) -> &mut Self {
-        let font = self.font.0.lock();
-
-        self.text
-            .insert(index, Character::from_char_with_font(code as u32, &font));
-
-        drop(font);
-
+        self.text.insert(index, code);
         self
     }
 
@@ -263,10 +232,7 @@ impl FormattedText {
         let font = self.font.0.lock();
 
         for (i, code) in str.chars().enumerate() {
-            self.text.insert(
-                position + i,
-                Character::from_char_with_font(code as u32, &font),
-            );
+            self.text.insert(position + i, code);
         }
 
         drop(font);
@@ -285,7 +251,7 @@ impl FormattedText {
     }
 
     pub fn build(&mut self) -> Vector2<f32> {
-        let font = self.font.0.lock();
+        let mut font = self.font.0.lock();
 
         let masked_text;
         let text = if let Some(mask_char) = self.mask_char {
@@ -300,16 +266,14 @@ impl FormattedText {
         let mut current_line = TextLine::new();
         let mut word: Option<Word> = None;
         self.lines.clear();
-        for (i, character) in text.iter().enumerate() {
-            let advance = match font.glyphs().get(character.glyph_index as usize) {
+        for (i, &character) in text.iter().enumerate() {
+            let advance = match font.glyph(character, self.height) {
                 Some(glyph) => glyph.advance,
-                None => font.height(),
+                None => self.height,
             };
-            let is_new_line =
-                character.char_code == u32::from(b'\n') || character.char_code == u32::from(b'\r');
+            let is_new_line = character == '\n' || character == '\r';
             let new_width = current_line.width + advance;
-            let is_white_space =
-                char::from_u32(character.char_code).map_or(false, |c| c.is_whitespace());
+            let is_white_space = character.is_whitespace();
             let word_ended = word.is_some() && is_white_space || i == self.text.len() - 1;
 
             if self.wrap == WrapMode::Word && !is_white_space {
@@ -336,7 +300,7 @@ impl FormattedText {
                 current_line.begin = if is_new_line { i + 1 } else { i };
                 current_line.end = current_line.begin;
                 current_line.width = advance;
-                total_height += font.ascender();
+                total_height += font.ascender(self.height);
             } else {
                 match self.wrap {
                     WrapMode::NoWrap => {
@@ -349,7 +313,7 @@ impl FormattedText {
                             current_line.begin = if is_new_line { i + 1 } else { i };
                             current_line.end = current_line.begin + 1;
                             current_line.width = advance;
-                            total_height += font.ascender();
+                            total_height += font.ascender(self.height);
                         } else {
                             current_line.width = new_width;
                             current_line.end += 1;
@@ -366,7 +330,7 @@ impl FormattedText {
                                     self.lines.push(current_line);
                                     current_line.begin = current_line.end;
                                     current_line.width = 0.0;
-                                    total_height += font.ascender();
+                                    total_height += font.ascender(self.height);
                                 } else if current_line.width + word.width > self.constraint.x {
                                     // The word will exceed horizontal constraint, we have to
                                     // commit current line and move the word in the next line.
@@ -374,7 +338,7 @@ impl FormattedText {
                                     current_line.begin = i - word.length;
                                     current_line.end = i;
                                     current_line.width = word.width;
-                                    total_height += font.ascender();
+                                    total_height += font.ascender(self.height);
                                 } else {
                                     // The word does not exceed horizontal constraint, append it
                                     // to the line.
@@ -395,16 +359,16 @@ impl FormattedText {
         }
         // Commit rest of text.
         if current_line.begin != current_line.end {
-            for character in text.iter().skip(current_line.end) {
-                let advance = match font.glyphs().get(character.glyph_index as usize) {
+            for &character in text.iter().skip(current_line.end) {
+                let advance = match font.glyph(character, self.height) {
                     Some(glyph) => glyph.advance,
-                    None => font.height(),
+                    None => self.height,
                 };
                 current_line.width += advance;
             }
             current_line.end = self.text.len();
             self.lines.push(current_line);
-            total_height += font.ascender();
+            total_height += font.ascender(self.height);
         }
 
         // Align lines according to desired alignment.
@@ -461,13 +425,14 @@ impl FormattedText {
         for line in self.lines.iter_mut() {
             cursor.x = line.x_offset;
 
+            let ascender = font.ascender(self.height);
             for &character in text.iter().take(line.end).skip(line.begin) {
-                match font.glyphs().get(character.glyph_index as usize) {
+                match font.glyph(character, self.height) {
                     Some(glyph) => {
                         // Insert glyph
                         let rect = Rect::new(
                             cursor.x + glyph.left.floor(),
-                            cursor.y + font.ascender().floor()
+                            cursor.y + ascender.floor()
                                 - glyph.top.floor()
                                 - glyph.bitmap_height as f32,
                             glyph.bitmap_width as f32,
@@ -485,9 +450,9 @@ impl FormattedText {
                         // Insert invalid symbol
                         let rect = Rect::new(
                             cursor.x,
-                            cursor.y + font.ascender(),
-                            font.height(),
-                            font.height(),
+                            cursor.y + font.ascender(self.height),
+                            self.height,
+                            self.height,
                         );
                         self.glyphs.push(TextGlyph {
                             bounds: rect,
@@ -497,13 +462,13 @@ impl FormattedText {
                     }
                 }
             }
-            line.height = font.ascender();
+            line.height = font.ascender(self.height);
             line.y_offset = cursor.y;
-            cursor.y += font.ascender();
+            cursor.y += font.ascender(self.height);
         }
 
         // Minus here is because descender has negative value.
-        let mut full_size = Vector2::new(0.0, total_height - font.descender());
+        let mut full_size = Vector2::new(0.0, total_height - font.descender(self.height));
         for line in self.lines.iter() {
             full_size.x = line.width.max(full_size.x);
         }
@@ -524,6 +489,7 @@ pub struct FormattedTextBuilder {
     shadow_brush: Brush,
     shadow_dilation: f32,
     shadow_offset: Vector2<f32>,
+    height: f32,
 }
 
 impl FormattedTextBuilder {
@@ -542,6 +508,7 @@ impl FormattedTextBuilder {
             shadow_brush: Brush::Solid(Color::BLACK),
             shadow_dilation: 1.0,
             shadow_offset: Vector2::new(1.0, 1.0),
+            height: 16.0,
         }
     }
 
@@ -562,6 +529,11 @@ impl FormattedTextBuilder {
 
     pub fn with_text(mut self, text: String) -> Self {
         self.text = text;
+        self
+    }
+
+    pub fn with_height(mut self, height: f32) -> Self {
+        self.height = height;
         self
     }
 
@@ -608,11 +580,7 @@ impl FormattedTextBuilder {
     pub fn build(self) -> FormattedText {
         let font = self.font.0.lock();
         FormattedText {
-            text: self
-                .text
-                .chars()
-                .map(|c| Character::from_char_with_font(c as u32, &font))
-                .collect(),
+            text: self.text.chars().collect(),
             lines: Vec::new(),
             glyphs: Vec::new(),
             vertical_alignment: self.vertical_alignment,
@@ -620,9 +588,8 @@ impl FormattedTextBuilder {
             brush: self.brush,
             constraint: self.constraint,
             wrap: self.wrap,
-            mask_char: self
-                .mask_char
-                .map(|code| Character::from_char_with_font(u32::from(code), &font)),
+            mask_char: self.mask_char,
+            height: self.height,
             shadow: self.shadow,
             shadow_brush: self.shadow_brush,
             font: {

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -252,21 +252,21 @@ use crate::{
         UiMessage,
     },
     popup::{Placement, PopupMessage},
-    ttf::{Font, FontBuilder, SharedFont},
+    ttf::{FontBuilder, SharedFont},
     widget::{Widget, WidgetBuilder, WidgetMessage},
 };
 use copypasta::ClipboardContext;
 use fxhash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
-use std::sync::Arc;
 use std::{
     cell::{Cell, Ref, RefCell, RefMut},
     collections::{btree_set::BTreeSet, hash_map::Entry, VecDeque},
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
+    path::Path,
     rc::Rc,
     sync::mpsc::{self, Receiver, Sender, TryRecvError},
+    sync::Arc,
 };
 
 use crate::constructor::WidgetConstructorContainer;

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -217,15 +217,9 @@ impl TextMessage {
 /// # };
 ///
 /// fn load_font() -> SharedFont {
-///     // Choose desired character set, default is Basic Latin + Latin Supplement.
-///     // Character set is a set of ranges with Unicode code points.
-///     let character_set = Font::default_char_set();
-///
 ///     // Normally `block_on` should be avoided by using async.
 ///     let font = block_on(Font::from_file(
-///         "path/to/your/font.ttf",
-///         24.0,
-///         character_set,
+///         "path/to/your/font.ttf", 512
 ///     ))
 ///     .unwrap();
 ///
@@ -236,6 +230,7 @@ impl TextMessage {
 ///     TextBuilder::new(WidgetBuilder::new())
 ///         .with_font(load_font())
 ///         .with_text(text)
+///         .with_height(20.0)
 ///         .build(&mut ui.build_ctx())
 /// }
 /// ```

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -510,6 +510,7 @@ impl TextBuilder {
         self
     }
 
+    /// Sets the desired height of the text.
     pub fn with_height(mut self, height: f32) -> Self {
         self.height = height;
         self

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -465,6 +465,7 @@ pub struct TextBuilder {
     shadow_brush: Brush,
     shadow_dilation: f32,
     shadow_offset: Vector2<f32>,
+    height: f32,
 }
 
 impl TextBuilder {
@@ -481,6 +482,7 @@ impl TextBuilder {
             shadow_brush: Brush::Solid(Color::BLACK),
             shadow_dilation: 1.0,
             shadow_offset: Vector2::new(1.0, 1.0),
+            height: 14.0,
         }
     }
 
@@ -505,6 +507,11 @@ impl TextBuilder {
     /// Sets the desired vertical alignment of the widget.
     pub fn with_vertical_text_alignment(mut self, valign: VerticalAlignment) -> Self {
         self.vertical_text_alignment = valign;
+        self
+    }
+
+    pub fn with_height(mut self, height: f32) -> Self {
+        self.height = height;
         self
     }
 
@@ -569,6 +576,7 @@ impl TextBuilder {
                     .with_shadow_brush(self.shadow_brush)
                     .with_shadow_dilation(self.shadow_dilation)
                     .with_shadow_offset(self.shadow_offset)
+                    .with_height(self.height)
                     .build(),
             ),
         };

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -1592,6 +1592,7 @@ pub struct TextBoxBuilder {
     shadow_dilation: f32,
     shadow_offset: Vector2<f32>,
     skip_chars: Vec<char>,
+    height: f32,
 }
 
 impl TextBoxBuilder {
@@ -1616,6 +1617,7 @@ impl TextBoxBuilder {
             shadow_dilation: 1.0,
             shadow_offset: Vector2::new(1.0, 1.0),
             skip_chars: Default::default(),
+            height: 14.0,
         }
     }
 
@@ -1682,6 +1684,11 @@ impl TextBoxBuilder {
     /// Enables or disables editing of the text box.
     pub fn with_editable(mut self, editable: bool) -> Self {
         self.editable = editable;
+        self
+    }
+
+    pub fn with_height(mut self, height: f32) -> Self {
+        self.height = height;
         self
     }
 
@@ -1754,6 +1761,7 @@ impl TextBoxBuilder {
                     .with_shadow_brush(self.shadow_brush)
                     .with_shadow_dilation(self.shadow_dilation)
                     .with_shadow_offset(self.shadow_offset)
+                    .with_height(self.height)
                     .build(),
             ),
             selection_range: None,

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -1687,6 +1687,7 @@ impl TextBoxBuilder {
         self
     }
 
+    /// Sets the desired height of the text.
     pub fn with_height(mut self, height: f32) -> Self {
         self.height = height;
         self

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -250,15 +250,9 @@ pub type FilterCallback = dyn FnMut(char) -> bool;
 /// # };
 ///
 /// fn load_font() -> SharedFont {
-///     // Choose desired character set, default is Basic Latin + Latin Supplement.
-///     // Character set is a set of ranges with Unicode code points.
-///     let character_set = Font::default_char_set();
-///
 ///     // Normally `block_on` should be avoided.
 ///     let font = block_on(Font::from_file(
-///         "path/to/your/font.ttf",
-///         24.0,
-///         character_set,
+///         "path/to/your/font.ttf", 512
 ///     ))
 ///     .unwrap();
 ///
@@ -269,6 +263,7 @@ pub type FilterCallback = dyn FnMut(char) -> bool;
 ///     TextBoxBuilder::new(WidgetBuilder::new())
 ///         .with_font(load_font())
 ///         .with_text(text)
+///         .with_height(20.0)
 ///         .build(&mut ui.build_ctx())
 /// }
 /// ```

--- a/fyrox-ui/src/ttf.rs
+++ b/fyrox-ui/src/ttf.rs
@@ -46,6 +46,8 @@ impl Atlas {
         height: FontHeight,
         page_size: usize,
     ) -> Option<&FontGlyph> {
+        let border = 2;
+
         match self.char_map.get(&unicode) {
             Some(glyph_index) => {
                 return self.glyphs.get(*glyph_index);
@@ -66,7 +68,7 @@ impl Atlas {
                             .enumerate()
                             .find_map(|(page_index, page)| {
                                 page.rect_packer
-                                    .find_free(metrics.width, metrics.height)
+                                    .find_free(metrics.width + border, metrics.height + border)
                                     .map(|bounds| (page_index, bounds))
                             });
 
@@ -80,7 +82,10 @@ impl Atlas {
 
                         let page_index = self.pages.len();
 
-                        match page.rect_packer.find_free(metrics.width, metrics.height) {
+                        match page
+                            .rect_packer
+                            .find_free(metrics.width + border, metrics.height + border)
+                        {
                             Some(bounds) => {
                                 placement_info = Some((page_index, bounds));
 
@@ -106,8 +111,6 @@ impl Atlas {
                         bitmap_height: metrics.height,
                         page_index,
                     };
-
-                    let border = 2;
 
                     let k = 1.0 / page_size as f32;
 

--- a/fyrox-ui/src/ttf.rs
+++ b/fyrox-ui/src/ttf.rs
@@ -27,6 +27,7 @@ pub struct Page {
     pub pixels: Vec<u8>,
     pub texture: Option<SharedTexture>,
     pub rect_packer: RectPacker<usize>,
+    pub modified: bool,
 }
 
 /// Atlas is a storage for glyphs of a particular size, each atlas could have any number of pages to
@@ -78,6 +79,7 @@ impl Atlas {
                             pixels: vec![0; page_size * page_size],
                             texture: None,
                             rect_packer: RectPacker::new(page_size, page_size),
+                            modified: true,
                         };
 
                         let page_index = self.pages.len();
@@ -101,6 +103,10 @@ impl Atlas {
                     let (page_index, placement_rect) = placement_info?;
                     let page = &mut self.pages[page_index];
                     let glyph_index = self.glyphs.len();
+
+                    // Raise a flag to notify users that the content of the page has changed, and
+                    // it should be re-uploaded to GPU (if needed).
+                    page.modified = true;
 
                     let mut glyph = FontGlyph {
                         left: metrics.xmin as f32,

--- a/fyrox-ui/src/ttf.rs
+++ b/fyrox-ui/src/ttf.rs
@@ -73,7 +73,7 @@ impl Atlas {
                     // No space for the character in any of the existing pages, create a new page.
                     if placement_info.is_none() {
                         let mut page = Page {
-                            pixels: Default::default(),
+                            pixels: vec![0; page_size * page_size],
                             texture: None,
                             rect_packer: RectPacker::new(page_size, page_size),
                         };
@@ -83,6 +83,8 @@ impl Atlas {
                         match page.rect_packer.find_free(metrics.width, metrics.height) {
                             Some(bounds) => {
                                 placement_info = Some((page_index, bounds));
+
+                                self.pages.push(page);
                             }
                             None => {
                                 // No free space in the given page size (requested glyph is too big).
@@ -109,8 +111,8 @@ impl Atlas {
 
                     let k = 1.0 / page_size as f32;
 
-                    let bw = placement_rect.w() - border;
-                    let bh = placement_rect.h() - border;
+                    let bw = placement_rect.w().saturating_sub(border);
+                    let bh = placement_rect.h().saturating_sub(border);
                     let bx = placement_rect.x() + border / 2;
                     let by = placement_rect.y() + border / 2;
 
@@ -156,7 +158,7 @@ pub struct Font {
     pub page_size: usize,
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Debug)]
 pub struct FontHeight(pub f32);
 
 impl From<f32> for FontHeight {

--- a/fyrox-ui/src/ttf.rs
+++ b/fyrox-ui/src/ttf.rs
@@ -3,11 +3,10 @@ use crate::{
     draw::SharedTexture,
 };
 use fxhash::FxHashMap;
-use fyrox_core::log::Log;
 use std::{
-    borrow::Cow,
     fmt::{Debug, Formatter},
-    ops::{Deref, Range},
+    hash::{Hash, Hasher},
+    ops::Deref,
     path::Path,
     sync::Arc,
 };
@@ -20,19 +19,166 @@ pub struct FontGlyph {
     pub tex_coords: [Vector2<f32>; 4],
     pub bitmap_width: usize,
     pub bitmap_height: usize,
+    pub page_index: usize,
+}
+
+/// Page is a storage for rasterized glyphs.
+pub struct Page {
     pub pixels: Vec<u8>,
+    pub texture: Option<SharedTexture>,
+    pub rect_packer: RectPacker<usize>,
+}
+
+/// Atlas is a storage for glyphs of a particular size, each atlas could have any number of pages to
+/// store the rasterized glyphs.
+#[derive(Default)]
+pub struct Atlas {
+    pub glyphs: Vec<FontGlyph>,
+    pub char_map: FxHashMap<char, usize>,
+    pub pages: Vec<Page>,
+}
+
+impl Atlas {
+    fn glyph(
+        &mut self,
+        font: &fontdue::Font,
+        unicode: char,
+        height: FontHeight,
+        page_size: usize,
+    ) -> Option<&FontGlyph> {
+        match self.char_map.get(&unicode) {
+            Some(glyph_index) => {
+                return self.glyphs.get(*glyph_index);
+            }
+            None => {
+                // Char might be missing, because it wasn't requested earlier. Try to find
+                // it in the inner font and render/pack it.
+
+                if let Some(char_index) = font.chars().get(&unicode) {
+                    let (metrics, glyph_raster) =
+                        font.rasterize_indexed(char_index.get(), height.0);
+
+                    // Find a page, that is capable to fit the new character or create a new
+                    // page and put the character there.
+                    let mut placement_info =
+                        self.pages
+                            .iter_mut()
+                            .enumerate()
+                            .find_map(|(page_index, page)| {
+                                page.rect_packer
+                                    .find_free(metrics.width, metrics.height)
+                                    .map(|bounds| (page_index, bounds))
+                            });
+
+                    // No space for the character in any of the existing pages, create a new page.
+                    if placement_info.is_none() {
+                        let mut page = Page {
+                            pixels: Default::default(),
+                            texture: None,
+                            rect_packer: RectPacker::new(page_size, page_size),
+                        };
+
+                        let page_index = self.pages.len();
+
+                        match page.rect_packer.find_free(metrics.width, metrics.height) {
+                            Some(bounds) => {
+                                placement_info = Some((page_index, bounds));
+                            }
+                            None => {
+                                // No free space in the given page size (requested glyph is too big).
+                                return None;
+                            }
+                        }
+                    }
+
+                    let (page_index, placement_rect) = placement_info?;
+                    let page = &mut self.pages[page_index];
+                    let glyph_index = self.glyphs.len();
+
+                    let mut glyph = FontGlyph {
+                        left: metrics.xmin as f32,
+                        top: metrics.ymin as f32,
+                        advance: metrics.advance_width,
+                        tex_coords: Default::default(),
+                        bitmap_width: metrics.width,
+                        bitmap_height: metrics.height,
+                        page_index,
+                    };
+
+                    let border = 2;
+
+                    let k = 1.0 / page_size as f32;
+
+                    let bw = placement_rect.w() - border;
+                    let bh = placement_rect.h() - border;
+                    let bx = placement_rect.x() + border / 2;
+                    let by = placement_rect.y() + border / 2;
+
+                    let tw = bw as f32 * k;
+                    let th = bh as f32 * k;
+                    let tx = bx as f32 * k;
+                    let ty = by as f32 * k;
+
+                    glyph.tex_coords[0] = Vector2::new(tx, ty);
+                    glyph.tex_coords[1] = Vector2::new(tx + tw, ty);
+                    glyph.tex_coords[2] = Vector2::new(tx + tw, ty + th);
+                    glyph.tex_coords[3] = Vector2::new(tx, ty + th);
+
+                    let row_end = by + bh;
+                    let col_end = bx + bw;
+
+                    // Copy glyph pixels to the atlas pixels
+                    for (src_row, row) in (by..row_end).enumerate() {
+                        for (src_col, col) in (bx..col_end).enumerate() {
+                            page.pixels[row * page_size + col] =
+                                glyph_raster[src_row * bw + src_col];
+                        }
+                    }
+
+                    self.glyphs.push(glyph);
+
+                    // Map the new glyph to its unicode position.
+                    self.char_map.insert(unicode, glyph_index);
+
+                    self.glyphs.get(glyph_index)
+                } else {
+                    None
+                }
+            }
+        }
+    }
 }
 
 #[derive(Default)]
 pub struct Font {
-    pub height: f32,
-    pub glyphs: Vec<FontGlyph>,
-    pub ascender: f32,
-    pub descender: f32,
-    pub char_map: FxHashMap<u32, usize>,
-    pub atlas: Vec<u8>,
-    pub atlas_size: usize,
-    pub texture: Option<SharedTexture>,
+    pub inner: Option<fontdue::Font>,
+    pub atlases: FxHashMap<FontHeight, Atlas>,
+    pub page_size: usize,
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct FontHeight(pub f32);
+
+impl From<f32> for FontHeight {
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+impl PartialEq for FontHeight {
+    fn eq(&self, other: &Self) -> bool {
+        fyrox_core::value_as_u8_slice(&self.0) == fyrox_core::value_as_u8_slice(&other.0)
+    }
+}
+
+impl Eq for FontHeight {}
+
+impl Hash for FontHeight {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Don't care about "genius" Rust decision to make f32 non-hashable. If a user is dumb enough
+        // to put NaN or any other special value as a glyph height, then it is their choice.
+        fyrox_core::hash_as_bytes(&self.0, state)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -73,314 +219,111 @@ impl Debug for Font {
 }
 
 impl Font {
-    #[allow(clippy::single_range_in_vec_init)]
-    pub fn default_char_set() -> &'static [Range<u32>] {
-        &[
-            // Basic Latin + Latin Supplement
-            0x0020..0x00FF,
-        ]
-    }
-
-    pub fn korean_char_set() -> &'static [Range<u32>] {
-        &[
-            // Basic Latin + Latin Supplement
-            0x0020..0x00FF,
-            // Korean alphabets
-            0x3131..0x3163,
-            // Korean characters
-            0xAC00..0xD7A3,
-            // Invalid
-            0xFFFD..0xFFFD,
-        ]
-    }
-
-    pub fn chinese_full_char_set() -> &'static [Range<u32>] {
-        &[
-            // Basic Latin + Latin Supplement
-            0x0020..0x00FF,
-            // General Punctuation
-            0x2000..0x206F,
-            // CJK Symbols and Punctuations, Hiragana, Katakana
-            0x3000..0x30FF,
-            // Katakana Phonetic Extensions
-            0x31F0..0x31FF,
-            // Half-width characters
-            0xFF00..0xFFEF,
-            // Invalid
-            0xFFFD..0xFFFD,
-            // CJK Ideograms
-            0x4e00..0x9FAF,
-        ]
-    }
-
-    pub fn cyrillic_char_set() -> &'static [Range<u32>] {
-        &[
-            // Basic Latin + Latin Supplement
-            0x0020..0x00FF,
-            // Cyrillic + Cyrillic Supplement
-            0x0400..0x052F,
-            // Cyrillic Extended-A
-            0x2DE0..0x2DFF,
-            // Cyrillic Extended-B
-            0xA640..0xA69F,
-        ]
-    }
-
-    pub fn thai_char_set() -> &'static [Range<u32>] {
-        &[
-            // Basic Latin + Latin Supplement
-            0x0020..0x00FF,
-            // Punctuations
-            0x2010..0x205E,
-            // Thai
-            0x0E00..0x0E7F,
-        ]
-    }
-
-    pub fn vietnamese_char_set() -> &'static [Range<u32>] {
-        &[
-            // Basic Latin + Latin Supplement
-            0x0020..0x00FF,
-            // Vietnamese
-            0x0102..0x0103,
-            0x0110..0x0111,
-            0x0128..0x0129,
-            0x0168..0x0169,
-            0x01A0..0x01A1,
-            0x01AF..0x01B0,
-            0x1EA0..0x1EF9,
-        ]
-    }
-
     pub fn from_memory(
         data: impl Deref<Target = [u8]>,
-        height: f32,
-        char_set: &[Range<u32>],
+        page_size: usize,
     ) -> Result<Self, &'static str> {
         let fontdue_font = fontdue::Font::from_bytes(data, fontdue::FontSettings::default())?;
-        let font_metrics = fontdue_font.horizontal_line_metrics(height).unwrap();
-
-        let mut font = Font {
-            height,
-            glyphs: Vec::new(),
-            ascender: font_metrics.ascent,
-            descender: font_metrics.descent,
-            char_map: FxHashMap::default(),
-            atlas: Vec::new(),
-            atlas_size: 0,
-            texture: None,
-        };
-
-        let mut index = 0;
-        for range in char_set {
-            for unicode in range.start..range.end {
-                if let Some(character) = std::char::from_u32(unicode) {
-                    let (metrics, bitmap) = fontdue_font.rasterize(character, height);
-
-                    font.glyphs.push(FontGlyph {
-                        left: metrics.xmin as f32,
-                        top: metrics.ymin as f32,
-                        pixels: bitmap,
-                        advance: metrics.advance_width,
-                        tex_coords: Default::default(),
-                        bitmap_width: metrics.width,
-                        bitmap_height: metrics.height,
-                    });
-
-                    font.char_map.insert(unicode, index);
-                    index += 1;
-                }
-            }
-        }
-
-        font.pack();
-
-        Ok(font)
+        Ok(Font {
+            inner: Some(fontdue_font),
+            atlases: Default::default(),
+            page_size,
+        })
     }
 
     pub async fn from_file<P: AsRef<Path>>(
         path: P,
-        height: f32,
-        char_set: &[Range<u32>],
+        page_size: usize,
     ) -> Result<Self, &'static str> {
         if let Ok(file_content) = io::load_file(path).await {
-            Self::from_memory(file_content, height, char_set)
+            Self::from_memory(file_content, page_size)
         } else {
             Err("Unable to read file")
         }
     }
 
+    /// Tries to get a glyph at the given unicode position of the given height. If there's no rendered
+    /// glyph, this method tries to render the glyph and put into a suitable atlas (see [`Atlas`] docs
+    /// for more info). If the given unicode position has no representation in the font, [`None`] will
+    /// be returned. If the requested size of the glyph is too big to fit into the page size of the
+    /// font, [`None`] will be returned. Keep in mind, that this method is free to create as many atlases
+    /// with any number of pages in them. Each atlas corresponds to a particular glyph size, each glyph
+    /// in the atlas could be rendered at any page in the atlas.
     #[inline]
-    pub fn glyph(&self, unicode: u32) -> Option<&FontGlyph> {
-        match self.char_map.get(&unicode) {
-            Some(glyph_index) => self.glyphs.get(*glyph_index),
-            None => None,
-        }
+    pub fn glyph(&mut self, unicode: char, height: f32) -> Option<&FontGlyph> {
+        self.atlases
+            .entry(FontHeight(height))
+            .or_insert_with(|| Atlas {
+                glyphs: Default::default(),
+                char_map: Default::default(),
+                pages: Default::default(),
+            })
+            .glyph(
+                self.inner
+                    .as_ref()
+                    .expect("Font reader must be initialized!"),
+                unicode,
+                FontHeight(height),
+                self.page_size,
+            )
     }
 
     #[inline]
-    pub fn glyph_index(&self, unicode: u32) -> Option<usize> {
-        self.char_map.get(&unicode).cloned()
+    pub fn ascender(&self, height: f32) -> f32 {
+        self.inner
+            .as_ref()
+            .unwrap()
+            .horizontal_line_metrics(height)
+            .map(|m| m.ascent)
+            .unwrap_or_default()
     }
 
     #[inline]
-    pub fn glyphs(&self) -> &[FontGlyph] {
-        &self.glyphs
+    pub fn descender(&self, height: f32) -> f32 {
+        self.inner
+            .as_ref()
+            .unwrap()
+            .horizontal_line_metrics(height)
+            .map(|m| m.descent)
+            .unwrap_or_default()
     }
 
     #[inline]
-    pub fn height(&self) -> f32 {
-        self.height
+    pub fn page_size(&self) -> usize {
+        self.page_size
     }
 
     #[inline]
-    pub fn ascender(&self) -> f32 {
-        self.ascender
-    }
-
-    #[inline]
-    pub fn descender(&self) -> f32 {
-        self.descender
-    }
-
-    #[inline]
-    pub fn atlas_pixels(&self) -> &[u8] {
-        self.atlas.as_slice()
-    }
-
-    #[inline]
-    pub fn atlas_size(&self) -> usize {
-        self.atlas_size
-    }
-
-    #[inline]
-    pub fn glyph_advance(&self, c: u32) -> f32 {
-        self.glyph(c).map_or(self.height(), |glyph| glyph.advance)
-    }
-
-    #[inline]
-    fn compute_atlas_size(&self, border: usize, size_factor: f32) -> usize {
-        let mut area = 0.0;
-        for glyph in self.glyphs.iter() {
-            area += (glyph.bitmap_width + border) as f32 * (glyph.bitmap_height + border) as f32;
-        }
-        (size_factor * area.sqrt()) as usize
-    }
-
-    fn pack(&mut self) {
-        let border = 2;
-        let mut atlas_size_factor = 1.3;
-        self.atlas_size = self.compute_atlas_size(border, atlas_size_factor);
-        'outer: loop {
-            self.atlas = vec![0; self.atlas_size * self.atlas_size];
-            let k = 1.0 / self.atlas_size as f32;
-            let mut rect_packer = RectPacker::new(self.atlas_size, self.atlas_size);
-            for glyph in self.glyphs.iter_mut() {
-                if let Some(bounds) =
-                    rect_packer.find_free(glyph.bitmap_width + border, glyph.bitmap_height + border)
-                {
-                    let bw = bounds.w() - border;
-                    let bh = bounds.h() - border;
-                    let bx = bounds.x() + border / 2;
-                    let by = bounds.y() + border / 2;
-
-                    let tw = bw as f32 * k;
-                    let th = bh as f32 * k;
-                    let tx = bx as f32 * k;
-                    let ty = by as f32 * k;
-
-                    glyph.tex_coords[0] = Vector2::new(tx, ty);
-                    glyph.tex_coords[1] = Vector2::new(tx + tw, ty);
-                    glyph.tex_coords[2] = Vector2::new(tx + tw, ty + th);
-                    glyph.tex_coords[3] = Vector2::new(tx, ty + th);
-
-                    let row_end = by + bh;
-                    let col_end = bx + bw;
-
-                    // Copy glyph pixels to atlas pixels
-                    for (src_row, row) in (by..row_end).enumerate() {
-                        for (src_col, col) in (bx..col_end).enumerate() {
-                            self.atlas[row * self.atlas_size + col] =
-                                glyph.pixels[src_row * bw + src_col];
-                        }
-                    }
-                } else {
-                    atlas_size_factor *= 1.3;
-                    let mut bigger = self.compute_atlas_size(border, atlas_size_factor);
-                    while bigger == self.atlas_size {
-                        atlas_size_factor *= 1.3;
-                        bigger = self.compute_atlas_size(border, atlas_size_factor);
-                    }
-                    Log::info(format!(
-                        "{} was not big enough for font atlas trying again with {bigger}",
-                        self.atlas_size
-                    ));
-                    self.atlas_size = self.compute_atlas_size(border, atlas_size_factor);
-
-                    continue 'outer;
-                }
-            }
-            break 'outer;
-        }
+    pub fn glyph_advance(&mut self, unicode: char, height: f32) -> f32 {
+        self.glyph(unicode, height)
+            .map_or(height, |glyph| glyph.advance)
     }
 }
 
 /// Font builder allows you to load fonts in declarative manner.
-pub struct FontBuilder<'a> {
-    height: Option<f32>,
-    char_set: Option<Cow<'a, [Range<u32>]>>,
+pub struct FontBuilder {
+    page_size: usize,
 }
-impl<'a> FontBuilder<'a> {
-    const DEFAULT_HEIGHT: f32 = 16.0;
 
+impl FontBuilder {
     /// Creates a default FontBuilder.
     pub fn new() -> Self {
-        Self {
-            height: None,
-            char_set: None,
-        }
-    }
-
-    /// Sets the desired font height for the produced font.
-    #[inline]
-    pub fn with_height(mut self, height: f32) -> Self {
-        self.height = Some(height);
-        self
-    }
-
-    /// Sets the desired character set for the produced font.
-    #[inline]
-    pub fn with_char_set(mut self, char_set: impl Into<Cow<'a, [Range<u32>]>>) -> Self {
-        self.char_set = Some(char_set.into());
-        self
+        Self { page_size: 1024 }
     }
 
     /// Creates a new font from the data at the specified path.
     pub async fn build_from_file(self, path: impl AsRef<Path>) -> Result<Font, &'static str> {
-        Font::from_file(path, self.height(), self.char_set()).await
+        Font::from_file(path, self.page_size).await
     }
 
     /// Creates a new font from bytes in memory.
     pub fn build_from_memory(self, data: impl Deref<Target = [u8]>) -> Result<Font, &'static str> {
-        Font::from_memory(data, self.height(), self.char_set())
+        Font::from_memory(data, self.page_size)
     }
 
     /// Creates a new font using the built-in font face.
     pub fn build_builtin(self) -> Result<Font, &'static str> {
-        let font_bytes = std::include_bytes!("./built_in_font.ttf").to_vec();
+        let font_bytes = include_bytes!("./built_in_font.ttf").to_vec();
         self.build_from_memory(font_bytes)
-    }
-
-    #[inline]
-    fn height(&self) -> f32 {
-        self.height.unwrap_or(Self::DEFAULT_HEIGHT)
-    }
-
-    #[inline]
-    #[allow(clippy::redundant_closure)]
-    fn char_set(&self) -> &[Range<u32>] {
-        self.char_set
-            .as_deref()
-            .unwrap_or_else(|| Font::default_char_set())
     }
 }

--- a/src/renderer/ui_renderer.rs
+++ b/src/renderer/ui_renderer.rs
@@ -263,40 +263,50 @@ impl UiRenderer {
             }
 
             match &cmd.texture {
-                CommandTexture::Font(font_arc) => {
+                CommandTexture::Font {
+                    font: font_arc,
+                    page_index,
+                    height,
+                } => {
                     let mut font = font_arc.0.lock();
-                    if font.texture.is_none() {
-                        let size = font.atlas_size() as u32;
-                        if let Some(details) = Texture::from_bytes(
-                            TextureKind::Rectangle {
-                                width: size,
-                                height: size,
-                            },
-                            TexturePixelKind::R8,
-                            font.atlas_pixels().to_vec(),
-                        ) {
-                            font.texture =
-                                Some(SharedTexture(Arc::new(Mutex::new(ResourceHeader {
-                                    kind: Default::default(),
-                                    type_uuid: details.type_uuid(),
-                                    state: ResourceState::new_ok(details),
-                                }))));
-                        }
-                    }
-                    let tex = UntypedResource(
-                        font.texture
-                            .clone()
-                            .unwrap()
-                            .0
-                            .downcast::<Mutex<ResourceHeader>>()
-                            .unwrap(),
-                    );
-                    if let Some(texture) =
-                        texture_cache.get(state, &tex.try_cast::<Texture>().unwrap())
+                    let page_size = font.page_size() as u32;
+                    if let Some(page) = font
+                        .atlases
+                        .get_mut(height)
+                        .and_then(|atlas| atlas.pages.get_mut(*page_index))
                     {
-                        diffuse_texture = texture;
+                        if page.texture.is_none() {
+                            if let Some(details) = Texture::from_bytes(
+                                TextureKind::Rectangle {
+                                    width: page_size,
+                                    height: page_size,
+                                },
+                                TexturePixelKind::R8,
+                                page.pixels.clone(),
+                            ) {
+                                page.texture =
+                                    Some(SharedTexture(Arc::new(Mutex::new(ResourceHeader {
+                                        kind: Default::default(),
+                                        type_uuid: details.type_uuid(),
+                                        state: ResourceState::new_ok(details),
+                                    }))));
+                            }
+                        }
+                        let tex = UntypedResource(
+                            page.texture
+                                .clone()
+                                .unwrap()
+                                .0
+                                .downcast::<Mutex<ResourceHeader>>()
+                                .unwrap(),
+                        );
+                        if let Some(texture) =
+                            texture_cache.get(state, &tex.try_cast::<Texture>().unwrap())
+                        {
+                            diffuse_texture = texture;
+                        }
+                        is_font_texture = true;
                     }
-                    is_font_texture = true;
                 }
                 CommandTexture::Texture(texture) => {
                     if let Ok(texture) = texture.clone().0.downcast::<Mutex<ResourceHeader>>() {

--- a/src/renderer/ui_renderer.rs
+++ b/src/renderer/ui_renderer.rs
@@ -275,7 +275,7 @@ impl UiRenderer {
                         .get_mut(height)
                         .and_then(|atlas| atlas.pages.get_mut(*page_index))
                     {
-                        if page.texture.is_none() {
+                        if page.texture.is_none() || page.modified {
                             if let Some(details) = Texture::from_bytes(
                                 TextureKind::Rectangle {
                                     width: page_size,
@@ -290,6 +290,7 @@ impl UiRenderer {
                                         type_uuid: details.type_uuid(),
                                         state: ResourceState::new_ok(details),
                                     }))));
+                                page.modified = false;
                             }
                         }
                         let tex = UntypedResource(


### PR DESCRIPTION
This PR adds support for dynamic font atlases which removes `height` parameter from fonts and gives access to all glyphs in a font on demand. An atlas (for a particular glyph size) will automatically be updated and a requested glyph will be rendered and packed in the atlas. Each atlas is split into a multiple number of pages to bypass texture size limitation on some GPUs.

This PR also adds an ability to specify text height for both `Text` and `TextBox` widgets, allowing you to use a single font for any character size.