### PR TITLE
Use layout instead of the deprecated gl_FragColor

### DIFF
--- a/editor/src/highlight.rs
+++ b/editor/src/highlight.rs
@@ -39,6 +39,8 @@ struct EdgeDetectShader {
 impl EdgeDetectShader {
     pub fn new(state: &PipelineState) -> Result<Self, FrameworkError> {
         let fragment_source = r#"
+layout (location = 0) out vec4 outColor;
+
 uniform sampler2D frameTexture;
 uniform vec4 color;
 
@@ -65,7 +67,7 @@ void main() {
   	float sobel_edge_v = n[0] + (2.0 * n[1]) + n[2] - (n[6] + (2.0 * n[7]) + n[8]);
 	float sobel = sqrt((sobel_edge_h * sobel_edge_h) + (sobel_edge_v * sobel_edge_v));
 
-	gl_FragColor = vec4(color.rgb, color.a * sobel);
+	outColor = vec4(color.rgb, color.a * sobel);
 }"#;
 
         let vertex_source = r#"


### PR DESCRIPTION
Fixes this error on macos
```sh
[ERROR]: Failed to compile EdgeDetectShader_FragmentShader shader: ERROR: 0:398: Use of undeclared identifier 'gl_FragColor'

thread 'main' panicked at editor/src/highlight.rs:163:62:
called `Result::unwrap()` on an `Err` value: ShaderCompilationFailed { shader_name: "EdgeDetectShader_FragmentShader", error_message: "ERROR: 0:398: Use of undeclared identifier 'gl_FragColor'\n" }
```
I couldn't even run the editor on macos with it using `gl_FragColor`.  This patch lets it run just fine.  AFAIK `gl_FragColor` was deprecated in OpenGL 3.0.  Layout defined at the top of the shader same as the vertex shader below it.

I would assume that windows/linux compiled but threw a deprecation warning before, but I don't have a machine to test that atm.  If so, this would fix that, too.