### PR TITLE
Common graph

### DIFF
--- a/.idea/rg3d-core.iml
+++ b/.idea/rg3d-core.iml
@@ -32,6 +32,7 @@
       <sourceFolder url="file://$MODULE_DIR$/template/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/fyrox-scripts/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/fyrox-animation/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/fyrox-graph/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/examples/wasm/target" />
     </content>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 	"editor",
     "editor-standalone",
 	"template"
-]
+, "fyrox-graph"]
 
 [profile.dev]
 opt-level = 0
@@ -43,6 +43,7 @@ fyrox-sound = { path = "fyrox-sound", version = "0.34.0" }
 fyrox-ui = { path = "fyrox-ui", version = "0.24.0" }
 fyrox-resource = { path = "fyrox-resource", version = "0.11.0" }
 fyrox-animation = { path = "fyrox-animation", version = "0.1.0" }
+fyrox-graph = { path = "fyrox-graph", version = "0.1.0" }
 rapier2d = { version = "0.18", features = ["debug-render"] }
 rapier3d = { version = "0.18", features = ["debug-render"] }
 image = { version = "0.24.3", default-features = false, features = ["gif", "jpeg", "png", "tga", "tiff", "bmp"] }

--- a/editor/src/inspector/editors/mod.rs
+++ b/editor/src/inspector/editors/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     message::MessageSender,
 };
+use fyrox::scene::base::BaseNode;
 use fyrox::{
     asset::{manager::ResourceManager, Resource},
     core::{
@@ -123,6 +124,7 @@ pub fn make_status_enum_editor_definition() -> EnumPropertyEditorDefinition<Stat
 pub fn make_property_editors_container(sender: MessageSender) -> PropertyEditorDefinitionContainer {
     let container = PropertyEditorDefinitionContainer::new();
 
+    container.insert(InspectablePropertyEditorDefinition::<BaseNode>::new());
     container.insert(TexturePropertyEditorDefinition { untyped: false });
     container.insert(TexturePropertyEditorDefinition { untyped: true });
     container.insert(FontPropertyEditorDefinition);

--- a/editor/src/scene/settings/mod.rs
+++ b/editor/src/scene/settings/mod.rs
@@ -24,7 +24,7 @@ use fyrox::{
         dim2,
         graph::{
             physics::{IntegrationParameters, PhysicsWorld},
-            Graph, NodePool,
+            Graph, LowLevelGraph,
         },
         SceneRenderingOptions,
     },
@@ -97,7 +97,7 @@ impl SceneSettingsWindow {
             PropertyFilter::new(|property| {
                 let mut pass = true;
 
-                property.downcast_ref::<NodePool>(&mut |v| {
+                property.downcast_ref::<LowLevelGraph>(&mut |v| {
                     if v.is_some() {
                         pass = false;
                     }

--- a/editor/src/ui_scene/interaction/move_mode.rs
+++ b/editor/src/ui_scene/interaction/move_mode.rs
@@ -162,7 +162,7 @@ impl InteractionMode for MoveWidgetsInteractionMode {
                 let new_screen_space_position = mouse_position - entry.delta;
                 let parent_inv_transform = ui_scene
                     .ui
-                    .try_get_node(ui_scene.ui.node(entry.widget).parent)
+                    .try_get_node(ui_scene.ui.node(entry.widget).parent())
                     .and_then(|w| w.visual_transform().try_inverse())
                     .unwrap_or_default();
                 let new_local_position = parent_inv_transform.transform_point(&Point2::new(

--- a/editor/src/ui_scene/utils.rs
+++ b/editor/src/ui_scene/utils.rs
@@ -35,14 +35,14 @@ impl<'a> WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'a> {
     fn children_of(&self, node: ErasedHandle) -> Vec<ErasedHandle> {
         self.ui
             .try_get_node(node.into())
-            .map(|n| n.children.iter().map(|c| (*c).into()).collect::<Vec<_>>())
+            .map(|n| n.children().iter().map(|c| (*c).into()).collect::<Vec<_>>())
             .unwrap_or_default()
     }
 
     fn child_count_of(&self, node: ErasedHandle) -> usize {
         self.ui
             .try_get_node(node.into())
-            .map(|n| n.children.len())
+            .map(|n| n.children().len())
             .unwrap_or_default()
     }
 

--- a/editor/src/utils/path_fixer.rs
+++ b/editor/src/utils/path_fixer.rs
@@ -228,7 +228,7 @@ impl PathFixer {
             .cast::<ListView>()
             .unwrap()
             .items()[index];
-        let item_text = ui.find_by_criteria_down(item, &|n| n.cast::<Text>().is_some());
+        let item_text = ui.find_by_criteria_down(item, |n| n.cast::<Text>().is_some());
 
         assert!(item_text.is_some());
 

--- a/editor/src/utils/ragdoll.rs
+++ b/editor/src/utils/ragdoll.rs
@@ -1149,7 +1149,7 @@ impl RagdollWizard {
             } else if message.destination() == self.autofill {
                 fn find_by_pattern(graph: &Graph, pattern: &str) -> Handle<Node> {
                     graph
-                        .find(graph.get_root(), &mut |n| n.name().contains(pattern))
+                        .find(graph.get_root(), |n| n.name().contains(pattern))
                         .map(|(h, _)| h)
                         .unwrap_or_default()
                 }

--- a/editor/src/world/mod.rs
+++ b/editor/src/world/mod.rs
@@ -385,7 +385,7 @@ impl WorldViewer {
         if let Some(&first_selected) = data_provider.selection().first() {
             let mut node_handle = first_selected;
             while node_handle.is_some() && node_handle != data_provider.root_node() {
-                let view = ui.find_by_criteria_down(self.tree_root, &|n| {
+                let view = ui.find_by_criteria_down(self.tree_root, |n| {
                     n.cast::<SceneItem>()
                         .map(|i| i.entity_handle == node_handle)
                         .unwrap_or_default()
@@ -837,7 +837,7 @@ fn map_selection(
     selection
         .iter()
         .filter_map(|&handle| {
-            let item = ui.find_by_criteria_down(root_node, &|n| {
+            let item = ui.find_by_criteria_down(root_node, |n| {
                 n.cast::<SceneItem>()
                     .map(|n| n.entity_handle == handle)
                     .unwrap_or_default()

--- a/fyrox-graph/Cargo.toml
+++ b/fyrox-graph/Cargo.toml
@@ -15,6 +15,6 @@ resolver = "2"
 rust-version = "1.72"
 
 [dependencies]
-fyrox-core = { path = "../fyrox-core", version = "0.27.0" }
+fyrox-core = { path = "../fyrox-core", version = "0.27.0", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 fxhash = "0.2.1"

--- a/fyrox-graph/Cargo.toml
+++ b/fyrox-graph/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fyrox-graph"
+version = "0.1.0"
+authors = ["Dmitry Stepanov <d1maxa@yandex.ru>"]
+edition = "2021"
+license = "MIT"
+description = "Graph utilities for Fyrox Game Engine"
+keywords = ["asset", "resource"]
+categories = ["game-development"]
+include = ["/src/**/*", "/Cargo.toml", "/LICENSE"]
+homepage = "https://fyrox.rs"
+documentation = "https://docs.rs/fyrox-graph"
+repository = "https://github.com/FyroxEngine/Fyrox"
+resolver = "2"
+rust-version = "1.72"
+
+[dependencies]
+fyrox-core = { path = "../fyrox-core", version = "0.27.0" }

--- a/fyrox-graph/Cargo.toml
+++ b/fyrox-graph/Cargo.toml
@@ -17,3 +17,4 @@ rust-version = "1.72"
 [dependencies]
 fyrox-core = { path = "../fyrox-core", version = "0.27.0" }
 serde = { version = "1", features = ["derive"] }
+fxhash = "0.2.1"

--- a/fyrox-graph/Cargo.toml
+++ b/fyrox-graph/Cargo.toml
@@ -16,3 +16,4 @@ rust-version = "1.72"
 
 [dependencies]
 fyrox-core = { path = "../fyrox-core", version = "0.27.0" }
+serde = { version = "1", features = ["derive"] }

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -1,0 +1,157 @@
+use fyrox_core::pool::{Handle, MultiBorrowContext, PayloadContainer, Pool};
+use fyrox_core::{reflect::prelude::*, visitor::prelude::*};
+use std::fmt::Debug;
+use std::ops::{Deref, DerefMut};
+
+#[derive(Reflect, Debug)]
+pub struct HierarchicalData<N>
+where
+    N: Debug,
+{
+    pub parent: Handle<N>,
+    pub children: Vec<Handle<N>>,
+}
+
+impl<N: Debug> Default for HierarchicalData<N> {
+    fn default() -> Self {
+        Self {
+            parent: Default::default(),
+            children: Default::default(),
+        }
+    }
+}
+
+impl<N: Debug> Clone for HierarchicalData<N> {
+    fn clone(&self) -> Self {
+        Self {
+            parent: self.parent,
+            children: self.children.clone(),
+        }
+    }
+}
+
+impl<N> Visit for HierarchicalData<N>
+where
+    N: Debug + 'static,
+{
+    fn visit(&mut self, _name: &str, visitor: &mut Visitor) -> VisitResult {
+        self.parent.visit("Parent", visitor)?;
+        self.children.visit("Children", visitor)?;
+        Ok(())
+    }
+}
+
+pub trait GraphNode<N>: Sized + Reflect + Visit + Debug
+where
+    N: Debug,
+{
+    fn children(&self) -> &[Handle<N>];
+    fn parent(&self) -> Handle<N>;
+    fn hierarchical_data_mut(&mut self) -> &mut HierarchicalData<N>;
+}
+
+#[derive(Reflect, Debug)]
+pub struct Graph<N, P = Option<N>>
+where
+    N: GraphNode<N>,
+    P: PayloadContainer<Element = N> + Debug + 'static,
+{
+    pub pool: Pool<N, P>,
+    pub stack: Vec<Handle<N>>,
+}
+
+impl<N, P> Visit for Graph<N, P>
+where
+    N: GraphNode<N>,
+    P: PayloadContainer<Element = N> + Debug + Visit + Default + 'static,
+{
+    fn visit(&mut self, _name: &str, visitor: &mut Visitor) -> VisitResult {
+        self.pool.visit("Pool", visitor)?;
+        Ok(())
+    }
+}
+
+impl<N, P> Deref for Graph<N, P>
+where
+    N: GraphNode<N>,
+    P: PayloadContainer<Element = N> + Debug + 'static,
+{
+    type Target = Pool<N, P>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pool
+    }
+}
+
+impl<N, P> DerefMut for Graph<N, P>
+where
+    N: GraphNode<N>,
+    P: PayloadContainer<Element = N> + Debug + 'static,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.pool
+    }
+}
+
+impl<N, P> Graph<N, P>
+where
+    N: GraphNode<N>,
+    P: PayloadContainer<Element = N> + Debug + 'static,
+{
+    pub fn new() -> Self {
+        Self {
+            pool: Pool::new(),
+            stack: Default::default(),
+        }
+    }
+
+    #[inline]
+    pub fn remove_node<'a, F>(&'a mut self, node_handle: Handle<N>, mut on_removed: F)
+    where
+        F: FnMut(Handle<N>, N, &MultiBorrowContext<'a, N, P>),
+    {
+        self.unlink(node_handle);
+
+        let mbc = self.pool.begin_multi_borrow();
+        self.stack.clear();
+        self.stack.push(node_handle);
+        while let Some(handle) = self.stack.pop() {
+            if let Ok(node) = mbc.free(handle) {
+                self.stack.extend_from_slice(node.children());
+                on_removed(handle, node, &mbc);
+            }
+        }
+    }
+
+    #[inline]
+    pub fn unlink(&mut self, node_handle: Handle<N>) {
+        // Replace parent handle of a child.
+        let parent_handle = std::mem::replace(
+            &mut self.pool[node_handle].hierarchical_data_mut().parent,
+            Handle::NONE,
+        );
+
+        // Remove the child from the parent's children list
+        if let Some(parent) = self.pool.try_borrow_mut(parent_handle) {
+            let hierarchical_data = parent.hierarchical_data_mut();
+            if let Some(i) = hierarchical_data
+                .children
+                .iter()
+                .position(|h| *h == node_handle)
+            {
+                hierarchical_data.children.remove(i);
+            }
+        }
+    }
+
+    /// Links specified child with specified parent.
+    #[inline]
+    pub fn link_nodes(&mut self, child: Handle<N>, parent: Handle<N>) {
+        self.unlink(child);
+        self.pool[child].hierarchical_data_mut().parent = parent;
+        self.pool[parent]
+            .hierarchical_data_mut()
+            .children
+            .push(child);
+    }
+}

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -73,6 +73,12 @@ where
     children: Vec<Handle<N>>,
 }
 
+impl<N: Debug + 'static> Default for BaseNodeBuilder<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<N: Debug + 'static> BaseNodeBuilder<N> {
     pub fn new() -> Self {
         Self {

--- a/fyrox-ui/Cargo.toml
+++ b/fyrox-ui/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.72"
 [dependencies]
 fyrox-core = { path = "../fyrox-core", version = "0.27.0", features = ["serde"] }
 fyrox-resource = { path = "../fyrox-resource", version = "0.11.0" }
+fyrox-graph = { path = "../fyrox-graph", version = "0.1.0" }
 lazy_static = "1.4.0"
 copypasta = "0.8.1"
 fontdue = "0.7.2"

--- a/fyrox-ui/src/border.rs
+++ b/fyrox-ui/src/border.rs
@@ -115,7 +115,7 @@ impl Control for Border {
 
         for child_handle in self.widget.children() {
             ui.measure_node(*child_handle, size_for_child);
-            let child = ui.nodes.borrow(*child_handle);
+            let child = ui.inner.borrow(*child_handle);
             let child_desired_size = child.desired_size();
             if child_desired_size.x > desired_size.x {
                 desired_size.x = child_desired_size.x;

--- a/fyrox-ui/src/build.rs
+++ b/fyrox-ui/src/build.rs
@@ -72,13 +72,13 @@ impl<'a> Index<Handle<UiNode>> for BuildContext<'a> {
     type Output = UiNode;
 
     fn index(&self, index: Handle<UiNode>) -> &Self::Output {
-        &self.ui.nodes[index]
+        &self.ui.inner[index]
     }
 }
 
 impl<'a> IndexMut<Handle<UiNode>> for BuildContext<'a> {
     fn index_mut(&mut self, index: Handle<UiNode>) -> &mut Self::Output {
-        &mut self.ui.nodes[index]
+        &mut self.ui.inner[index]
     }
 }
 
@@ -124,7 +124,7 @@ impl<'a> BuildContext<'a> {
 
     /// Tries to fetch the node by its handle. Returns `None` if the handle is invalid.
     pub fn try_get_node_mut(&mut self, node: Handle<UiNode>) -> Option<&mut UiNode> {
-        self.ui.nodes.try_borrow_mut(node)
+        self.ui.inner.try_borrow_mut(node)
     }
 
     /// Pushes a new picking restriction to the picking-restriction stack. See [`UserInterface::push_picking_restriction`]

--- a/fyrox-ui/src/canvas.rs
+++ b/fyrox-ui/src/canvas.rs
@@ -74,7 +74,7 @@ impl Control for Canvas {
         scope_profile!();
 
         for &child_handle in self.widget.children() {
-            let child = ui.nodes.borrow(child_handle);
+            let child = ui.inner.borrow(child_handle);
             ui.arrange_node(
                 child_handle,
                 &Rect::new(

--- a/fyrox-ui/src/color/gradient.rs
+++ b/fyrox-ui/src/color/gradient.rs
@@ -526,7 +526,7 @@ impl Control for ColorPoint {
                         }
                         WidgetMessage::MouseMove { pos, .. } => {
                             if self.dragging {
-                                let parent_canvas = ui.node(self.parent);
+                                let parent_canvas = ui.node(self.base_node.parent());
 
                                 let cursor_x_local_to_parent =
                                     parent_canvas.screen_to_local(*pos).x;

--- a/fyrox-ui/src/control.rs
+++ b/fyrox-ui/src/control.rs
@@ -104,7 +104,7 @@ pub trait Control:
     ///         let mut size: Vector2<f32> = Vector2::default();
     ///
     ///         // Measure children nodes and find the largest size of them.
-    ///         for &child in self.children.iter() {
+    ///         for &child in self.children().iter() {
     ///             // Recursively measure children nodes. Measured size will be put in `desired_size`
     ///             // of the widget.
     ///             ui.measure_node(child, available_size);
@@ -172,7 +172,7 @@ pub trait Control:
     ///         let final_rect = Rect::new(0.0, 0.0, final_size.x, final_size.y);
     ///
     ///         // Commit final locations and size for each child node.
-    ///         for &child in self.children.iter() {
+    ///         for &child in self.children().iter() {
     ///             ui.arrange_node(child, &final_rect);
     ///         }
     ///

--- a/fyrox-ui/src/dock/config.rs
+++ b/fyrox-ui/src/dock/config.rs
@@ -101,7 +101,7 @@ impl TileDescriptor {
                     if window_handle.is_none() {
                         for other_window_handle in windows.iter().cloned() {
                             if let Some(window_node) = ui.try_get_node(other_window_handle) {
-                                if &window_node.name() == window_name {
+                                if window_node.name() == window_name {
                                     window_handle = other_window_handle;
                                 }
                             }

--- a/fyrox-ui/src/dock/config.rs
+++ b/fyrox-ui/src/dock/config.rs
@@ -43,7 +43,7 @@ impl TileContentDescriptor {
             TileContent::Empty => Self::Empty,
             TileContent::Window(window) => Self::Window(
                 ui.try_get_node(*window)
-                    .map(|w| w.name.clone())
+                    .map(|w| w.name().to_string())
                     .unwrap_or_default(),
             ),
             TileContent::VerticalTiles { splitter, tiles } => {
@@ -96,12 +96,12 @@ impl TileDescriptor {
                 TileContentDescriptor::Empty => TileContent::Empty,
                 TileContentDescriptor::Window(window_name) => {
                     let mut window_handle =
-                        ui.find_by_criteria_down(ui.root(), &|n| n.name() == window_name);
+                        ui.find_by_criteria_down(ui.root(), |n| n.name() == window_name);
 
                     if window_handle.is_none() {
                         for other_window_handle in windows.iter().cloned() {
                             if let Some(window_node) = ui.try_get_node(other_window_handle) {
-                                if &window_node.name == window_name {
+                                if &window_node.name() == window_name {
                                     window_handle = other_window_handle;
                                 }
                             }

--- a/fyrox-ui/src/dock/mod.rs
+++ b/fyrox-ui/src/dock/mod.rs
@@ -60,7 +60,7 @@ impl Control for DockingManager {
         if message.destination() == self.handle && message.direction() == MessageDirection::ToWidget
         {
             if let Some(DockingManagerMessage::Layout(layout_descriptor)) = message.data() {
-                if let Some(root_tile_handle) = self.children.first().cloned() {
+                if let Some(root_tile_handle) = self.base_node.children().first().cloned() {
                     let mut windows = Vec::new();
                     let mut stack = vec![root_tile_handle];
                     while let Some(tile_handle) = stack.pop() {

--- a/fyrox-ui/src/dock/mod.rs
+++ b/fyrox-ui/src/dock/mod.rs
@@ -104,8 +104,8 @@ impl Control for DockingManager {
                     // Restore floating windows.
                     self.floating_windows.borrow_mut().clear();
                     for floating_window_desc in layout_descriptor.floating_windows.iter() {
-                        let floating_window = ui.find_by_criteria_down(ui.root(), &|n| {
-                            n.name == floating_window_desc.name
+                        let floating_window = ui.find_by_criteria_down(ui.root(), |n| {
+                            n.name() == floating_window_desc.name
                         });
                         if floating_window.is_some() {
                             self.floating_windows.borrow_mut().push(floating_window);
@@ -161,7 +161,7 @@ impl DockingManager {
                 .iter()
                 .filter_map(|h| {
                     ui.try_get_node(*h).map(|w| FloatingWindowDescriptor {
-                        name: w.name.clone(),
+                        name: w.name().to_string(),
                         position: w.actual_local_position(),
                         size: w.actual_local_size(),
                     })

--- a/fyrox-ui/src/grid.rs
+++ b/fyrox-ui/src/grid.rs
@@ -251,7 +251,7 @@ fn calc_total_size_of_non_stretch_dims(
         } else if dim.size_mode == SizeMode::Auto {
             let mut dim_size = 0.0f32;
             for child_handle in children {
-                let child = ui.nodes.borrow(*child_handle);
+                let child = ui.inner.borrow(*child_handle);
                 if let Some(desired_size) = (desired_size_fetcher)(child, i) {
                     dim_size = dim_size.max(desired_size);
                 }
@@ -458,7 +458,7 @@ impl Control for Grid {
         arrange_dims(&mut rows, final_size.y);
 
         for child_handle in self.widget.children() {
-            let child = ui.nodes.borrow(*child_handle);
+            let child = ui.inner.borrow(*child_handle);
             if let Some(column) = columns.get(child.column()) {
                 if let Some(row) = rows.get(child.row()) {
                     ui.arrange_node(

--- a/fyrox-ui/src/inspector/editors/mod.rs
+++ b/fyrox-ui/src/inspector/editors/mod.rs
@@ -1,4 +1,5 @@
 use crate::vector_image::Primitive;
+use crate::widget::BaseNode;
 use crate::{
     bit::BitField,
     border::Border,
@@ -325,6 +326,7 @@ impl PropertyEditorDefinitionContainer {
         container.insert(InheritablePropertyEditorDefinition::<Curve>::new());
 
         // UI
+        container.insert(InspectablePropertyEditorDefinition::<BaseNode>::new());
         container.insert(EnumPropertyEditorDefinition::<Brush>::new());
         container.insert(EnumPropertyEditorDefinition::<Orientation>::new());
         container.insert(EnumPropertyEditorDefinition::<VerticalAlignment>::new());

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -948,7 +948,7 @@ impl Control for Inspector {
                             }
                         }
 
-                        parent_handle = parent.parent;
+                        parent_handle = parent.base_node.parent();
                     }
                 }
             }

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -697,7 +697,7 @@ impl Clone for UserInterface {
     fn clone(&self) -> Self {
         let (sender, receiver) = mpsc::channel();
         let (layout_events_sender, layout_events_receiver) = mpsc::channel();
-        let mut inner = fyrox_graph::Graph::new();
+        let mut inner = fyrox_graph::Graph::new_empty();
         for (handle, node) in self.inner.pair_iter() {
             let mut clone = node.clone_boxed();
             clone.layout_events_sender = Some(layout_events_sender.clone());
@@ -847,7 +847,7 @@ impl UserInterface {
             receiver,
             visual_debug: false,
             captured_node: Handle::NONE,
-            inner: fyrox_graph::Graph::new(),
+            inner: fyrox_graph::Graph::new_empty(),
             cursor_position: Vector2::new(0.0, 0.0),
             drawing_context: DrawingContext::new(),
             picked_node: Handle::NONE,

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -2688,7 +2688,7 @@ impl UserInterface {
     ) -> Handle<UiNode> {
         let node = self.inner.borrow(node_handle);
         let mut cloned = UiNode(node.clone_boxed());
-        cloned.id = Uuid::new_v4();
+        cloned.base_node.instance_id = Default::default();
 
         let mut cloned_children = Vec::new();
         for child in node.children().to_vec() {
@@ -2729,7 +2729,7 @@ impl UserInterface {
         let mut cloned = UiNode(node.clone_boxed());
         cloned.base_node.children.clear();
         cloned.base_node.parent = Handle::NONE;
-        cloned.id = Uuid::new_v4();
+        cloned.base_node.instance_id = Default::default();
         let cloned_node_handle = dest.add_node(cloned);
 
         for child in children {
@@ -2774,7 +2774,7 @@ impl UserInterface {
 
         let node = self.inner.borrow(node_handle);
         let mut cloned = UiNode(node.clone_boxed());
-        cloned.id = Uuid::new_v4();
+        cloned.base_node.instance_id = Default::default();
 
         let mut cloned_children = Vec::new();
         for child in node.children().to_vec() {

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -285,6 +285,7 @@ use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
 pub use alignment::*;
 pub use build::*;
 pub use control::*;
+use fyrox_graph::NodeId;
 use fyrox_resource::io::FsResourceIo;
 pub use node::*;
 pub use thickness::*;
@@ -2835,6 +2836,21 @@ impl UserInterface {
             widget.invalidate_layout();
         }
         Ok(ui)
+    }
+
+    /// Returns a handle of the node that has the given id.
+    pub fn id_to_node_handle(&self, id: NodeId) -> Option<&Handle<UiNode>> {
+        self.inner.id_to_node_handle(id)
+    }
+
+    /// Tries to borrow a node by its id.
+    pub fn node_by_id(&self, id: NodeId) -> Option<(Handle<UiNode>, &UiNode)> {
+        self.inner.node_by_id(id)
+    }
+
+    /// Tries to borrow a node by its id.
+    pub fn node_by_id_mut(&mut self, id: NodeId) -> Option<(Handle<UiNode>, &mut UiNode)> {
+        self.inner.node_by_id_mut(id)
     }
 }
 

--- a/fyrox-ui/src/nine_patch.rs
+++ b/fyrox-ui/src/nine_patch.rs
@@ -51,7 +51,7 @@ impl Control for NinePatch {
         let center_size =
             Vector2::new(available_size.x - x_overflow, available_size.y - y_overflow);
 
-        for &child in self.children.iter() {
+        for &child in self.base_node.children().iter() {
             ui.measure_node(child, center_size);
             let desired_size = ui.node(child).desired_size();
             size.x = size.x.max(desired_size.x.ceil());
@@ -79,7 +79,7 @@ impl Control for NinePatch {
             final_size.y - y_overflow,
         );
 
-        for &child in self.children.iter() {
+        for &child in self.base_node.children().iter() {
             ui.arrange_node(child, &final_rect);
         }
 

--- a/fyrox-ui/src/node/mod.rs
+++ b/fyrox-ui/src/node/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     core::{reflect::prelude::*, visitor::prelude::*},
     BaseControl, Control,
 };
+use fyrox_graph::BaseNode;
 use std::{
     any::{Any, TypeId},
     fmt::{Debug, Formatter},
@@ -19,6 +20,16 @@ pub mod container;
 /// casting, component querying, etc. You could also be interested in [`Control`] docs, since it
 /// contains all the interesting stuff and detailed description for each method.
 pub struct UiNode(pub Box<dyn Control>);
+
+impl fyrox_graph::GraphNode<UiNode> for UiNode {
+    fn as_base_node_mut(&mut self) -> &mut BaseNode<UiNode> {
+        &mut self.base_node
+    }
+
+    fn as_base_node(&self) -> &BaseNode<UiNode> {
+        &self.base_node
+    }
+}
 
 impl Debug for UiNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/fyrox-ui/src/screen.rs
+++ b/fyrox-ui/src/screen.rs
@@ -104,7 +104,7 @@ uuid_provider!(Screen = "3bc7649f-a1ba-49be-bc4e-e0624654e40c");
 
 impl Control for Screen {
     fn measure_override(&self, ui: &UserInterface, _available_size: Vector2<f32>) -> Vector2<f32> {
-        for &child in self.children.iter() {
+        for &child in self.base_node.children().iter() {
             ui.measure_node(child, ui.screen_size());
         }
 
@@ -114,7 +114,7 @@ impl Control for Screen {
     fn arrange_override(&self, ui: &UserInterface, _final_size: Vector2<f32>) -> Vector2<f32> {
         let final_rect = Rect::new(0.0, 0.0, ui.screen_size().x, ui.screen_size().y);
 
-        for &child in self.children.iter() {
+        for &child in self.base_node.children().iter() {
             ui.arrange_node(child, &final_rect);
         }
 

--- a/fyrox-ui/src/scroll_bar.rs
+++ b/fyrox-ui/src/scroll_bar.rs
@@ -337,7 +337,7 @@ impl Control for ScrollBar {
                 match msg {
                     WidgetMessage::MouseDown { pos, .. } => {
                         if self.indicator.is_some() {
-                            let indicator_pos = ui.nodes.borrow(self.indicator).screen_position();
+                            let indicator_pos = ui.inner.borrow(self.indicator).screen_position();
                             self.is_dragging = true;
                             self.offset = indicator_pos - *pos;
                             ui.capture_mouse(self.indicator);
@@ -353,7 +353,7 @@ impl Control for ScrollBar {
                         if self.indicator.is_some() {
                             let indicator_canvas = ui.node(self.indicator_canvas);
                             let indicator_size =
-                                ui.nodes.borrow(self.indicator).actual_global_size();
+                                ui.inner.borrow(self.indicator).actual_global_size();
                             if self.is_dragging {
                                 let percent = match self.orientation {
                                     Orientation::Horizontal => {

--- a/fyrox-ui/src/scroll_panel.rs
+++ b/fyrox-ui/src/scroll_panel.rs
@@ -182,7 +182,7 @@ impl Control for ScrollPanel {
         for child_handle in self.widget.children() {
             ui.measure_node(*child_handle, size_for_child);
 
-            let child = ui.nodes.borrow(*child_handle);
+            let child = ui.inner.borrow(*child_handle);
             let child_desired_size = child.desired_size();
             if child_desired_size.x > desired_size.x {
                 desired_size.x = child_desired_size.x;
@@ -296,7 +296,7 @@ impl Control for ScrollPanel {
                     ScrollPanelMessage::ScrollToEnd => {
                         let mut max_size = Vector2::default();
                         for child_handle in self.widget.children() {
-                            let child = ui.nodes.borrow(*child_handle);
+                            let child = ui.inner.borrow(*child_handle);
                             let child_desired_size = child.desired_size();
                             if child_desired_size.x > max_size.x {
                                 max_size.x = child_desired_size.x;

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -672,8 +672,6 @@ pub struct Widget {
     /// cases it will most likely be [`Handle::NONE`].
     #[reflect(read_only)]
     pub handle: Handle<UiNode>,
-    /// Name of the widget. Could be useful for debugging purposes.
-    pub name: String,
     /// Desired position relative to the parent node. It is just a recommendation for the layout system, actual position
     /// will be stored in the `actual_local_position` field and can be fetched using [`Widget::actual_local_position`]
     /// method.
@@ -832,13 +830,13 @@ impl Widget {
     /// Returns the name of the widget.
     #[inline]
     pub fn name(&self) -> &str {
-        self.name.as_str()
+        self.base_node.name.as_str()
     }
 
     /// Sets the new name of the widget.
     #[inline]
     pub fn set_name<P: AsRef<str>>(&mut self, name: P) -> &mut Self {
-        self.name = name.as_ref().to_owned();
+        self.base_node.name = name.as_ref().to_owned();
         self
     }
 
@@ -1234,7 +1232,7 @@ impl Widget {
                     &WidgetMessage::Opacity(opacity) => self.opacity = opacity,
                     WidgetMessage::Background(background) => self.background = background.clone(),
                     WidgetMessage::Foreground(foreground) => self.foreground = foreground.clone(),
-                    WidgetMessage::Name(name) => self.name = name.clone(),
+                    WidgetMessage::Name(name) => self.base_node.name = name.clone(),
                     &WidgetMessage::Width(width) => {
                         if self.width != width {
                             self.set_width_notify(width);
@@ -1951,7 +1949,6 @@ impl WidgetBuilder {
     pub fn build(self) -> Widget {
         Widget {
             handle: Default::default(),
-            name: self.name,
             desired_local_position: self.desired_position,
             width: self.width,
             height: self.height,
@@ -1975,6 +1972,7 @@ impl WidgetBuilder {
             base_node: BaseNode {
                 parent: Handle::NONE,
                 children: self.children,
+                name: self.name,
             },
             command_indices: Default::default(),
             is_mouse_directly_over: false,

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -19,6 +19,7 @@ use crate::{
     UserInterface, VerticalAlignment, BRUSH_FOREGROUND, BRUSH_PRIMARY,
 };
 use fyrox_core::parking_lot::Mutex;
+use fyrox_graph::NodeId;
 use std::sync::Arc;
 use std::{
     any::Any,
@@ -660,6 +661,7 @@ impl WidgetMessage {
     );
 }
 
+/// Generic node data.
 pub type BaseNode = fyrox_graph::BaseNode<UiNode>;
 
 /// Widget is a base UI element, that is always used to build derived, more complex, widgets. In general, it is a container
@@ -778,8 +780,6 @@ pub struct Widget {
     #[reflect(hidden)]
     #[visit(skip)]
     pub layout_events_sender: Option<Sender<LayoutEvent>>,
-    /// Unique identifier of the widget.
-    pub id: Uuid,
     //
     // Layout. Interior mutability is a must here because layout performed in a series of recursive calls.
     //
@@ -1669,7 +1669,7 @@ pub struct WidgetBuilder {
     /// Whether the widget bounds should be clipped by its parent or not.
     pub clip_to_bounds: bool,
     /// Unique id of the widget.
-    pub id: Uuid,
+    pub instance_id: NodeId,
 }
 
 impl Default for WidgetBuilder {
@@ -1714,7 +1714,7 @@ impl WidgetBuilder {
             layout_transform: Matrix3::identity(),
             render_transform: Matrix3::identity(),
             clip_to_bounds: true,
-            id: Uuid::new_v4(),
+            instance_id: Default::default(),
         }
     }
 
@@ -1908,7 +1908,7 @@ impl WidgetBuilder {
 
     /// Sets the desired widget id.
     pub fn with_id(mut self, id: Uuid) -> Self {
-        self.id = id;
+        self.instance_id = NodeId(id);
         self
     }
 
@@ -1974,6 +1974,7 @@ impl WidgetBuilder {
                 parent: Handle::NONE,
                 children: self.children,
                 name: self.name,
+                instance_id: self.instance_id,
             },
             command_indices: Default::default(),
             is_mouse_directly_over: false,
@@ -2001,7 +2002,6 @@ impl WidgetBuilder {
             render_transform: self.render_transform,
             visual_transform: Matrix3::identity(),
             clip_to_bounds: self.clip_to_bounds,
-            id: self.id,
         }
     }
 }

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -19,7 +19,6 @@ use crate::{
     UserInterface, VerticalAlignment, BRUSH_FOREGROUND, BRUSH_PRIMARY,
 };
 use fyrox_core::parking_lot::Mutex;
-use fyrox_graph::BaseNode;
 use std::sync::Arc;
 use std::{
     any::Any,
@@ -661,13 +660,15 @@ impl WidgetMessage {
     );
 }
 
+pub type BaseNode = fyrox_graph::BaseNode<UiNode>;
+
 /// Widget is a base UI element, that is always used to build derived, more complex, widgets. In general, it is a container
 /// for layout information, basic visual appearance, visibility options, parent-child information. It does almost nothing
 /// on its own, instead, the user interface modifies its state accordingly.
 #[derive(Default, Debug, Clone, Reflect, Visit)]
 pub struct Widget {
     /// Base node of the widget.
-    pub base_node: fyrox_graph::BaseNode<UiNode>,
+    pub base_node: BaseNode,
     /// Self handle of the widget. It is valid **only**, if the widget is added to the user interface, in other
     /// cases it will most likely be [`Handle::NONE`].
     #[reflect(read_only)]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -35,7 +35,7 @@ use crate::{
     scene::{
         base::NodeScriptMessage,
         camera::SkyBoxKind,
-        graph::{GraphUpdateSwitches, NodePool},
+        graph::{GraphUpdateSwitches, LowLevelGraph},
         node::{constructor::NodeConstructorContainer, Node},
         sound::SoundEngine,
         Scene, SceneContainer, SceneLoader,
@@ -1651,7 +1651,7 @@ impl Engine {
                             (&mut scene as &mut dyn Reflect).apply_recursively_mut(
                                 &mut |object| {
                                     let type_id = (*object).type_id();
-                                    if type_id != TypeId::of::<NodePool>() {
+                                    if type_id != TypeId::of::<LowLevelGraph>() {
                                         object.as_inheritable_variable_mut(&mut |variable| {
                                             if let Some(variable) = variable {
                                                 variable.reset_modified_flag();
@@ -1675,7 +1675,7 @@ impl Engine {
                                     &mut scene,
                                     source_scene_ref,
                                     &[
-                                        TypeId::of::<NodePool>(),
+                                        TypeId::of::<LowLevelGraph>(),
                                         TypeId::of::<UntypedResource>(),
                                         TypeId::of::<navmesh::Container>(),
                                     ],

--- a/src/resource/model/mod.rs
+++ b/src/resource/model/mod.rs
@@ -376,7 +376,7 @@ impl ModelResourceExtension for ModelResource {
     }
 
     fn retarget_animations(&self, root: Handle<Node>, graph: &mut Graph) -> Vec<Handle<Animation>> {
-        if let Some((animation_player, _)) = graph.find(root, &mut |n| {
+        if let Some((animation_player, _)) = graph.find(root, |n| {
             n.query_component_ref::<AnimationPlayer>().is_some()
         }) {
             self.retarget_animations_to_player(root, animation_player, graph)

--- a/src/scene/animation/mod.rs
+++ b/src/scene/animation/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     generic_animation::value::{BoundValueCollection, TrackValue, ValueBinding},
     scene::{
         base::{Base, BaseBuilder},
-        graph::{Graph, NodePool},
+        graph::{Graph, LowLevelGraph},
         node::{Node, NodeTrait, UpdateContext},
     },
 };
@@ -54,11 +54,11 @@ pub mod prelude {
 pub trait AnimationContainerExt {
     /// Updates all animations in the container and applies their poses to respective nodes. This method is intended to
     /// be used only by the internals of the engine!
-    fn update_animations(&mut self, nodes: &mut NodePool, apply: bool, dt: f32);
+    fn update_animations(&mut self, nodes: &mut LowLevelGraph, apply: bool, dt: f32);
 }
 
 impl AnimationContainerExt for AnimationContainer {
-    fn update_animations(&mut self, nodes: &mut NodePool, apply: bool, dt: f32) {
+    fn update_animations(&mut self, nodes: &mut LowLevelGraph, apply: bool, dt: f32) {
         for animation in self.iter_mut().filter(|anim| anim.is_enabled()) {
             animation.tick(dt);
             if apply {
@@ -71,7 +71,7 @@ impl AnimationContainerExt for AnimationContainer {
 /// Extension trait for [`AnimationPose`].
 pub trait AnimationPoseExt {
     /// Tries to set each value to the each property from the animation pose to respective scene nodes.
-    fn apply_internal(&self, nodes: &mut NodePool);
+    fn apply_internal(&self, nodes: &mut LowLevelGraph);
 
     /// Tries to set each value to the each property from the animation pose to respective scene nodes.
     fn apply(&self, graph: &mut Graph);
@@ -84,7 +84,7 @@ pub trait AnimationPoseExt {
 }
 
 impl AnimationPoseExt for AnimationPose {
-    fn apply_internal(&self, nodes: &mut NodePool) {
+    fn apply_internal(&self, nodes: &mut LowLevelGraph) {
         for (node, local_pose) in self.poses() {
             if node.is_none() {
                 Log::writeln(MessageKind::Error, "Invalid node handle found for animation pose, most likely it means that animation retargeting failed!");

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -19,7 +19,7 @@ use crate::{
     script::{Script, ScriptTrait},
 };
 use fyrox_core::uuid_provider;
-use fyrox_graph::HierarchicalData;
+use fyrox_graph::BaseNode;
 use serde::{Deserialize, Serialize};
 use std::{any::Any, cell::Cell, sync::mpsc::Sender};
 use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
@@ -373,7 +373,7 @@ pub struct Base {
     pub(crate) global_visibility: Cell<bool>,
 
     #[reflect(hidden)]
-    pub(crate) hierarchical_data: HierarchicalData<Node>,
+    pub(crate) base_node: BaseNode<Node>,
 
     #[reflect(hidden)]
     pub(crate) global_transform: Cell<Matrix4<f32>>,
@@ -509,14 +509,14 @@ impl Base {
     /// Returns handle of parent node.
     #[inline]
     pub fn parent(&self) -> Handle<Node> {
-        self.hierarchical_data.parent
+        self.base_node.parent
     }
 
     /// Returns slice of handles to children nodes. This can be used, for example, to
     /// traverse tree starting from some node.
     #[inline]
     pub fn children(&self) -> &[Handle<Node>] {
-        self.hierarchical_data.children.as_slice()
+        self.base_node.children.as_slice()
     }
 
     /// Returns global transform matrix, such matrix contains combined transformation
@@ -944,7 +944,7 @@ impl Visit for Base {
         }
         self.local_transform.visit("Transform", &mut region)?;
         self.visibility.visit("Visibility", &mut region)?;
-        self.hierarchical_data.visit("", &mut region)?;
+        self.base_node.visit("", &mut region)?;
         self.resource.visit("Resource", &mut region)?;
         self.is_resource_instance_root
             .visit("IsResourceInstance", &mut region)?;
@@ -1146,7 +1146,7 @@ impl BaseBuilder {
             self_handle: Default::default(),
             script_message_sender: None,
             name: self.name,
-            hierarchical_data: HierarchicalData {
+            base_node: BaseNode {
                 parent: Handle::NONE,
                 children: self.children,
             },

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -19,7 +19,6 @@ use crate::{
     script::{Script, ScriptTrait},
 };
 use fyrox_core::uuid_provider;
-use fyrox_graph::BaseNode;
 use serde::{Deserialize, Serialize};
 use std::{any::Any, cell::Cell, sync::mpsc::Sender};
 use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
@@ -292,6 +291,8 @@ impl Visit for SceneNodeId {
     }
 }
 
+pub type BaseNode = fyrox_graph::BaseNode<Node>;
+
 /// Base scene graph node is a simplest possible node, it is used to build more complex ones using composition.
 /// It contains all fundamental properties for each scene graph nodes, like local and global transforms, name,
 /// lifetime, etc. Base node is a building block for all complex node hierarchies - it contains list of children
@@ -314,7 +315,7 @@ impl Visit for SceneNodeId {
 /// ```
 #[derive(Debug, Reflect, Clone)]
 pub struct Base {
-    pub(crate) base_node: BaseNode<Node>,
+    pub(crate) base_node: BaseNode,
 
     #[reflect(hidden)]
     pub(crate) self_handle: Handle<Node>,

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -19,9 +19,10 @@ use crate::{
     script::{Script, ScriptTrait},
 };
 use fyrox_core::uuid_provider;
-use fyrox_graph::NodeId;
 use std::{any::Any, cell::Cell, sync::mpsc::Sender};
 use strum_macros::{AsRefStr, EnumString, EnumVariantNames};
+
+pub use fyrox_graph::NodeId;
 
 /// Level of detail is a collection of objects for given normalized distance range.
 /// Objects will be rendered **only** if they're in specified range.

--- a/src/scene/collider.rs
+++ b/src/scene/collider.rs
@@ -1,6 +1,7 @@
 //! Collider is a geometric entity that can be attached to a rigid body to allow participate it
 //! participate in contact generation, collision response and proximity queries.
 
+use crate::scene::node::GenericContext;
 use crate::{
     core::{
         algebra::Vector3,
@@ -772,8 +773,8 @@ impl NodeTrait for Collider {
         Self::type_uuid()
     }
 
-    fn on_removed_from_graph(&mut self, graph: &mut Graph) {
-        graph.physics.remove_collider(self.native.get());
+    fn on_removed_from_graph(&mut self, ctx: &mut GenericContext) {
+        ctx.physics.remove_collider(self.native.get());
         self.native.set(ColliderHandle::invalid());
 
         Log::info(format!(
@@ -782,8 +783,8 @@ impl NodeTrait for Collider {
         ));
     }
 
-    fn on_unlink(&mut self, graph: &mut Graph) {
-        if graph.physics.remove_collider(self.native.get()) {
+    fn on_unlink(&mut self, ctx: &mut GenericContext) {
+        if ctx.physics.remove_collider(self.native.get()) {
             // Remove native collider when detaching a collider node from rigid body node.
             self.native.set(ColliderHandle::invalid());
         }

--- a/src/scene/dim2/collider.rs
+++ b/src/scene/dim2/collider.rs
@@ -1,6 +1,7 @@
 //! Collider is a geometric entity that can be attached to a rigid body to allow participate it
 //! participate in contact generation, collision response and proximity queries.
 
+use crate::scene::node::GenericContext;
 use crate::{
     core::{
         algebra::Vector2,
@@ -550,8 +551,8 @@ impl NodeTrait for Collider {
         Self::type_uuid()
     }
 
-    fn on_removed_from_graph(&mut self, graph: &mut Graph) {
-        graph.physics2d.remove_collider(self.native.get());
+    fn on_removed_from_graph(&mut self, ctx: &mut GenericContext) {
+        ctx.physics2d.remove_collider(self.native.get());
         self.native.set(ColliderHandle::invalid());
 
         Log::info(format!(
@@ -560,8 +561,8 @@ impl NodeTrait for Collider {
         ));
     }
 
-    fn on_unlink(&mut self, graph: &mut Graph) {
-        if graph.physics2d.remove_collider(self.native.get()) {
+    fn on_unlink(&mut self, ctx: &mut GenericContext) {
+        if ctx.physics2d.remove_collider(self.native.get()) {
             // Remove native collider when detaching a collider node from rigid body node.
             self.native.set(ColliderHandle::invalid());
         }

--- a/src/scene/dim2/joint.rs
+++ b/src/scene/dim2/joint.rs
@@ -1,5 +1,6 @@
 //! Joint is used to restrict motion of two rigid bodies.
 
+use crate::scene::node::GenericContext;
 use crate::{
     core::{
         algebra::{Isometry2, Matrix4, UnitComplex, Vector2},
@@ -275,8 +276,8 @@ impl NodeTrait for Joint {
         Self::type_uuid()
     }
 
-    fn on_removed_from_graph(&mut self, graph: &mut Graph) {
-        graph.physics2d.remove_joint(self.native.get());
+    fn on_removed_from_graph(&mut self, ctx: &mut GenericContext) {
+        ctx.physics2d.remove_joint(self.native.get());
         self.native.set(ImpulseJointHandle::invalid());
 
         Log::info(format!(

--- a/src/scene/dim2/physics.rs
+++ b/src/scene/dim2/physics.rs
@@ -25,7 +25,7 @@ use crate::{
         dim2::{self, collider::ColliderShape, joint::JointParams, rigidbody::ApplyAction},
         graph::{
             physics::{FeatureId, IntegrationParameters, PhysicsPerformanceStatistics},
-            NodePool,
+            LowLevelGraph,
         },
         node::{Node, NodeTrait},
     },
@@ -831,7 +831,7 @@ impl PhysicsWorld {
 
     pub(crate) fn sync_to_collider_node(
         &mut self,
-        nodes: &NodePool,
+        nodes: &LowLevelGraph,
         handle: Handle<Node>,
         collider_node: &scene::dim2::collider::Collider,
     ) {
@@ -950,7 +950,7 @@ impl PhysicsWorld {
 
     pub(crate) fn sync_to_joint_node(
         &mut self,
-        nodes: &NodePool,
+        nodes: &LowLevelGraph,
         handle: Handle<Node>,
         joint: &scene::dim2::joint::Joint,
     ) {

--- a/src/scene/dim2/rigidbody.rs
+++ b/src/scene/dim2/rigidbody.rs
@@ -8,6 +8,7 @@
 //! using [`RigidBody::wake_up`]. By default any external action does **not** wakes up rigid body.
 //! You can also explicitly tell to rigid body that it cannot sleep, by calling
 //! [`RigidBody::set_can_sleep`] with `false` value.
+use crate::scene::node::GenericContext;
 use crate::{
     core::{
         algebra::{Matrix4, Vector2},
@@ -416,8 +417,8 @@ impl NodeTrait for RigidBody {
         Self::type_uuid()
     }
 
-    fn on_removed_from_graph(&mut self, graph: &mut Graph) {
-        graph.physics2d.remove_body(self.native.get());
+    fn on_removed_from_graph(&mut self, ctx: &mut GenericContext) {
+        ctx.physics2d.remove_body(self.native.get());
         self.native.set(RigidBodyHandle::invalid());
 
         Log::info(format!(
@@ -444,7 +445,7 @@ impl NodeTrait for RigidBody {
             // Rigid body 2D can be root node of a scene, in this case it does not have a parent.
             context
                 .nodes
-                .try_borrow(self.parent)
+                .try_borrow(self.parent())
                 .map(|p| p.global_transform())
                 .unwrap_or_else(Matrix4::identity),
         );

--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -204,7 +204,8 @@ fn isometric_global_transform(nodes: &LowLevelGraph, node: Handle<Node>) -> Matr
 // cases (mostly when copying a node), because `Graph::add_node` uses children list to attach
 // children to the given node, and when copying a node it is important that this step is skipped.
 fn clear_links(mut node: Node) -> Node {
-    node.base_node = Default::default();
+    node.base_node.children.clear();
+    node.base_node.parent = Handle::NONE;
     node
 }
 
@@ -463,7 +464,7 @@ impl Graph {
         sound_context: &mut SoundContext,
     ) {
         node.on_removed_from_graph(&mut GenericContext {
-            nodes: &mbc,
+            nodes: mbc,
             physics,
             physics2d,
             sound_context,

--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -573,76 +573,66 @@ impl Graph {
     /// Searches for a node down the tree starting from the specified node using the specified closure. Returns a tuple
     /// with a handle and a reference to the found node. If nothing is found, it returns [`None`].
     #[inline]
-    pub fn find<C>(&self, root_node: Handle<Node>, cmp: &mut C) -> Option<(Handle<Node>, &Node)>
-    where
-        C: FnMut(&Node) -> bool,
-    {
-        self.inner.find(root_node, cmp)
+    pub fn find(
+        &self,
+        root: Handle<Node>,
+        cmp: impl FnMut(&Node) -> bool,
+    ) -> Option<(Handle<Node>, &Node)> {
+        self.inner.find(root, cmp)
     }
 
     /// Searches for a node down the tree starting from the specified node using the specified closure. Returns a tuple
     /// with a handle and a reference to the mapped value. If nothing is found, it returns [`None`].
     #[inline]
-    pub fn find_map<C, T>(&self, root_node: Handle<Node>, cmp: &mut C) -> Option<(Handle<Node>, &T)>
-    where
-        C: FnMut(&Node) -> Option<&T>,
-        T: ?Sized,
-    {
-        self.inner.find_map(root_node, cmp)
+    pub fn find_map<T: ?Sized>(
+        &self,
+        root: Handle<Node>,
+        cmp: impl FnMut(&Node) -> Option<&T>,
+    ) -> Option<(Handle<Node>, &T)> {
+        self.inner.find_map(root, cmp)
     }
 
     /// Searches for a node up the tree starting from the specified node using the specified closure. Returns a tuple
     /// with a handle and a reference to the found node. If nothing is found, it returns [`None`].
     #[inline]
-    pub fn find_up<C>(&self, root_node: Handle<Node>, cmp: &mut C) -> Option<(Handle<Node>, &Node)>
-    where
-        C: FnMut(&Node) -> bool,
-    {
+    pub fn find_up(
+        &self,
+        root_node: Handle<Node>,
+        cmp: impl FnMut(&Node) -> bool,
+    ) -> Option<(Handle<Node>, &Node)> {
         self.inner.find_up(root_node, cmp)
     }
 
     /// Searches for a node up the tree starting from the specified node using the specified closure. Returns a tuple
     /// with a handle and a reference to the mapped value. If nothing is found, it returns [`None`].
     #[inline]
-    pub fn find_up_map<C, T>(
+    pub fn find_up_map<T: ?Sized>(
         &self,
-        root_node: Handle<Node>,
-        cmp: &mut C,
-    ) -> Option<(Handle<Node>, &T)>
-    where
-        C: FnMut(&Node) -> Option<&T>,
-        T: ?Sized,
-    {
-        self.inner.find_up_map(root_node, cmp)
+        root: Handle<Node>,
+        cmp: impl FnMut(&Node) -> Option<&T>,
+    ) -> Option<(Handle<Node>, &T)> {
+        self.inner.find_up_map(root, cmp)
     }
 
     /// Searches for a node with the specified name down the tree starting from the specified node. Returns a tuple with
     /// a handle and a reference to the found node. If nothing is found, it returns [`None`].
     #[inline]
-    pub fn find_by_name(
-        &self,
-        root_node: Handle<Node>,
-        name: &str,
-    ) -> Option<(Handle<Node>, &Node)> {
-        self.find(root_node, &mut |node| node.name() == name)
+    pub fn find_by_name(&self, root: Handle<Node>, name: &str) -> Option<(Handle<Node>, &Node)> {
+        self.inner.find_by_name(root, name)
     }
 
     /// Searches for a node with the specified name up the tree starting from the specified node. Returns a tuple with a
     /// handle and a reference to the found node. If nothing is found, it returns [`None`].
     #[inline]
-    pub fn find_up_by_name(
-        &self,
-        root_node: Handle<Node>,
-        name: &str,
-    ) -> Option<(Handle<Node>, &Node)> {
-        self.find_up(root_node, &mut |node| node.name() == name)
+    pub fn find_up_by_name(&self, root: Handle<Node>, name: &str) -> Option<(Handle<Node>, &Node)> {
+        self.inner.find_up_by_name(root, name)
     }
 
     /// Searches for a node with the specified name down the tree starting from the graph root. Returns a tuple with a
     /// handle and a reference to the found node. If nothing is found, it returns [`None`].
     #[inline]
     pub fn find_by_name_from_root(&self, name: &str) -> Option<(Handle<Node>, &Node)> {
-        self.find_by_name(self.inner.root, name)
+        self.inner.find_by_name_from_root(name)
     }
 
     /// Searches for a **first** node with a script of the given type `S` in the hierarchy starting from the
@@ -652,7 +642,7 @@ impl Graph {
     where
         S: ScriptTrait,
     {
-        self.find(root_node, &mut |n| {
+        self.find(root_node, |n| {
             n.script().and_then(|s| s.cast::<S>()).is_some()
         })
     }
@@ -660,11 +650,8 @@ impl Graph {
     /// Searches node using specified compare closure starting from root. Returns a tuple with a handle and
     /// a reference to the found node. If nothing is found, it returns [`None`].
     #[inline]
-    pub fn find_from_root<C>(&self, cmp: &mut C) -> Option<(Handle<Node>, &Node)>
-    where
-        C: FnMut(&Node) -> bool,
-    {
-        self.find(self.inner.root, cmp)
+    pub fn find_from_root(&self, cmp: impl FnMut(&Node) -> bool) -> Option<(Handle<Node>, &Node)> {
+        self.inner.find_from_root(cmp)
     }
 
     /// Creates deep copy of node with all children. This is relatively heavy operation!
@@ -1095,7 +1082,7 @@ impl Graph {
 
                         // Link it with existing node.
                         if resource_node.parent().is_some() {
-                            let parent = self.find(instance_root, &mut |n| {
+                            let parent = self.find(instance_root, |n| {
                                 n.original_handle_in_resource == resource_node.parent()
                             });
 
@@ -2089,7 +2076,7 @@ impl Visit for Graph {
 
         let mut region = visitor.enter_region(name)?;
 
-        self.inner.visit("", &mut region)?;
+        self.inner.visit("Root", "Pool", &mut region)?;
         self.sound_context.visit("SoundContext", &mut region)?;
         self.physics.visit("PhysicsWorld", &mut region)?;
         self.physics2d.visit("PhysicsWorld2D", &mut region)?;

--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -216,7 +216,7 @@ fn isometric_global_transform(nodes: &LowLevelGraph, node: Handle<Node>) -> Matr
 // cases (mostly when copying a node), because `Graph::add_node` uses children list to attach
 // children to the given node, and when copying a node it is important that this step is skipped.
 fn clear_links(mut node: Node) -> Node {
-    node.hierarchical_data = Default::default();
+    node.base_node = Default::default();
     node
 }
 
@@ -312,7 +312,7 @@ impl Graph {
         self.unlink_internal(new_root);
         let prev_root_children = self
             .try_get(prev_root)
-            .map(|r| r.hierarchical_data.children.clone())
+            .map(|r| r.base_node.children.clone())
             .unwrap_or_default();
         for child in prev_root_children {
             self.link_nodes(child, new_root);

--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -512,7 +512,7 @@ impl Graph {
     #[inline]
     pub fn link_nodes(&mut self, child: Handle<Node>, parent: Handle<Node>) {
         self.unlink_internal(child);
-        self.inner.link_nodes(child, parent);
+        self.inner.link_nodes(child, parent, false);
     }
 
     /// Links specified child with specified parent while keeping the

--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -577,13 +577,7 @@ impl Graph {
     where
         C: FnMut(&Node) -> bool,
     {
-        self.inner.try_borrow(root_node).and_then(|root| {
-            if cmp(root) {
-                Some((root_node, root))
-            } else {
-                root.children().iter().find_map(|c| self.find(*c, cmp))
-            }
-        })
+        self.inner.find(root_node, cmp)
     }
 
     /// Searches for a node down the tree starting from the specified node using the specified closure. Returns a tuple
@@ -594,13 +588,7 @@ impl Graph {
         C: FnMut(&Node) -> Option<&T>,
         T: ?Sized,
     {
-        self.inner.try_borrow(root_node).and_then(|root| {
-            if let Some(x) = cmp(root) {
-                Some((root_node, x))
-            } else {
-                root.children().iter().find_map(|c| self.find_map(*c, cmp))
-            }
-        })
+        self.inner.find_map(root_node, cmp)
     }
 
     /// Searches for a node up the tree starting from the specified node using the specified closure. Returns a tuple
@@ -610,14 +598,7 @@ impl Graph {
     where
         C: FnMut(&Node) -> bool,
     {
-        let mut handle = root_node;
-        while let Some(node) = self.inner.try_borrow(handle) {
-            if cmp(node) {
-                return Some((handle, node));
-            }
-            handle = node.parent();
-        }
-        None
+        self.inner.find_up(root_node, cmp)
     }
 
     /// Searches for a node up the tree starting from the specified node using the specified closure. Returns a tuple
@@ -632,14 +613,7 @@ impl Graph {
         C: FnMut(&Node) -> Option<&T>,
         T: ?Sized,
     {
-        let mut handle = root_node;
-        while let Some(node) = self.inner.try_borrow(handle) {
-            if let Some(x) = cmp(node) {
-                return Some((handle, x));
-            }
-            handle = node.parent();
-        }
-        None
+        self.inner.find_up_map(root_node, cmp)
     }
 
     /// Searches for a node with the specified name down the tree starting from the specified node. Returns a tuple with

--- a/src/scene/graph/physics.rs
+++ b/src/scene/graph/physics.rs
@@ -21,7 +21,7 @@ use crate::{
         self,
         collider::{self, ColliderShape, GeometrySource},
         debug::SceneDrawingContext,
-        graph::{isometric_global_transform, NodePool},
+        graph::{isometric_global_transform, LowLevelGraph},
         joint::{JointLocalFrames, JointParams},
         mesh::{
             buffer::{VertexAttributeUsage, VertexReadTrait},
@@ -455,7 +455,7 @@ fn make_trimesh(
     owner_inv_transform: Matrix4<f32>,
     owner: Handle<Node>,
     sources: &[GeometrySource],
-    nodes: &NodePool,
+    nodes: &LowLevelGraph,
 ) -> SharedShape {
     let mut mesh_builder = RawMeshBuilder::new(0, 0);
 
@@ -678,7 +678,7 @@ fn collider_shape_into_native_shape(
     shape: &ColliderShape,
     owner_inv_global_transform: Matrix4<f32>,
     owner_collider: Handle<Node>,
-    pool: &NodePool,
+    pool: &LowLevelGraph,
 ) -> Option<SharedShape> {
     match shape {
         ColliderShape::Ball(ball) => Some(SharedShape::ball(ball.radius)),
@@ -1394,7 +1394,7 @@ impl PhysicsWorld {
 
     pub(crate) fn sync_to_collider_node(
         &mut self,
-        nodes: &NodePool,
+        nodes: &LowLevelGraph,
         handle: Handle<Node>,
         collider_node: &scene::collider::Collider,
     ) {
@@ -1525,7 +1525,7 @@ impl PhysicsWorld {
 
     pub(crate) fn sync_to_joint_node(
         &mut self,
-        nodes: &NodePool,
+        nodes: &LowLevelGraph,
         handle: Handle<Node>,
         joint: &scene::joint::Joint,
     ) {

--- a/src/scene/joint.rs
+++ b/src/scene/joint.rs
@@ -1,5 +1,6 @@
 //! Joint is used to restrict motion of two rigid bodies.
 
+use crate::scene::node::GenericContext;
 use crate::{
     core::{
         algebra::Matrix4,
@@ -348,8 +349,8 @@ impl NodeTrait for Joint {
         Self::type_uuid()
     }
 
-    fn on_removed_from_graph(&mut self, graph: &mut Graph) {
-        graph.physics.remove_joint(self.native.get());
+    fn on_removed_from_graph(&mut self, ctx: &mut GenericContext) {
+        ctx.physics.remove_joint(self.native.get());
         self.native.set(ImpulseJointHandle::invalid());
 
         Log::info(format!(

--- a/src/scene/node/mod.rs
+++ b/src/scene/node/mod.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 use fyrox_core::pool::MultiBorrowContext;
 use fyrox_core::ComponentProvider;
-use fyrox_graph::{GraphNode, HierarchicalData};
+use fyrox_graph::{BaseNode, GraphNode};
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
@@ -322,16 +322,12 @@ pub trait NodeTrait: BaseNodeTrait + Reflect + Visit {
 pub struct Node(Box<dyn NodeTrait>);
 
 impl GraphNode<Node> for Node {
-    fn children(&self) -> &[Handle<Node>] {
-        &self.hierarchical_data.children
+    fn as_base_node_mut(&mut self) -> &mut BaseNode<Node> {
+        &mut self.base_node
     }
 
-    fn parent(&self) -> Handle<Node> {
-        self.hierarchical_data.parent
-    }
-
-    fn hierarchical_data_mut(&mut self) -> &mut HierarchicalData<Node> {
-        &mut self.hierarchical_data
+    fn as_base_node(&self) -> &BaseNode<Node> {
+        &self.base_node
     }
 }
 

--- a/src/scene/rigidbody.rs
+++ b/src/scene/rigidbody.rs
@@ -8,6 +8,7 @@
 //! using [`RigidBody::wake_up`]. By default any external action does **not** wakes up rigid body.
 //! You can also explicitly tell to rigid body that it cannot sleep, by calling
 //! [`RigidBody::set_can_sleep`] with `false` value.
+use crate::scene::node::GenericContext;
 use crate::{
     core::{
         algebra::{Matrix4, Vector3},
@@ -520,8 +521,8 @@ impl NodeTrait for RigidBody {
         Self::type_uuid()
     }
 
-    fn on_removed_from_graph(&mut self, graph: &mut Graph) {
-        graph.physics.remove_body(self.native.get());
+    fn on_removed_from_graph(&mut self, ctx: &mut GenericContext) {
+        ctx.physics.remove_body(self.native.get());
         self.native.set(RigidBodyHandle::invalid());
 
         Log::info(format!(
@@ -548,7 +549,7 @@ impl NodeTrait for RigidBody {
             // Rigid body can be root node of a scene, in this case it does not have a parent.
             context
                 .nodes
-                .try_borrow(self.parent)
+                .try_borrow(self.parent())
                 .map(|p| p.global_transform())
                 .unwrap_or_else(Matrix4::identity),
         );

--- a/src/scene/sound/context.rs
+++ b/src/scene/sound/context.rs
@@ -164,7 +164,7 @@ impl SoundContext {
         if !sound.is_globally_enabled()
             || !node_overrides.map_or(true, |f| f.contains(&sound_handle))
         {
-            self.remove_sound(sound.native.get(), &sound.name);
+            self.remove_sound(sound.native.get(), &sound.base_node.name);
             sound.native.set(Default::default());
             return;
         }

--- a/src/scene/sound/mod.rs
+++ b/src/scene/sound/mod.rs
@@ -384,7 +384,7 @@ impl NodeTrait for Sound {
     fn on_removed_from_graph(&mut self, graph: &mut GenericContext) {
         graph
             .sound_context
-            .remove_sound(self.native.get(), &self.name);
+            .remove_sound(self.native.get(), &self.base_node.name);
         self.native.set(Default::default());
     }
 

--- a/src/scene/sound/mod.rs
+++ b/src/scene/sound/mod.rs
@@ -36,6 +36,7 @@ pub use fyrox_sound::{
     source::Status,
 };
 
+use crate::scene::node::GenericContext;
 use crate::scene::Scene;
 use fyrox_resource::state::ResourceState;
 use fyrox_sound::source::SoundSource;
@@ -380,7 +381,7 @@ impl NodeTrait for Sound {
         Self::type_uuid()
     }
 
-    fn on_removed_from_graph(&mut self, graph: &mut Graph) {
+    fn on_removed_from_graph(&mut self, graph: &mut GenericContext) {
         graph
             .sound_context
             .remove_sound(self.native.get(), &self.name);


### PR DESCRIPTION
This PR adds a new `fyrox-graph` crates which contains low-level graph implementation, which replaces the most common graph operations in both Scene and UI graphs. The main motivation of this PR is to minimize duplicated code and move the most common algorithms in the common crate, to prevent re-inventing them for each use case.