### PR TITLE
Anim editor refactoring to support UI animations

### DIFF
--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -276,7 +276,7 @@ impl AbsmEditor {
         engine: &mut Engine,
     ) {
         // Leave preview mode before execution of any scene command.
-        if let Message::DoGameSceneCommand(_)
+        if let Message::DoCommand(_)
         | Message::UndoCurrentSceneCommand
         | Message::RedoCurrentSceneCommand = message
         {

--- a/editor/src/absm/parameter.rs
+++ b/editor/src/absm/parameter.rs
@@ -149,7 +149,7 @@ impl ParameterPanel {
                         },
                     );
                 } else {
-                    sender.send(Message::DoGameSceneCommand(
+                    sender.send(Message::DoCommand(
                         make_command(args, move |ctx| {
                             fetch_machine(ctx, absm_node_handle).parameters_mut()
                         })

--- a/editor/src/absm/state_graph/context.rs
+++ b/editor/src/absm/state_graph/context.rs
@@ -248,7 +248,6 @@ impl NodeContextMenu {
 
                     let mut group = vec![Command::new(ChangeSelectionCommand::new(
                         Selection::new(new_selection),
-                        editor_selection.clone(),
                     ))];
 
                     group.extend(transitions_to_remove.map(|transition| {
@@ -359,10 +358,7 @@ impl TransitionContextMenu {
                         .unwrap();
 
                     let group = vec![
-                        Command::new(ChangeSelectionCommand::new(
-                            Selection::new(new_selection),
-                            editor_selection.clone(),
-                        )),
+                        Command::new(ChangeSelectionCommand::new(Selection::new(new_selection))),
                         Command::new(DeleteTransitionCommand::new(
                             absm_node_handle,
                             layer_index,

--- a/editor/src/absm/state_graph/mod.rs
+++ b/editor/src/absm/state_graph/mod.rs
@@ -200,10 +200,7 @@ impl StateGraphViewer {
                             });
 
                             if !selection.is_empty() && &selection != editor_selection {
-                                sender.do_scene_command(ChangeSelectionCommand::new(
-                                    selection,
-                                    editor_selection.clone(),
-                                ));
+                                sender.do_scene_command(ChangeSelectionCommand::new(selection));
                             }
                         }
                     }

--- a/editor/src/absm/state_viewer/context.rs
+++ b/editor/src/absm/state_viewer/context.rs
@@ -228,7 +228,6 @@ impl NodeContextMenu {
 
                     let mut group = vec![Command::new(ChangeSelectionCommand::new(
                         Selection::new(new_selection),
-                        editor_selection.clone(),
                     ))];
 
                     group.extend(selection.entities.iter().filter_map(|entry| {

--- a/editor/src/absm/state_viewer/mod.rs
+++ b/editor/src/absm/state_viewer/mod.rs
@@ -287,10 +287,7 @@ impl StateViewer {
                                 });
 
                                 if !selection.is_empty() && &selection != editor_selection {
-                                    sender.do_scene_command(ChangeSelectionCommand::new(
-                                        selection,
-                                        editor_selection.clone(),
-                                    ));
+                                    sender.do_scene_command(ChangeSelectionCommand::new(selection));
                                 }
                             }
                         }

--- a/editor/src/absm/toolbar.rs
+++ b/editor/src/absm/toolbar.rs
@@ -191,10 +191,7 @@ impl Toolbar {
                 let mut new_selection = selection;
                 new_selection.layer = Some(*index);
                 new_selection.entities.clear();
-                sender.do_scene_command(ChangeSelectionCommand::new(
-                    Selection::new(new_selection),
-                    editor_selection.clone(),
-                ));
+                sender.do_scene_command(ChangeSelectionCommand::new(Selection::new(new_selection)));
             }
         } else if let Some(TextMessage::Text(text)) = message.data() {
             if message.destination() == self.layer_name
@@ -306,8 +303,8 @@ impl Toolbar {
                     if let Some(layer_index) = selection.layer {
                         let mut commands = Vec::new();
 
-                        commands.push(Command::new(ChangeSelectionCommand::new(
-                            Selection::new(AbsmSelection {
+                        commands.push(Command::new(ChangeSelectionCommand::new(Selection::new(
+                            AbsmSelection {
                                 absm_node_handle: selection.absm_node_handle,
                                 layer: if absm_node.machine().layers().len() > 1 {
                                     Some(0)
@@ -315,9 +312,8 @@ impl Toolbar {
                                     None
                                 },
                                 entities: vec![],
-                            }),
-                            editor_selection.clone(),
-                        )));
+                            },
+                        ))));
 
                         commands.push(Command::new(RemoveLayerCommand::new(
                             selection.absm_node_handle,

--- a/editor/src/animation/command/mod.rs
+++ b/editor/src/animation/command/mod.rs
@@ -1,44 +1,71 @@
-use crate::command::CommandContext;
 use crate::{
     animation::selection::AnimationSelection,
-    command::CommandTrait,
+    command::{CommandContext, CommandTrait},
     scene::{commands::GameSceneContext, Selection},
+    ui_scene::UiScene,
 };
 use fyrox::{
     core::{
         curve::Curve,
         log::Log,
-        pool::{Handle, Ticket},
+        pool::{ErasedHandle, Handle, Ticket},
         uuid::Uuid,
+        variable::InheritableVariable,
     },
-    scene::{
-        animation::{absm::prelude::*, prelude::*},
-        node::Node,
+    generic_animation::{
+        signal::AnimationSignal, track::Track, value::ValueBinding, Animation, AnimationContainer,
+        RootMotionSettings,
     },
+    graph::BaseSceneGraph,
 };
 use std::{
+    any::TypeId,
     fmt::Debug,
     ops::{IndexMut, Range},
 };
 
-pub fn fetch_animation_player(
-    handle: Handle<Node>,
-    context: &mut GameSceneContext,
-) -> &mut AnimationPlayer {
-    context.scene.graph[handle]
-        .query_component_mut::<AnimationPlayer>()
-        .unwrap()
+pub fn fetch_animations_container<N: Debug + 'static>(
+    handle: Handle<N>,
+    context: &mut dyn CommandContext,
+) -> &mut InheritableVariable<AnimationContainer<Handle<N>>> {
+    // SAFETY: Borrow checker cannot resolve lifetime properly in the following `if` chain.
+    // This is safe to do, because there's only one mutable reference anyway. Should be fixed
+    // with Polonius.
+    let context2 = unsafe { &mut *(context as *mut dyn CommandContext) };
+
+    if let Some(game_scene) = context.component_mut::<GameSceneContext>() {
+        game_scene
+            .scene
+            .graph
+            .node_mut(ErasedHandle::from(handle).into())
+            .query_component_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>()
+            .unwrap()
+    } else if let Some(ui) = context2.component_mut::<UiScene>() {
+        ui.ui
+            .node_mut(ErasedHandle::from(handle).into())
+            .query_component_mut(TypeId::of::<
+                InheritableVariable<AnimationContainer<Handle<N>>>,
+            >())
+            .and_then(|c| c.downcast_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>())
+            .unwrap()
+    } else {
+        panic!("Unsupported container!")
+    }
 }
 
 #[derive(Debug)]
-pub struct AddTrackCommand {
-    animation_player: Handle<Node>,
-    animation: Handle<Animation>,
-    track: Option<Track>,
+pub struct AddTrackCommand<N: Debug + 'static> {
+    animation_player: Handle<N>,
+    animation: Handle<Animation<Handle<N>>>,
+    track: Option<Track<Handle<N>>>,
 }
 
-impl AddTrackCommand {
-    pub fn new(animation_player: Handle<Node>, animation: Handle<Animation>, track: Track) -> Self {
+impl<N: Debug + 'static> AddTrackCommand<N> {
+    pub fn new(
+        animation_player: Handle<N>,
+        animation: Handle<Animation<Handle<N>>>,
+        track: Track<Handle<N>>,
+    ) -> Self {
         Self {
             animation_player,
             animation,
@@ -47,35 +74,38 @@ impl AddTrackCommand {
     }
 }
 
-impl CommandTrait for AddTrackCommand {
+impl<N: Debug + 'static> CommandTrait for AddTrackCommand<N> {
     fn name(&mut self, _: &dyn CommandContext) -> String {
         "Add Track".to_string()
     }
 
     fn execute(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
-        fetch_animation_player(self.animation_player, context).animations_mut()[self.animation]
+        fetch_animations_container(self.animation_player, context)[self.animation]
             .add_track(self.track.take().unwrap());
     }
 
     fn revert(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
-        self.track = fetch_animation_player(self.animation_player, context).animations_mut()
-            [self.animation]
-            .pop_track();
+        self.track =
+            fetch_animations_container(self.animation_player, context)[self.animation].pop_track();
     }
 }
 
 #[derive(Debug)]
-pub struct RemoveTrackCommand {
-    animation_player: Handle<Node>,
-    animation: Handle<Animation>,
+pub struct RemoveTrackCommand<N: Debug + 'static> {
+    animation_player: Handle<N>,
+    animation: Handle<Animation<Handle<N>>>,
     index: usize,
-    track: Option<Track>,
+    track: Option<Track<Handle<N>>>,
 }
 
-impl RemoveTrackCommand {
-    pub fn new(animation_player: Handle<Node>, animation: Handle<Animation>, index: usize) -> Self {
+impl<N: Debug + 'static> RemoveTrackCommand<N> {
+    pub fn new(
+        animation_player: Handle<N>,
+        animation: Handle<Animation<Handle<N>>>,
+        index: usize,
+    ) -> Self {
         Self {
             animation_player,
             animation,
@@ -85,7 +115,7 @@ impl RemoveTrackCommand {
     }
 }
 
-impl CommandTrait for RemoveTrackCommand {
+impl<N: Debug + 'static> CommandTrait for RemoveTrackCommand<N> {
     fn name(&mut self, _: &dyn CommandContext) -> String {
         "Remove Track".to_string()
     }
@@ -93,31 +123,30 @@ impl CommandTrait for RemoveTrackCommand {
     fn execute(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
         self.track = Some(
-            fetch_animation_player(self.animation_player, context).animations_mut()[self.animation]
+            fetch_animations_container(self.animation_player, context)[self.animation]
                 .remove_track(self.index),
         );
     }
 
     fn revert(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
-        fetch_animation_player(self.animation_player, context).animations_mut()[self.animation]
+        fetch_animations_container(self.animation_player, context)[self.animation]
             .insert_track(self.index, self.track.take().unwrap());
     }
 }
 
 #[derive(Debug)]
-pub struct ReplaceTrackCurveCommand {
-    pub animation_player: Handle<Node>,
-    pub animation: Handle<Animation>,
+pub struct ReplaceTrackCurveCommand<N: Debug + 'static> {
+    pub animation_player: Handle<N>,
+    pub animation: Handle<Animation<Handle<N>>>,
     pub curve: Curve,
 }
 
-impl ReplaceTrackCurveCommand {
+impl<N: Debug + 'static> ReplaceTrackCurveCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
-        for track in fetch_animation_player(self.animation_player, context).animations_mut()
-            [self.animation]
-            .tracks_mut()
+        for track in
+            fetch_animations_container(self.animation_player, context)[self.animation].tracks_mut()
         {
             for curve in track.data_container_mut().curves_mut() {
                 if curve.id() == self.curve.id() {
@@ -131,7 +160,7 @@ impl ReplaceTrackCurveCommand {
     }
 }
 
-impl CommandTrait for ReplaceTrackCurveCommand {
+impl<N: Debug + 'static> CommandTrait for ReplaceTrackCurveCommand<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Replace Track Curve".to_string()
     }
@@ -146,27 +175,27 @@ impl CommandTrait for ReplaceTrackCurveCommand {
 }
 
 #[derive(Debug)]
-pub enum AddAnimationCommand {
+pub enum AddAnimationCommand<N: Debug + 'static> {
     Unknown,
     NonExecuted {
-        animation_player: Handle<Node>,
-        animation: Animation,
+        animation_player: Handle<N>,
+        animation: Animation<Handle<N>>,
     },
     Executed {
-        animation_player: Handle<Node>,
-        animation: Handle<Animation>,
+        animation_player: Handle<N>,
+        animation: Handle<Animation<Handle<N>>>,
         selection: Selection,
     },
     Reverted {
-        animation_player: Handle<Node>,
-        animation: Animation,
-        ticket: Ticket<Animation>,
+        animation_player: Handle<N>,
+        animation: Animation<Handle<N>>,
+        ticket: Ticket<Animation<Handle<N>>>,
         selection: Selection,
     },
 }
 
-impl AddAnimationCommand {
-    pub fn new(animation_player: Handle<Node>, animation: Animation) -> Self {
+impl<N: Debug + 'static> AddAnimationCommand<N> {
+    pub fn new(animation_player: Handle<N>, animation: Animation<Handle<N>>) -> Self {
         Self::NonExecuted {
             animation_player,
             animation,
@@ -174,7 +203,7 @@ impl AddAnimationCommand {
     }
 }
 
-impl CommandTrait for AddAnimationCommand {
+impl<N: Debug + 'static> CommandTrait for AddAnimationCommand<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Add Animation".to_string()
     }
@@ -186,9 +215,7 @@ impl CommandTrait for AddAnimationCommand {
                 animation_player,
                 animation,
             } => {
-                let handle = fetch_animation_player(animation_player, context)
-                    .animations_mut()
-                    .add(animation);
+                let handle = fetch_animations_container(animation_player, context).add(animation);
 
                 let old_selection = std::mem::replace(
                     context.selection,
@@ -211,8 +238,7 @@ impl CommandTrait for AddAnimationCommand {
                 ticket,
                 selection,
             } => {
-                let handle = fetch_animation_player(animation_player, context)
-                    .animations_mut()
+                let handle = fetch_animations_container(animation_player, context)
                     .put_back(ticket, animation);
 
                 let old_selection = std::mem::replace(context.selection, selection);
@@ -235,9 +261,8 @@ impl CommandTrait for AddAnimationCommand {
                 animation,
                 selection,
             } => {
-                let (ticket, animation) = fetch_animation_player(animation_player, context)
-                    .animations_mut()
-                    .take_reserve(animation);
+                let (ticket, animation) =
+                    fetch_animations_container(animation_player, context).take_reserve(animation);
 
                 let old_selection = std::mem::replace(context.selection, selection);
 
@@ -260,33 +285,31 @@ impl CommandTrait for AddAnimationCommand {
             ..
         } = std::mem::replace(self, Self::Unknown)
         {
-            fetch_animation_player(animation_player, context)
-                .animations_mut()
-                .forget_ticket(ticket);
+            fetch_animations_container(animation_player, context).forget_ticket(ticket);
         }
     }
 }
 
 #[derive(Debug)]
-pub enum RemoveAnimationCommand {
+pub enum RemoveAnimationCommand<N: Debug + 'static> {
     Unknown,
     NonExecuted {
-        animation_player: Handle<Node>,
-        animation: Handle<Animation>,
+        animation_player: Handle<N>,
+        animation: Handle<Animation<Handle<N>>>,
     },
     Executed {
-        animation_player: Handle<Node>,
-        animation: Animation,
-        ticket: Ticket<Animation>,
+        animation_player: Handle<N>,
+        animation: Animation<Handle<N>>,
+        ticket: Ticket<Animation<Handle<N>>>,
     },
     Reverted {
-        animation_player: Handle<Node>,
-        animation: Handle<Animation>,
+        animation_player: Handle<N>,
+        animation: Handle<Animation<Handle<N>>>,
     },
 }
 
-impl RemoveAnimationCommand {
-    pub fn new(animation_player: Handle<Node>, animation: Handle<Animation>) -> Self {
+impl<N: Debug + 'static> RemoveAnimationCommand<N> {
+    pub fn new(animation_player: Handle<N>, animation: Handle<Animation<Handle<N>>>) -> Self {
         Self::NonExecuted {
             animation_player,
             animation,
@@ -294,7 +317,7 @@ impl RemoveAnimationCommand {
     }
 }
 
-impl CommandTrait for RemoveAnimationCommand {
+impl<N: Debug + 'static> CommandTrait for RemoveAnimationCommand<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Remove Animation".to_string()
     }
@@ -310,9 +333,8 @@ impl CommandTrait for RemoveAnimationCommand {
                 animation_player,
                 animation,
             } => {
-                let (ticket, animation) = fetch_animation_player(animation_player, context)
-                    .animations_mut()
-                    .take_reserve(animation);
+                let (ticket, animation) =
+                    fetch_animations_container(animation_player, context).take_reserve(animation);
 
                 *self = Self::Executed {
                     animation_player,
@@ -332,8 +354,7 @@ impl CommandTrait for RemoveAnimationCommand {
                 animation,
                 ticket,
             } => {
-                let handle = fetch_animation_player(animation_player, context)
-                    .animations_mut()
+                let handle = fetch_animations_container(animation_player, context)
                     .put_back(ticket, animation);
 
                 *self = Self::Reverted {
@@ -353,33 +374,30 @@ impl CommandTrait for RemoveAnimationCommand {
             ..
         } = std::mem::replace(self, Self::Unknown)
         {
-            fetch_animation_player(animation_player, context)
-                .animations_mut()
-                .forget_ticket(ticket);
+            fetch_animations_container(animation_player, context).forget_ticket(ticket);
         }
     }
 }
 
 #[derive(Debug)]
-pub struct ReplaceAnimationCommand {
-    pub animation_player: Handle<Node>,
-    pub animation_handle: Handle<Animation>,
-    pub animation: Animation,
+pub struct ReplaceAnimationCommand<N: Debug + 'static> {
+    pub animation_player: Handle<N>,
+    pub animation_handle: Handle<Animation<Handle<N>>>,
+    pub animation: Animation<Handle<N>>,
 }
 
-impl ReplaceAnimationCommand {
+impl<N: Debug + 'static> ReplaceAnimationCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
         std::mem::swap(
-            fetch_animation_player(self.animation_player, context)
-                .animations_mut()
+            fetch_animations_container(self.animation_player, context)
                 .get_mut(self.animation_handle),
             &mut self.animation,
         );
     }
 }
 
-impl CommandTrait for ReplaceAnimationCommand {
+impl<N: Debug + 'static> CommandTrait for ReplaceAnimationCommand<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Replace Animation".to_string()
     }
@@ -397,19 +415,19 @@ impl CommandTrait for ReplaceAnimationCommand {
 macro_rules! define_animation_swap_command {
     ($name:ident<$value_type:ty>($self:ident, $context:ident) $swap:block) => {
         #[derive(Debug)]
-        pub struct $name {
-            pub node_handle: Handle<Node>,
-            pub animation_handle: Handle<Animation>,
+        pub struct $name<N: Debug + 'static> {
+            pub node_handle: Handle<N>,
+            pub animation_handle: Handle<Animation<Handle<N>>>,
             pub value: $value_type,
         }
 
-        impl $name {
+        impl<N: Debug + 'static> $name<N> {
             fn swap(&mut $self, $context: &mut GameSceneContext) {
                 $swap
             }
         }
 
-        impl CommandTrait for $name {
+        impl<N: Debug + 'static> CommandTrait for $name<N> {
             fn name(&mut self, _context: &dyn CommandContext) -> String {
                 stringify!($name).to_string()
             }
@@ -427,14 +445,12 @@ macro_rules! define_animation_swap_command {
     };
 }
 
-fn fetch_animation(
-    animation_player: Handle<Node>,
-    animation: Handle<Animation>,
+fn fetch_animation<N: Debug + 'static>(
+    animation_player: Handle<N>,
+    animation: Handle<Animation<Handle<N>>>,
     ctx: &mut GameSceneContext,
-) -> &mut Animation {
-    fetch_animation_player(animation_player, ctx)
-        .animations_mut()
-        .index_mut(animation)
+) -> &mut Animation<Handle<N>> {
+    fetch_animations_container(animation_player, ctx).index_mut(animation)
 }
 
 define_animation_swap_command!(SetAnimationSpeedCommand<f32>(self, context) {
@@ -472,7 +488,7 @@ define_animation_swap_command!(SetAnimationEnabledCommand<bool>(self, context) {
     self.value = old;
 });
 
-define_animation_swap_command!(SetAnimationRootMotionSettingsCommand<Option<RootMotionSettings>>(self, context) {
+define_animation_swap_command!(SetAnimationRootMotionSettingsCommand<Option<RootMotionSettings<Handle<N>>>>(self, context) {
     let animation = fetch_animation(self.node_handle, self.animation_handle, context);
     let old = animation.root_motion_settings_ref().cloned();
     animation.set_root_motion_settings(self.value.clone());
@@ -480,13 +496,13 @@ define_animation_swap_command!(SetAnimationRootMotionSettingsCommand<Option<Root
 });
 
 #[derive(Debug)]
-pub struct AddAnimationSignal {
-    pub animation_player_handle: Handle<Node>,
-    pub animation_handle: Handle<Animation>,
+pub struct AddAnimationSignal<N: Debug + 'static> {
+    pub animation_player_handle: Handle<N>,
+    pub animation_handle: Handle<Animation<Handle<N>>>,
     pub signal: Option<AnimationSignal>,
 }
 
-impl CommandTrait for AddAnimationSignal {
+impl<N: Debug + 'static> CommandTrait for AddAnimationSignal<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Add Animation Signal".to_string()
     }
@@ -505,14 +521,14 @@ impl CommandTrait for AddAnimationSignal {
 }
 
 #[derive(Debug)]
-pub struct MoveAnimationSignal {
-    pub animation_player_handle: Handle<Node>,
-    pub animation_handle: Handle<Animation>,
+pub struct MoveAnimationSignal<N: Debug + 'static> {
+    pub animation_player_handle: Handle<N>,
+    pub animation_handle: Handle<Animation<Handle<N>>>,
     pub signal: Uuid,
     pub time: f32,
 }
 
-impl MoveAnimationSignal {
+impl<N: Debug + 'static> MoveAnimationSignal<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
         std::mem::swap(
@@ -527,7 +543,7 @@ impl MoveAnimationSignal {
     }
 }
 
-impl CommandTrait for MoveAnimationSignal {
+impl<N: Debug + 'static> CommandTrait for MoveAnimationSignal<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Move Animation Signal".to_string()
     }
@@ -542,14 +558,14 @@ impl CommandTrait for MoveAnimationSignal {
 }
 
 #[derive(Debug)]
-pub struct RemoveAnimationSignal {
-    pub animation_player_handle: Handle<Node>,
-    pub animation_handle: Handle<Animation>,
+pub struct RemoveAnimationSignal<N: Debug + 'static> {
+    pub animation_player_handle: Handle<N>,
+    pub animation_handle: Handle<Animation<Handle<N>>>,
     pub signal_index: usize,
     pub signal: Option<AnimationSignal>,
 }
 
-impl CommandTrait for RemoveAnimationSignal {
+impl<N: Debug + 'static> CommandTrait for RemoveAnimationSignal<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Remove Animation".to_string()
     }
@@ -570,14 +586,14 @@ impl CommandTrait for RemoveAnimationSignal {
 }
 
 #[derive(Debug)]
-pub struct SetTrackEnabledCommand {
-    pub animation_player_handle: Handle<Node>,
-    pub animation_handle: Handle<Animation>,
+pub struct SetTrackEnabledCommand<N: Debug + 'static> {
+    pub animation_player_handle: Handle<N>,
+    pub animation_handle: Handle<Animation<Handle<N>>>,
     pub track: Uuid,
     pub enabled: bool,
 }
 
-impl SetTrackEnabledCommand {
+impl<N: Debug + 'static> SetTrackEnabledCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
         let track = fetch_animation(self.animation_player_handle, self.animation_handle, context)
@@ -592,7 +608,7 @@ impl SetTrackEnabledCommand {
     }
 }
 
-impl CommandTrait for SetTrackEnabledCommand {
+impl<N: Debug + 'static> CommandTrait for SetTrackEnabledCommand<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Set Track Enabled".to_string()
     }
@@ -607,14 +623,14 @@ impl CommandTrait for SetTrackEnabledCommand {
 }
 
 #[derive(Debug)]
-pub struct SetTrackTargetCommand {
-    pub animation_player_handle: Handle<Node>,
-    pub animation_handle: Handle<Animation>,
+pub struct SetTrackTargetCommand<N: Debug + 'static> {
+    pub animation_player_handle: Handle<N>,
+    pub animation_handle: Handle<Animation<Handle<N>>>,
     pub track: Uuid,
-    pub target: Handle<Node>,
+    pub target: Handle<N>,
 }
 
-impl SetTrackTargetCommand {
+impl<N: Debug + 'static> SetTrackTargetCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
         let track = fetch_animation(self.animation_player_handle, self.animation_handle, context)
@@ -629,7 +645,7 @@ impl SetTrackTargetCommand {
     }
 }
 
-impl CommandTrait for SetTrackTargetCommand {
+impl<N: Debug + 'static> CommandTrait for SetTrackTargetCommand<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Set Track Target".to_string()
     }
@@ -644,14 +660,14 @@ impl CommandTrait for SetTrackTargetCommand {
 }
 
 #[derive(Debug)]
-pub struct SetTrackBindingCommand {
-    pub animation_player_handle: Handle<Node>,
-    pub animation_handle: Handle<Animation>,
+pub struct SetTrackBindingCommand<N: Debug + 'static> {
+    pub animation_player_handle: Handle<N>,
+    pub animation_handle: Handle<Animation<Handle<N>>>,
     pub track: Uuid,
     pub binding: ValueBinding,
 }
 
-impl SetTrackBindingCommand {
+impl<N: Debug + 'static> SetTrackBindingCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
         let context = context.get_mut::<GameSceneContext>();
         let track = fetch_animation(self.animation_player_handle, self.animation_handle, context)
@@ -666,7 +682,7 @@ impl SetTrackBindingCommand {
     }
 }
 
-impl CommandTrait for SetTrackBindingCommand {
+impl<N: Debug + 'static> CommandTrait for SetTrackBindingCommand<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Set Track Binding".to_string()
     }

--- a/editor/src/animation/command/mod.rs
+++ b/editor/src/animation/command/mod.rs
@@ -16,10 +16,9 @@ use fyrox::{
         signal::AnimationSignal, track::Track, value::ValueBinding, Animation, AnimationContainer,
         RootMotionSettings,
     },
-    graph::BaseSceneGraph,
+    graph::{BaseSceneGraph, SceneGraphNode},
 };
 use std::{
-    any::TypeId,
     fmt::Debug,
     ops::{IndexMut, Range},
 };
@@ -38,15 +37,12 @@ pub fn fetch_animations_container<N: Debug + 'static>(
             .scene
             .graph
             .node_mut(ErasedHandle::from(handle).into())
-            .query_component_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>()
+            .component_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>()
             .unwrap()
     } else if let Some(ui) = context2.component_mut::<UiSceneContext>() {
         ui.ui
             .node_mut(ErasedHandle::from(handle).into())
-            .query_component_mut(TypeId::of::<
-                InheritableVariable<AnimationContainer<Handle<N>>>,
-            >())
-            .and_then(|c| c.downcast_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>())
+            .component_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>()
             .unwrap()
     } else {
         panic!("Unsupported container!")

--- a/editor/src/animation/mod.rs
+++ b/editor/src/animation/mod.rs
@@ -14,6 +14,8 @@ use crate::{
     scene::{commands::ChangeSelectionCommand, Selection},
     send_sync_message, Message,
 };
+use fyrox::graph::PrefabData;
+use fyrox::resource::model::AnimationSource;
 use fyrox::{
     asset::manager::ResourceManager,
     core::{
@@ -237,7 +239,7 @@ impl AnimationEditor {
         ));
     }
 
-    pub fn handle_ui_message<G, N>(
+    pub fn handle_ui_message<P, G, N>(
         &mut self,
         message: &UiMessage,
         editor_selection: &Selection,
@@ -248,8 +250,9 @@ impl AnimationEditor {
         sender: &MessageSender,
         node_overrides: &mut FxHashSet<Handle<N>>,
     ) where
-        G: SceneGraph<Node = N>,
-        N: SceneGraphNode<SceneGraph = G>,
+        P: PrefabData<Graph = G> + AnimationSource<Node = N, SceneGraph = G, Prefab = P>,
+        G: SceneGraph<Node = N, Prefab = P>,
+        N: SceneGraphNode<SceneGraph = G, ResourceData = P>,
     {
         let selection = fetch_selection(editor_selection);
 
@@ -514,7 +517,7 @@ impl AnimationEditor {
 
         // Revert state of nodes.
         for (handle, node) in preview_data.downcast::<PreviewModeData<N>>().unwrap().nodes {
-            assert!(node_overrides.remove(&handle));
+            node_overrides.remove(&handle);
             *graph.node_mut(handle) = node;
         }
     }

--- a/editor/src/animation/mod.rs
+++ b/editor/src/animation/mod.rs
@@ -564,7 +564,7 @@ impl AnimationEditor {
         N: SceneGraphNode<SceneGraph = G>,
     {
         // Leave preview mode before execution of any scene command.
-        if let Message::DoGameSceneCommand(_)
+        if let Message::DoCommand(_)
         | Message::UndoCurrentSceneCommand
         | Message::RedoCurrentSceneCommand = message
         {

--- a/editor/src/animation/mod.rs
+++ b/editor/src/animation/mod.rs
@@ -200,7 +200,7 @@ impl AnimationEditor {
                 scene,
                 &mut engine.user_interface,
                 selection.animation_player,
-                animation_player,
+                animation_player.animations(),
                 editor_selection,
                 game_scene,
                 &selection,
@@ -577,7 +577,7 @@ impl AnimationEditor {
             .and_then(|n| n.query_component_ref::<AnimationPlayer>())
         {
             self.toolbar.sync_to_model(
-                animation_player,
+                animation_player.animations(),
                 &selection,
                 scene,
                 &mut engine.user_interface,

--- a/editor/src/animation/mod.rs
+++ b/editor/src/animation/mod.rs
@@ -201,7 +201,6 @@ impl AnimationEditor {
                 &mut engine.user_interface,
                 selection.animation_player,
                 animation_player_ref.animations(),
-                editor_selection,
                 game_scene,
                 &selection,
             );
@@ -298,14 +297,13 @@ impl AnimationEditor {
                             });
                         }
                         RulerMessage::SelectSignal(id) => {
-                            sender.do_scene_command(ChangeSelectionCommand::new(
-                                Selection::new(AnimationSelection {
+                            sender.do_scene_command(ChangeSelectionCommand::new(Selection::new(
+                                AnimationSelection {
                                     animation_player: selection.animation_player,
                                     animation: selection.animation,
                                     entities: vec![SelectedEntity::Signal(*id)],
-                                }),
-                                editor_selection.clone(),
-                            ));
+                                },
+                            )));
                         }
                         _ => (),
                     }

--- a/editor/src/animation/selection.rs
+++ b/editor/src/animation/selection.rs
@@ -1,8 +1,9 @@
 use crate::scene::SelectionContainer;
 use fyrox::{
     core::{pool::Handle, uuid::Uuid},
-    scene::{animation::prelude::*, node::Node},
+    generic_animation::Animation,
 };
+use std::fmt::{Debug, Formatter};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SelectedEntity {
@@ -11,20 +12,66 @@ pub enum SelectedEntity {
     Signal(Uuid),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AnimationSelection {
-    pub animation_player: Handle<Node>,
-    pub animation: Handle<Animation>,
+#[derive(Eq)]
+pub struct AnimationSelection<N>
+where
+    N: 'static,
+{
+    pub animation_player: Handle<N>,
+    pub animation: Handle<Animation<Handle<N>>>,
     pub entities: Vec<SelectedEntity>,
 }
 
-impl SelectionContainer for AnimationSelection {
+impl<N> Debug for AnimationSelection<N>
+where
+    N: 'static,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} {:?}",
+            self.animation_player, self.animation, self.entities
+        )
+    }
+}
+
+impl<N> Clone for AnimationSelection<N>
+where
+    N: 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            animation_player: self.animation_player,
+            animation: self.animation,
+            entities: self.entities.clone(),
+        }
+    }
+}
+
+impl<N> PartialEq for AnimationSelection<N>
+where
+    N: 'static,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.entities == other.entities
+            && self.animation == other.animation
+            && self.animation_player == other.animation_player
+    }
+}
+
+impl<N> SelectionContainer for AnimationSelection<N>
+where
+    N: 'static,
+{
     fn len(&self) -> usize {
         self.entities.len()
     }
 }
 
-impl AnimationSelection {
+impl<N> AnimationSelection<N>
+where
+    N: 'static,
+{
     pub fn first_selected_track(&self) -> Option<Uuid> {
         self.entities.iter().find_map(|e| {
             if let SelectedEntity::Track(id) = e {

--- a/editor/src/animation/toolbar.rs
+++ b/editor/src/animation/toolbar.rs
@@ -835,7 +835,6 @@ impl Toolbar {
         ui: &mut UserInterface,
         animation_player_handle: Handle<Node>,
         animations: &AnimationContainer,
-        editor_selection: &Selection,
         game_scene: &GameScene,
         selection: &AnimationSelection,
     ) -> ToolbarAction {
@@ -857,14 +856,13 @@ impl Toolbar {
                     .node(item)
                     .user_data_cloned::<Handle<Animation>>()
                     .unwrap();
-                sender.do_scene_command(ChangeSelectionCommand::new(
-                    Selection::new(AnimationSelection {
+                sender.do_scene_command(ChangeSelectionCommand::new(Selection::new(
+                    AnimationSelection {
                         animation_player: animation_player_handle,
                         animation,
                         entities: vec![],
-                    }),
-                    editor_selection.clone(),
-                ));
+                    },
+                )));
                 return ToolbarAction::SelectAnimation(animation);
             }
         } else if let Some(ButtonMessage::Click) = message.data() {
@@ -885,14 +883,13 @@ impl Toolbar {
             } else if message.destination() == self.remove_current_animation {
                 if animations.try_get(selection.animation).is_some() {
                     let group = vec![
-                        Command::new(ChangeSelectionCommand::new(
-                            Selection::new(AnimationSelection {
+                        Command::new(ChangeSelectionCommand::new(Selection::new(
+                            AnimationSelection {
                                 animation_player: animation_player_handle,
                                 animation: Default::default(),
                                 entities: vec![],
-                            }),
-                            editor_selection.clone(),
-                        )),
+                            },
+                        ))),
                         Command::new(RemoveAnimationCommand::new(
                             animation_player_handle,
                             selection.animation,

--- a/editor/src/animation/toolbar.rs
+++ b/editor/src/animation/toolbar.rs
@@ -1031,7 +1031,7 @@ impl Toolbar {
                 && message.direction() == MessageDirection::FromWidget
             {
                 if let Some(first) = selected_nodes.first() {
-                    self.selected_import_root = (*first).into();
+                    self.selected_import_root = *first;
 
                     ui.send_message(WindowMessage::open_modal(
                         self.import_file_selector,

--- a/editor/src/animation/track.rs
+++ b/editor/src/animation/track.rs
@@ -831,7 +831,7 @@ impl TrackList {
         } else if let Some(NodeSelectorMessage::Selection(node_selection)) = message.data() {
             if message.destination() == self.node_selector {
                 if let Some(first) = node_selection.first() {
-                    self.selected_node = (*first).into();
+                    self.selected_node = *first;
 
                     match self.property_binding_mode {
                         PropertyBindingMode::Generic => {

--- a/editor/src/animation/track.rs
+++ b/editor/src/animation/track.rs
@@ -951,10 +951,7 @@ impl TrackList {
                         .collect(),
                 });
 
-                sender.do_scene_command(ChangeSelectionCommand::new(
-                    new_selection,
-                    Selection::new(selection.clone()),
-                ));
+                sender.do_scene_command(ChangeSelectionCommand::new(new_selection));
             }
         } else if let Some(MenuItemMessage::Click) = message.data() {
             if message.destination() == self.context_menu.remove_track {
@@ -966,7 +963,6 @@ impl TrackList {
                             // Just reset inner selection.
                             entities: vec![],
                         }),
-                        Selection::new(selection.clone()),
                     ))];
 
                     for entity in selection.entities.iter() {

--- a/editor/src/audio/mod.rs
+++ b/editor/src/audio/mod.rs
@@ -262,7 +262,6 @@ impl AudioPanel {
                 if let Some(selection) = editor_selection.as_audio_bus() {
                     let mut commands = vec![Command::new(ChangeSelectionCommand::new(
                         Selection::new_empty(),
-                        editor_selection.clone(),
                     ))];
 
                     for &bus in &selection.buses {
@@ -286,12 +285,11 @@ impl AudioPanel {
                     ui,
                 );
 
-                sender.do_scene_command(ChangeSelectionCommand::new(
-                    Selection::new(AudioBusSelection {
+                sender.do_scene_command(ChangeSelectionCommand::new(Selection::new(
+                    AudioBusSelection {
                         buses: vec![effect],
-                    }),
-                    editor_selection.clone(),
-                ))
+                    },
+                )))
             }
         } else if let Some(AudioBusViewMessage::ChangeParent(new_parent)) = message.data() {
             if message.direction() == MessageDirection::FromWidget {

--- a/editor/src/audio/preview.rs
+++ b/editor/src/audio/preview.rs
@@ -177,7 +177,7 @@ impl AudioPreviewPanel {
         game_scene: &mut GameScene,
         engine: &mut Engine,
     ) {
-        if let Message::DoGameSceneCommand(_)
+        if let Message::DoCommand(_)
         | Message::UndoCurrentSceneCommand
         | Message::RedoCurrentSceneCommand = message
         {

--- a/editor/src/camera/panel.rs
+++ b/editor/src/camera/panel.rs
@@ -70,7 +70,7 @@ impl CameraPreviewControlPanel {
         game_scene: &mut GameScene,
         engine: &mut Engine,
     ) {
-        if let Message::DoGameSceneCommand(_)
+        if let Message::DoCommand(_)
         | Message::UndoCurrentSceneCommand
         | Message::RedoCurrentSceneCommand = message
         {

--- a/editor/src/interaction/move_mode.rs
+++ b/editor/src/interaction/move_mode.rs
@@ -411,10 +411,7 @@ impl InteractionMode for MoveInteractionMode {
 
             if &new_selection != editor_selection {
                 self.message_sender
-                    .do_scene_command(ChangeSelectionCommand::new(
-                        new_selection,
-                        editor_selection.clone(),
-                    ));
+                    .do_scene_command(ChangeSelectionCommand::new(new_selection));
             }
         }
     }

--- a/editor/src/interaction/move_mode.rs
+++ b/editor/src/interaction/move_mode.rs
@@ -378,7 +378,7 @@ impl InteractionMode for MoveInteractionMode {
 
                 // Commit changes.
                 self.message_sender
-                    .send(Message::DoGameSceneCommand(Command::new(commands)));
+                    .send(Message::DoCommand(Command::new(commands)));
             }
         } else {
             let new_selection = game_scene

--- a/editor/src/interaction/navmesh/mod.rs
+++ b/editor/src/interaction/navmesh/mod.rs
@@ -320,10 +320,7 @@ impl InteractionMode for EditNavmeshMode {
 
                 if &new_selection != editor_selection {
                     self.message_sender
-                        .do_scene_command(ChangeSelectionCommand::new(
-                            new_selection,
-                            editor_selection.clone(),
-                        ));
+                        .do_scene_command(ChangeSelectionCommand::new(new_selection));
                 }
             }
         }
@@ -464,12 +461,9 @@ impl InteractionMode for EditNavmeshMode {
 
                             // Discard selection.
                             self.message_sender
-                                .do_scene_command(ChangeSelectionCommand::new(
-                                    Selection::new(NavmeshSelection::empty(
-                                        selection.navmesh_node(),
-                                    )),
-                                    editor_selection.clone(),
-                                ));
+                                .do_scene_command(ChangeSelectionCommand::new(Selection::new(
+                                    NavmeshSelection::empty(selection.navmesh_node()),
+                                )));
                         }
                     }
                 }
@@ -622,10 +616,9 @@ impl InteractionMode for EditNavmeshMode {
                             )));
                         }
 
-                        commands.push(Command::new(ChangeSelectionCommand::new(
-                            Selection::new(NavmeshSelection::empty(selection.navmesh_node())),
-                            editor_selection.clone(),
-                        )));
+                        commands.push(Command::new(ChangeSelectionCommand::new(Selection::new(
+                            NavmeshSelection::empty(selection.navmesh_node()),
+                        ))));
 
                         self.message_sender
                             .do_scene_command(CommandGroup::from(commands));
@@ -650,10 +643,9 @@ impl InteractionMode for EditNavmeshMode {
                         );
 
                         self.message_sender
-                            .do_scene_command(ChangeSelectionCommand::new(
-                                Selection::new(selection),
-                                editor_selection.clone(),
-                            ));
+                            .do_scene_command(ChangeSelectionCommand::new(Selection::new(
+                                selection,
+                            )));
                     }
 
                     true

--- a/editor/src/interaction/rotate_mode.rs
+++ b/editor/src/interaction/rotate_mode.rs
@@ -167,10 +167,7 @@ impl InteractionMode for RotateInteractionMode {
 
             if &new_selection != editor_selection {
                 self.message_sender
-                    .do_scene_command(ChangeSelectionCommand::new(
-                        new_selection,
-                        editor_selection.clone(),
-                    ));
+                    .do_scene_command(ChangeSelectionCommand::new(new_selection));
             }
         }
     }

--- a/editor/src/interaction/scale_mode.rs
+++ b/editor/src/interaction/scale_mode.rs
@@ -159,10 +159,7 @@ impl InteractionMode for ScaleInteractionMode {
 
             if &new_selection != editor_selection {
                 self.message_sender
-                    .do_scene_command(ChangeSelectionCommand::new(
-                        new_selection,
-                        editor_selection.clone(),
-                    ));
+                    .do_scene_command(ChangeSelectionCommand::new(new_selection));
             }
         }
     }

--- a/editor/src/interaction/select_mode.rs
+++ b/editor/src/interaction/select_mode.rs
@@ -135,10 +135,7 @@ impl InteractionMode for SelectInteractionMode {
 
         if &new_selection != editor_selection {
             self.message_sender
-                .do_scene_command(ChangeSelectionCommand::new(
-                    new_selection,
-                    editor_selection.clone(),
-                ));
+                .do_scene_command(ChangeSelectionCommand::new(new_selection));
         }
         engine
             .user_interface

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1512,7 +1512,7 @@ impl Editor {
                 self.animation_editor.sync_to_model(
                     &current_scene_entry.selection,
                     &mut engine.user_interface,
-                    &mut engine.scenes[game_scene.scene].graph,
+                    &engine.scenes[game_scene.scene].graph,
                 );
                 self.absm_editor
                     .sync_to_model(&current_scene_entry.selection, game_scene, engine);
@@ -1545,7 +1545,7 @@ impl Editor {
                 self.animation_editor.sync_to_model(
                     &current_scene_entry.selection,
                     &mut engine.user_interface,
-                    &mut ui_scene.ui,
+                    &ui_scene.ui,
                 );
                 self.world_viewer.sync_to_model(
                     &UiSceneWorldViewerDataProvider {

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1086,10 +1086,7 @@ impl Editor {
                             } else if let Some(selection) = entry.selection.as_ui() {
                                 if let Some(ui_scene) = entry.controller.downcast_mut::<UiScene>() {
                                     sender.send(Message::DoUiSceneCommand(
-                                        selection.make_deletion_command(
-                                            &ui_scene.ui,
-                                            entry.selection.clone(),
-                                        ),
+                                        selection.make_deletion_command(&ui_scene.ui),
                                     ));
                                 }
                             }
@@ -1196,7 +1193,6 @@ impl Editor {
                     message,
                     &mut engine.user_interface,
                     &mut engine.scenes[game_scene.scene].graph,
-                    &current_scene_entry.selection,
                     game_scene,
                     &self.message_sender,
                 );

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1191,6 +1191,7 @@ impl Editor {
                     &mut engine.user_interface,
                     &engine.resource_manager,
                     &self.message_sender,
+                    game_scene.graph_switches.node_overrides.as_mut().unwrap(),
                 );
                 self.ragdoll_wizard.handle_ui_message(
                     message,
@@ -1300,6 +1301,7 @@ impl Editor {
                     &mut engine.user_interface,
                     &engine.resource_manager,
                     &self.message_sender,
+                    &mut Default::default(), // TODO
                 );
                 self.world_viewer.handle_ui_message(
                     message,
@@ -1672,12 +1674,16 @@ impl Editor {
                 self.animation_editor.try_leave_preview_mode(
                     &mut engine.scenes[game_scene.scene].graph,
                     &engine.user_interface,
+                    game_scene.graph_switches.node_overrides.as_mut().unwrap(),
                 );
                 self.absm_editor
                     .try_leave_preview_mode(&entry.selection, game_scene, engine);
             } else if let Some(ui_scene) = entry.controller.downcast_mut::<UiScene>() {
-                self.animation_editor
-                    .try_leave_preview_mode(&mut ui_scene.ui, &self.engine.user_interface);
+                self.animation_editor.try_leave_preview_mode(
+                    &mut ui_scene.ui,
+                    &self.engine.user_interface,
+                    &mut Default::default(), // TODO
+                );
             }
         }
     }
@@ -2157,6 +2163,7 @@ impl Editor {
                             &message,
                             &mut self.engine.scenes[game_scene.scene].graph,
                             &self.engine.user_interface,
+                            game_scene.graph_switches.node_overrides.as_mut().unwrap(),
                         );
                         self.absm_editor.handle_message(
                             &message,
@@ -2169,6 +2176,7 @@ impl Editor {
                             &message,
                             &mut ui_scene.ui,
                             &self.engine.user_interface,
+                            &mut Default::default(), // TODO
                         );
                     }
 

--- a/editor/src/message.rs
+++ b/editor/src/message.rs
@@ -14,8 +14,7 @@ use std::{path::PathBuf, sync::mpsc::Sender};
 
 #[derive(Debug)]
 pub enum Message {
-    DoGameSceneCommand(Command),
-    DoUiSceneCommand(Command),
+    DoCommand(Command),
     UndoCurrentSceneCommand,
     RedoCurrentSceneCommand,
     ClearCurrentSceneCommandStack,
@@ -89,14 +88,14 @@ impl MessageSender {
     where
         C: CommandTrait,
     {
-        self.send(Message::DoGameSceneCommand(Command::new(cmd)))
+        self.send(Message::DoCommand(Command::new(cmd)))
     }
 
     pub fn do_ui_scene_command<C>(&self, cmd: C)
     where
         C: CommandTrait,
     {
-        self.send(Message::DoUiSceneCommand(Command::new(cmd)))
+        self.send(Message::DoCommand(Command::new(cmd)))
     }
 
     pub fn send(&self, message: Message) {

--- a/editor/src/particle.rs
+++ b/editor/src/particle.rs
@@ -205,7 +205,7 @@ impl ParticleSystemPreviewControlPanel {
         game_scene: &mut GameScene,
         engine: &mut Engine,
     ) {
-        if let Message::DoGameSceneCommand(_)
+        if let Message::DoCommand(_)
         | Message::UndoCurrentSceneCommand
         | Message::RedoCurrentSceneCommand = message
         {

--- a/editor/src/scene/commands/mod.rs
+++ b/editor/src/scene/commands/mod.rs
@@ -12,10 +12,10 @@ use fyrox::{
     asset::manager::ResourceManager,
     core::{log::Log, pool::Handle, reflect::prelude::*, type_traits::prelude::*},
     engine::SerializationContext,
-    graph::{BaseSceneGraph, SceneGraphNode},
+    graph::{AbstractSceneGraph, BaseSceneGraph, SceneGraphNode},
     scene::{graph::SubGraph, node::Node, Scene},
 };
-use std::sync::Arc;
+use std::{any::Any, sync::Arc};
 
 pub mod effect;
 pub mod graph;

--- a/editor/src/scene/commands/mod.rs
+++ b/editor/src/scene/commands/mod.rs
@@ -12,10 +12,10 @@ use fyrox::{
     asset::manager::ResourceManager,
     core::{log::Log, pool::Handle, reflect::prelude::*, type_traits::prelude::*},
     engine::SerializationContext,
-    graph::{AbstractSceneGraph, BaseSceneGraph, SceneGraphNode},
+    graph::{BaseSceneGraph, SceneGraphNode},
     scene::{graph::SubGraph, node::Node, Scene},
 };
-use std::{any::Any, sync::Arc};
+use std::sync::Arc;
 
 pub mod effect;
 pub mod graph;

--- a/editor/src/scene/container.rs
+++ b/editor/src/scene/container.rs
@@ -1,3 +1,4 @@
+use crate::command::CommandStack;
 use crate::{
     highlight::HighlightRenderPass,
     interaction::{
@@ -30,6 +31,7 @@ pub struct EditorSceneEntry {
     pub has_unsaved_changes: bool,
     pub path: Option<PathBuf>,
     pub selection: Selection,
+    pub command_stack: CommandStack,
     pub controller: Box<dyn SceneController>,
     pub interaction_modes: InteractionModeContainer,
     pub current_interaction_mode: Option<Uuid>,
@@ -103,6 +105,7 @@ impl EditorSceneEntry {
             id: Uuid::new_v4(),
             path,
             selection: Default::default(),
+            command_stack: CommandStack::new(false),
         };
 
         entry.set_interaction_mode(engine, Some(MoveInteractionMode::type_uuid()));
@@ -136,6 +139,7 @@ impl EditorSceneEntry {
             id: Uuid::new_v4(),
             path,
             selection: Default::default(),
+            command_stack: CommandStack::new(false),
         };
 
         entry.set_interaction_mode(engine, Some(UiSelectInteractionMode::type_uuid()));

--- a/editor/src/scene/container.rs
+++ b/editor/src/scene/container.rs
@@ -363,7 +363,7 @@ impl EditorSceneEntry {
         settings: &Settings,
     ) {
         self.controller
-            .on_drop(handle, screen_bounds, engine, settings, &self.selection)
+            .on_drop(handle, screen_bounds, engine, settings)
     }
 }
 

--- a/editor/src/scene/controller.rs
+++ b/editor/src/scene/controller.rs
@@ -1,3 +1,4 @@
+use crate::command::{Command, CommandStack};
 use crate::{
     scene::Selection,
     settings::{keys::KeyBindings, Settings},
@@ -88,11 +89,34 @@ pub trait SceneController: 'static {
         engine: &mut Engine,
     ) -> Result<String, String>;
 
-    fn undo(&mut self, selection: &mut Selection, engine: &mut Engine);
+    fn do_command(
+        &mut self,
+        command_stack: &mut CommandStack,
+        command: Command,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    );
 
-    fn redo(&mut self, selection: &mut Selection, engine: &mut Engine);
+    fn undo(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    );
 
-    fn clear_command_stack(&mut self, selection: &mut Selection, engine: &mut Engine);
+    fn redo(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    );
+
+    fn clear_command_stack(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    );
 
     fn on_before_render(&mut self, editor_selection: &Selection, engine: &mut Engine);
 
@@ -110,14 +134,22 @@ pub trait SceneController: 'static {
 
     fn is_interacting(&self) -> bool;
 
-    fn on_destroy(&mut self, engine: &mut Engine, selection: &mut Selection);
+    fn on_destroy(
+        &mut self,
+        command_stack: &mut CommandStack,
+        engine: &mut Engine,
+        selection: &mut Selection,
+    );
 
     fn on_message(&mut self, message: &Message, selection: &Selection, engine: &mut Engine)
         -> bool;
 
-    fn top_command_index(&self) -> Option<usize>;
-
-    fn command_names(&mut self, selection: &mut Selection, engine: &mut Engine) -> Vec<String>;
+    fn command_names(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    ) -> Vec<String>;
 
     fn first_selected_entity(
         &self,

--- a/editor/src/scene/controller.rs
+++ b/editor/src/scene/controller.rs
@@ -75,7 +75,6 @@ pub trait SceneController: 'static {
         screen_bounds: Rect<f32>,
         engine: &mut Engine,
         settings: &Settings,
-        editor_selection: &Selection,
     );
 
     fn render_target(&self, engine: &Engine) -> Option<TextureResource>;

--- a/editor/src/scene/dialog.rs
+++ b/editor/src/scene/dialog.rs
@@ -178,7 +178,7 @@ impl NodeRemovalDialog {
                     MessageDirection::ToWidget,
                 ));
 
-                sender.send(Message::DoGameSceneCommand(make_delete_selection_command(
+                sender.send(Message::DoCommand(make_delete_selection_command(
                     editor_selection,
                     game_scene,
                     engine,

--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -399,15 +399,15 @@ impl GameScene {
         }
     }
 
-    fn select_object(&mut self, handle: ErasedHandle, engine: &Engine, selection: &Selection) {
+    fn select_object(&mut self, handle: ErasedHandle, engine: &Engine) {
         if engine.scenes[self.scene]
             .graph
             .is_valid_handle(handle.into())
         {
-            self.sender.do_scene_command(ChangeSelectionCommand::new(
-                Selection::new(GraphSelection::single_or_empty(handle.into())),
-                selection.clone(),
-            ))
+            self.sender
+                .do_scene_command(ChangeSelectionCommand::new(Selection::new(
+                    GraphSelection::single_or_empty(handle.into()),
+                )))
         }
     }
 
@@ -613,7 +613,6 @@ impl SceneController for GameScene {
         screen_bounds: Rect<f32>,
         engine: &mut Engine,
         settings: &Settings,
-        editor_selection: &Selection,
     ) {
         if handle.is_none() {
             return;
@@ -635,10 +634,9 @@ impl SceneController for GameScene {
                     let group = vec![
                         Command::new(AddModelCommand::new(sub_graph)),
                         // We also want to select newly instantiated model.
-                        Command::new(ChangeSelectionCommand::new(
-                            Selection::new(GraphSelection::single_or_empty(preview.instance)),
-                            editor_selection.clone(),
-                        )),
+                        Command::new(ChangeSelectionCommand::new(Selection::new(
+                            GraphSelection::single_or_empty(preview.instance),
+                        ))),
                     ];
 
                     self.sender.do_scene_command(CommandGroup::from(group));
@@ -873,7 +871,7 @@ impl SceneController for GameScene {
                 false
             }
             Message::SelectObject { handle } => {
-                self.select_object(*handle, engine, selection);
+                self.select_object(*handle, engine);
                 false
             }
             Message::FocusObject(handle) => {

--- a/editor/src/scene/selector.rs
+++ b/editor/src/scene/selector.rs
@@ -1,5 +1,6 @@
 use crate::utils::make_node_name;
 use fyrox::graph::BaseSceneGraph;
+use fyrox::graph::{SceneGraph, SceneGraphNode};
 use fyrox::{
     core::{
         algebra::Vector2, parking_lot::Mutex, pool::ErasedHandle, pool::Handle,
@@ -22,7 +23,6 @@ use fyrox::{
         window::{Window, WindowBuilder, WindowMessage},
         BuildContext, Control, HorizontalAlignment, Orientation, Thickness, UiNode, UserInterface,
     },
-    scene::{graph::Graph, node::Node},
 };
 use std::{
     ops::{Deref, DerefMut},
@@ -38,15 +38,15 @@ pub struct HierarchyNode {
 }
 
 impl HierarchyNode {
-    pub fn from_scene_node(
-        node_handle: Handle<Node>,
-        ignored_node: Handle<Node>,
-        graph: &Graph,
-    ) -> Self {
-        let node = &graph[node_handle];
+    pub fn from_scene_node<G, N>(node_handle: Handle<N>, ignored_node: Handle<N>, graph: &G) -> Self
+    where
+        G: SceneGraph<Node = N>,
+        N: SceneGraphNode<SceneGraph = G>,
+    {
+        let node = &graph.node(node_handle);
 
         Self {
-            name: node.name_owned(),
+            name: node.name().to_string(),
             handle: node_handle.into(),
             children: node
                 .children()

--- a/editor/src/scene/settings/mod.rs
+++ b/editor/src/scene/settings/mod.rs
@@ -132,7 +132,7 @@ impl SceneSettingsWindow {
                 if let Some(command) = make_command(property_changed, |ctx| {
                     ctx.get_mut::<GameSceneContext>().scene as &mut dyn Reflect
                 }) {
-                    sender.send(Message::DoGameSceneCommand(command));
+                    sender.send(Message::DoCommand(command));
                 }
             }
         }

--- a/editor/src/ui_scene/interaction/mod.rs
+++ b/editor/src/ui_scene/interaction/mod.rs
@@ -125,10 +125,7 @@ impl InteractionMode for UiSelectInteractionMode {
 
         if &new_selection != editor_selection {
             self.message_sender
-                .do_ui_scene_command(ChangeSelectionCommand::new(
-                    new_selection,
-                    editor_selection.clone(),
-                ));
+                .do_ui_scene_command(ChangeSelectionCommand::new(new_selection));
         }
         engine
             .user_interface

--- a/editor/src/ui_scene/interaction/move_mode.rs
+++ b/editor/src/ui_scene/interaction/move_mode.rs
@@ -131,10 +131,10 @@ impl InteractionMode for MoveWidgetsInteractionMode {
                     Default::default()
                 };
                 new_selection.insert_or_exclude(picked);
-                self.sender.do_ui_scene_command(ChangeSelectionCommand::new(
-                    Selection::new(new_selection),
-                    editor_selection.clone(),
-                ));
+                self.sender
+                    .do_ui_scene_command(ChangeSelectionCommand::new(Selection::new(
+                        new_selection,
+                    )));
             }
         }
     }

--- a/editor/src/ui_scene/menu.rs
+++ b/editor/src/ui_scene/menu.rs
@@ -125,7 +125,7 @@ impl WidgetContextMenu {
             if let Some(MenuItemMessage::Click) = message.data::<MenuItemMessage>() {
                 if message.destination() == self.delete_selection {
                     if let Some(ui_selection) = editor_selection.as_ui() {
-                        sender.send(Message::DoUiSceneCommand(
+                        sender.send(Message::DoCommand(
                             ui_selection.make_deletion_command(&ui_scene.ui),
                         ));
                     }

--- a/editor/src/ui_scene/menu.rs
+++ b/editor/src/ui_scene/menu.rs
@@ -126,8 +126,7 @@ impl WidgetContextMenu {
                 if message.destination() == self.delete_selection {
                     if let Some(ui_selection) = editor_selection.as_ui() {
                         sender.send(Message::DoUiSceneCommand(
-                            ui_selection
-                                .make_deletion_command(&ui_scene.ui, editor_selection.clone()),
+                            ui_selection.make_deletion_command(&ui_scene.ui),
                         ));
                     }
                 } else if message.destination() == self.copy_selection {

--- a/editor/src/ui_scene/mod.rs
+++ b/editor/src/ui_scene/mod.rs
@@ -96,13 +96,12 @@ impl UiScene {
         self.ui.invalidate_layout();
     }
 
-    fn select_object(&mut self, handle: ErasedHandle, selection: &Selection) {
+    fn select_object(&mut self, handle: ErasedHandle) {
         if self.ui.try_get(handle.into()).is_some() {
             self.message_sender
-                .do_ui_scene_command(ChangeSelectionCommand::new(
-                    Selection::new(UiSelection::single_or_empty(handle.into())),
-                    selection.clone(),
-                ))
+                .do_ui_scene_command(ChangeSelectionCommand::new(Selection::new(
+                    UiSelection::single_or_empty(handle.into()),
+                )))
         }
     }
 }
@@ -222,7 +221,6 @@ impl SceneController for UiScene {
         _screen_bounds: Rect<f32>,
         _engine: &mut Engine,
         _settings: &Settings,
-        editor_selection: &Selection,
     ) {
         if handle.is_none() {
             return;
@@ -236,10 +234,9 @@ impl SceneController for UiScene {
             let group = vec![
                 Command::new(AddUiPrefabCommand::new(sub_graph)),
                 // We also want to select newly instantiated model.
-                Command::new(ChangeSelectionCommand::new(
-                    Selection::new(UiSelection::single_or_empty(preview.instance)),
-                    editor_selection.clone(),
-                )),
+                Command::new(ChangeSelectionCommand::new(Selection::new(
+                    UiSelection::single_or_empty(preview.instance),
+                ))),
             ];
 
             self.message_sender
@@ -408,12 +405,12 @@ impl SceneController for UiScene {
     fn on_message(
         &mut self,
         message: &Message,
-        selection: &Selection,
+        _selection: &Selection,
         engine: &mut Engine,
     ) -> bool {
         match message {
             Message::SelectObject { handle } => {
-                self.select_object(*handle, selection);
+                self.select_object(*handle);
             }
             Message::SyncNodeHandleName { view, handle } => {
                 engine

--- a/editor/src/ui_scene/mod.rs
+++ b/editor/src/ui_scene/mod.rs
@@ -60,7 +60,6 @@ pub struct PreviewInstance {
 pub struct UiScene {
     pub ui: UserInterface,
     pub render_target: TextureResource,
-    pub command_stack: CommandStack,
     pub message_sender: MessageSender,
     pub clipboard: Clipboard,
     pub preview_instance: Option<PreviewInstance>,
@@ -71,30 +70,10 @@ impl UiScene {
         Self {
             ui,
             render_target: TextureResource::new_render_target(200, 200),
-            command_stack: CommandStack::new(false),
             message_sender,
             clipboard: Default::default(),
             preview_instance: None,
         }
-    }
-
-    pub fn do_command(
-        &mut self,
-        command: Command,
-        selection: &mut Selection,
-        _engine: &mut Engine,
-    ) {
-        UiSceneContext::exec(
-            &mut self.ui,
-            selection,
-            self.message_sender.clone(),
-            &mut self.clipboard,
-            |ctx| {
-                self.command_stack.do_command(command, ctx);
-            },
-        );
-
-        self.ui.invalidate_layout();
     }
 
     fn select_object(&mut self, handle: ErasedHandle) {
@@ -283,37 +262,72 @@ impl SceneController for UiScene {
         }
     }
 
-    fn undo(&mut self, selection: &mut Selection, _engine: &mut Engine) {
+    fn do_command(
+        &mut self,
+        command_stack: &mut CommandStack,
+        command: Command,
+        selection: &mut Selection,
+        _engine: &mut Engine,
+    ) {
         UiSceneContext::exec(
             &mut self.ui,
             selection,
             self.message_sender.clone(),
             &mut self.clipboard,
-            |ctx| self.command_stack.undo(ctx),
+            |ctx| {
+                command_stack.do_command(command, ctx);
+            },
         );
 
         self.ui.invalidate_layout();
     }
 
-    fn redo(&mut self, selection: &mut Selection, _engine: &mut Engine) {
+    fn undo(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        _engine: &mut Engine,
+    ) {
         UiSceneContext::exec(
             &mut self.ui,
             selection,
             self.message_sender.clone(),
             &mut self.clipboard,
-            |ctx| self.command_stack.redo(ctx),
+            |ctx| command_stack.undo(ctx),
         );
 
         self.ui.invalidate_layout();
     }
 
-    fn clear_command_stack(&mut self, selection: &mut Selection, _engine: &mut Engine) {
+    fn redo(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        _engine: &mut Engine,
+    ) {
         UiSceneContext::exec(
             &mut self.ui,
             selection,
             self.message_sender.clone(),
             &mut self.clipboard,
-            |ctx| self.command_stack.clear(ctx),
+            |ctx| command_stack.redo(ctx),
+        );
+
+        self.ui.invalidate_layout();
+    }
+
+    fn clear_command_stack(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        _engine: &mut Engine,
+    ) {
+        UiSceneContext::exec(
+            &mut self.ui,
+            selection,
+            self.message_sender.clone(),
+            &mut self.clipboard,
+            |ctx| command_stack.clear(ctx),
         );
 
         self.ui.invalidate_layout();
@@ -393,13 +407,18 @@ impl SceneController for UiScene {
         false
     }
 
-    fn on_destroy(&mut self, _engine: &mut Engine, selection: &mut Selection) {
+    fn on_destroy(
+        &mut self,
+        command_stack: &mut CommandStack,
+        _engine: &mut Engine,
+        selection: &mut Selection,
+    ) {
         UiSceneContext::exec(
             &mut self.ui,
             selection,
             self.message_sender.clone(),
             &mut self.clipboard,
-            |ctx| self.command_stack.clear(ctx),
+            |ctx| command_stack.clear(ctx),
         );
     }
 
@@ -439,12 +458,13 @@ impl SceneController for UiScene {
         false
     }
 
-    fn top_command_index(&self) -> Option<usize> {
-        self.command_stack.top
-    }
-
-    fn command_names(&mut self, selection: &mut Selection, _engine: &mut Engine) -> Vec<String> {
-        self.command_stack
+    fn command_names(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        _engine: &mut Engine,
+    ) -> Vec<String> {
+        command_stack
             .commands
             .iter_mut()
             .map(|c| {
@@ -520,7 +540,7 @@ impl SceneController for UiScene {
             }
         } else if group.len() == 1 {
             self.message_sender
-                .send(Message::DoUiSceneCommand(group.into_iter().next().unwrap()))
+                .send(Message::DoCommand(group.into_iter().next().unwrap()))
         } else {
             self.message_sender
                 .do_ui_scene_command(CommandGroup::from(group));

--- a/editor/src/ui_scene/selection.rs
+++ b/editor/src/ui_scene/selection.rs
@@ -1,6 +1,6 @@
 use crate::{
     command::{Command, CommandGroup},
-    scene::{commands::ChangeSelectionCommand, Selection, SelectionContainer},
+    scene::{commands::ChangeSelectionCommand, SelectionContainer},
     ui_scene::commands::graph::DeleteWidgetsSubGraphCommand,
 };
 use fyrox::{
@@ -86,10 +86,10 @@ impl UiSelection {
         root_widgets
     }
 
-    pub fn make_deletion_command(&self, ui: &UserInterface, old_selection: Selection) -> Command {
+    pub fn make_deletion_command(&self, ui: &UserInterface) -> Command {
         // Change selection first.
         let mut command_group = CommandGroup::from(vec![Command::new(
-            ChangeSelectionCommand::new(Default::default(), old_selection),
+            ChangeSelectionCommand::new(Default::default()),
         )]);
 
         let root_nodes = self.root_widgets(ui);

--- a/editor/src/ui_scene/utils.rs
+++ b/editor/src/ui_scene/utils.rs
@@ -203,10 +203,9 @@ impl<'a> WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'a> {
                     Command::new(AddUiPrefabCommand::new(sub_graph)),
                     Command::new(LinkWidgetsCommand::new(instance, node.into())),
                     // We also want to select newly instantiated model.
-                    Command::new(ChangeSelectionCommand::new(
-                        Selection::new(UiSelection::single_or_empty(instance)),
-                        self.selection.clone(),
-                    )),
+                    Command::new(ChangeSelectionCommand::new(Selection::new(
+                        UiSelection::single_or_empty(instance),
+                    ))),
                 ];
 
                 self.sender.do_ui_scene_command(CommandGroup::from(group));
@@ -231,10 +230,8 @@ impl<'a> WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'a> {
         }
 
         if &new_selection != self.selection {
-            self.sender.do_ui_scene_command(ChangeSelectionCommand::new(
-                new_selection,
-                self.selection.clone(),
-            ));
+            self.sender
+                .do_ui_scene_command(ChangeSelectionCommand::new(new_selection));
         }
     }
 }

--- a/editor/src/utils/ragdoll.rs
+++ b/editor/src/utils/ragdoll.rs
@@ -457,7 +457,6 @@ impl RagdollPreset {
     pub fn create_and_send_command(
         &self,
         graph: &mut Graph,
-        editor_selection: &Selection,
         game_scene: &GameScene,
         sender: &MessageSender,
     ) {
@@ -977,10 +976,9 @@ impl RagdollPreset {
         let group = vec![
             Command::new(AddModelCommand::new(sub_graph)),
             // We also want to select newly instantiated model.
-            Command::new(ChangeSelectionCommand::new(
-                Selection::new(GraphSelection::single_or_empty(ragdoll)),
-                editor_selection.clone(),
-            )),
+            Command::new(ChangeSelectionCommand::new(Selection::new(
+                GraphSelection::single_or_empty(ragdoll),
+            ))),
         ];
 
         sender.do_scene_command(CommandGroup::from(group).with_custom_name("Generate Ragdoll"));
@@ -1116,7 +1114,6 @@ impl RagdollWizard {
         message: &UiMessage,
         ui: &mut UserInterface,
         graph: &mut Graph,
-        editor_selection: &Selection,
         game_scene: &GameScene,
         sender: &MessageSender,
     ) {
@@ -1135,7 +1132,7 @@ impl RagdollWizard {
         } else if let Some(ButtonMessage::Click) = message.data() {
             if message.destination() == self.ok {
                 self.preset
-                    .create_and_send_command(graph, editor_selection, game_scene, sender);
+                    .create_and_send_command(graph, game_scene, sender);
 
                 ui.send_message(WindowMessage::close(
                     self.window,

--- a/editor/src/world/graph/menu.rs
+++ b/editor/src/world/graph/menu.rs
@@ -204,7 +204,7 @@ impl SceneNodeContextMenu {
                     {
                         sender.send(Message::OpenNodeRemovalDialog);
                     } else {
-                        sender.send(Message::DoGameSceneCommand(make_delete_selection_command(
+                        sender.send(Message::DoCommand(make_delete_selection_command(
                             editor_selection,
                             game_scene,
                             engine,

--- a/editor/src/world/graph/mod.rs
+++ b/editor/src/world/graph/mod.rs
@@ -223,10 +223,9 @@ impl<'a> WorldViewerDataProvider for EditorSceneWrapper<'a> {
                 let group = vec![
                     Command::new(AddModelCommand::new(sub_graph)),
                     Command::new(LinkNodesCommand::new(instance, node.into())),
-                    Command::new(ChangeSelectionCommand::new(
-                        Selection::new(GraphSelection::single_or_empty(instance)),
-                        self.selection.clone(),
-                    )),
+                    Command::new(ChangeSelectionCommand::new(Selection::new(
+                        GraphSelection::single_or_empty(instance),
+                    ))),
                 ];
 
                 self.sender.do_scene_command(CommandGroup::from(group));
@@ -255,10 +254,8 @@ impl<'a> WorldViewerDataProvider for EditorSceneWrapper<'a> {
         }
 
         if &new_selection != self.selection {
-            self.sender.do_scene_command(ChangeSelectionCommand::new(
-                new_selection,
-                self.selection.clone(),
-            ));
+            self.sender
+                .do_scene_command(ChangeSelectionCommand::new(new_selection));
         }
     }
 }

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -12,6 +12,7 @@ use fyrox_core::{
     ComponentProvider, NameProvider,
 };
 use fyrox_resource::{untyped::UntypedResource, Resource, TypedResourceData};
+use std::any::Any;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::{
@@ -537,6 +538,20 @@ pub trait SceneGraphNode: AbstractSceneNode + Clone + 'static {
 
         previous_value
     }
+
+    /// Tries to borrow a component of given type.
+    #[inline]
+    fn component_ref<T: Any>(&self) -> Option<&T> {
+        ComponentProvider::query_component_ref(self, TypeId::of::<T>())
+            .and_then(|c| c.downcast_ref())
+    }
+
+    /// Tries to borrow a component of given type.
+    #[inline]
+    fn component_mut<T: Any>(&mut self) -> Option<&mut T> {
+        ComponentProvider::query_component_mut(self, TypeId::of::<T>())
+            .and_then(|c| c.downcast_mut())
+    }
 }
 
 pub trait PrefabData: TypedResourceData + 'static {
@@ -696,6 +711,10 @@ pub trait BaseSceneGraph: AbstractSceneGraph {
 pub trait SceneGraph: BaseSceneGraph {
     /// Creates new iterator that iterates over internal collection giving (handle; node) pairs.
     fn pair_iter(&self) -> impl Iterator<Item = (Handle<Self::Node>, &Self::Node)>;
+
+    /// Creates an iterator that has linear iteration order over internal collection
+    /// of nodes. It does *not* perform any tree traversal!
+    fn linear_iter(&self) -> impl Iterator<Item = &Self::Node>;
 
     /// Creates an iterator that has linear iteration order over internal collection
     /// of nodes. It does *not* perform any tree traversal!

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -1595,6 +1595,10 @@ mod test {
             self.nodes.pair_iter()
         }
 
+        fn linear_iter(&self) -> impl Iterator<Item = &Self::Node> {
+            self.nodes.iter()
+        }
+
         fn linear_iter_mut(&mut self) -> impl Iterator<Item = &mut Self::Node> {
             self.nodes.iter_mut()
         }

--- a/fyrox-ui/src/animation.rs
+++ b/fyrox-ui/src/animation.rs
@@ -118,6 +118,7 @@ impl BoundValueCollectionExt for BoundValueCollection {
 #[derive(Visit, Reflect, Clone, Debug, ComponentProvider)]
 pub struct AnimationPlayer {
     widget: Widget,
+    #[component(include)]
     animations: InheritableVariable<AnimationContainer>,
     auto_apply: bool,
 }

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -690,7 +690,7 @@ impl Visit for UserInterface {
         self.double_click_time_slice
             .visit("DoubleClickTimeSlice", &mut region)?;
 
-        if visitor.is_reading() {
+        if region.is_reading() {
             for node in self.nodes.iter() {
                 self.methods_registry.register(node.deref());
             }

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -2938,6 +2938,11 @@ impl SceneGraph for UserInterface {
     }
 
     #[inline]
+    fn linear_iter(&self) -> impl Iterator<Item = &Self::Node> {
+        self.nodes.iter()
+    }
+
+    #[inline]
     fn linear_iter_mut(&mut self) -> impl Iterator<Item = &mut Self::Node> {
         self.nodes.iter_mut()
     }

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -690,8 +690,10 @@ impl Visit for UserInterface {
         self.double_click_time_slice
             .visit("DoubleClickTimeSlice", &mut region)?;
 
-        for node in self.nodes.iter() {
-            self.methods_registry.register(node.deref());
+        if visitor.is_reading() {
+            for node in self.nodes.iter() {
+                self.methods_registry.register(node.deref());
+            }
         }
 
         Ok(())

--- a/fyrox-ui/src/node/constructor.rs
+++ b/fyrox-ui/src/node/constructor.rs
@@ -1,6 +1,6 @@
 //! A special container that is able to create widgets by their type UUID.
-use crate::screen::Screen;
 use crate::{
+    animation::AnimationPlayer,
     bit::BitField,
     border::Border,
     button::Button,
@@ -28,6 +28,7 @@ use crate::{
     progress_bar::ProgressBar,
     range::RangeEditor,
     rect::RectEditor,
+    screen::Screen,
     scroll_bar::ScrollBar,
     scroll_panel::ScrollPanel,
     scroll_viewer::ScrollViewer,
@@ -198,6 +199,7 @@ impl WidgetConstructorContainer {
         container.add::<Text>();
         container.add::<TextBox>();
         container.add::<Screen>();
+        container.add::<AnimationPlayer>();
 
         container
     }

--- a/src/resource/model/mod.rs
+++ b/src/resource/model/mod.rs
@@ -265,7 +265,7 @@ pub trait AnimationSource {
     ///
     /// # Panic
     ///
-    /// Panics if `dest_animation_player` is invalid handle, or the node does not have [`AnimationPlayer`]
+    /// Panics if `dest_animation_player` is invalid handle, or the node does not have [`AnimationContainer`]
     /// component.
     fn retarget_animations_to_player(
         &self,
@@ -376,7 +376,7 @@ pub trait ModelResourceExtension: Sized {
     ///
     /// # Panic
     ///
-    /// Panics if `dest_animation_player` is invalid handle, or the node does not have [`AnimationPlayer`]
+    /// Panics if `dest_animation_player` is invalid handle, or the node does not have [`AnimationContainer`]
     /// component.
     fn retarget_animations_to_player(
         &self,

--- a/src/resource/model/mod.rs
+++ b/src/resource/model/mod.rs
@@ -20,8 +20,8 @@
 
 use crate::{
     asset::{
-        io::ResourceIo, manager::ResourceManager, options::ImportOptions, Resource, ResourceData,
-        MODEL_RESOURCE_UUID,
+        io::ResourceIo, manager::ResourceManager, options::ImportOptions, untyped::ResourceKind,
+        Resource, ResourceData, MODEL_RESOURCE_UUID,
     },
     core::{
         algebra::{UnitQuaternion, Vector3},
@@ -30,23 +30,21 @@ use crate::{
         reflect::prelude::*,
         uuid::Uuid,
         uuid_provider,
+        variable::InheritableVariable,
         visitor::{Visit, VisitError, VisitResult, Visitor},
-        TypeUuidProvider,
+        NameProvider, TypeUuidProvider,
     },
     engine::SerializationContext,
-    graph::{NodeHandleMap, PrefabData, SceneGraph},
+    generic_animation::AnimationContainer,
+    graph::{BaseSceneGraph, NodeHandleMap, NodeMapping, PrefabData, SceneGraph, SceneGraphNode},
     resource::fbx::{self, error::FbxError},
     scene::{
-        animation::{Animation, AnimationPlayer},
-        base::SceneNodeId,
-        graph::Graph,
-        node::Node,
-        transform::Transform,
+        animation::Animation, base::SceneNodeId, graph::Graph, node::Node, transform::Transform,
         Scene, SceneLoader,
     },
 };
 use fxhash::FxHashMap;
-use fyrox_graph::NodeMapping;
+use fyrox_ui::{UiNode, UserInterface};
 use serde::{Deserialize, Serialize};
 use std::{
     any::Any,
@@ -178,6 +176,144 @@ impl<'a, 'b, 'c> InstantiationContext<'a, 'b, 'c> {
     }
 }
 
+/// Common trait that has animation retargetting methods.
+pub trait AnimationSource {
+    /// Prefab type.
+    type Prefab: PrefabData<Graph = Self::SceneGraph>;
+    /// Scene graph type.
+    type SceneGraph: SceneGraph<Node = Self::Node, Prefab = Self::Prefab>;
+    /// Scene node type.
+    type Node: SceneGraphNode<SceneGraph = Self::SceneGraph, ResourceData = Self::Prefab>;
+
+    /// Returns a reference to an inner graph.
+    fn inner_graph(&self) -> &Self::SceneGraph;
+
+    /// Tries to retarget animations from given model resource to a node hierarchy starting
+    /// from `root` on a given scene.
+    ///
+    /// Animation retargeting allows you to "transfer" animation from a model to a model
+    /// instance on a scene. Imagine you have a character that should have multiple animations
+    /// like idle, run, shoot, walk, etc. and you want to store each animation in a separate
+    /// file. Then when you creating a character on a level you want to have all possible
+    /// animations assigned to a character, this is where this function comes into play:
+    /// you just load a model of your character with skeleton, but without any animations,
+    /// then you load several "models" which have only skeleton with some animation (such
+    /// "models" can be considered as "animation" resources). After this you need to
+    /// instantiate model on your level and retarget all animations you need to that instance
+    /// from other "models". All you have after this is a handle to a model and bunch of
+    /// handles to specific animations. After this animations can be blended in any combinations
+    /// you need to. For example idle animation can be blended with walk animation when your
+    /// character starts walking.
+    ///
+    /// # Notes
+    ///
+    /// Most of the 3d model formats can contain only one animation, so in most cases
+    /// this function will return vector with only one animation.
+    fn retarget_animations_directly(
+        &self,
+        root: Handle<Self::Node>,
+        graph: &Self::SceneGraph,
+        self_kind: ResourceKind,
+    ) -> Vec<fyrox_animation::Animation<Handle<Self::Node>>> {
+        let mut retargetted_animations = Vec::new();
+
+        let model_graph = self.inner_graph();
+        for src_node_ref in model_graph.linear_iter() {
+            if let Some(src_animations) = src_node_ref
+                .component_ref::<InheritableVariable<AnimationContainer<Handle<Self::Node>>>>()
+            {
+                for src_anim in src_animations.iter() {
+                    let mut anim_copy = src_anim.clone();
+
+                    // Remap animation track nodes from resource to instance. This is required
+                    // because we've made a plain copy and it has tracks with node handles mapped
+                    // to nodes of internal scene.
+                    for (i, ref_track) in src_anim.tracks().iter().enumerate() {
+                        let ref_node = &model_graph.node(ref_track.target());
+                        let track = &mut anim_copy.tracks_mut()[i];
+                        // Find instantiated node that corresponds to node in resource
+                        match graph.find_by_name(root, ref_node.name()) {
+                            Some((instance_node, _)) => {
+                                // One-to-one track mapping so there is [i] indexing.
+                                track.set_target(instance_node);
+                            }
+                            None => {
+                                track.set_target(Default::default());
+                                Log::writeln(
+                                    MessageKind::Error,
+                                    format!(
+                                        "Failed to retarget animation {:?} for node {}",
+                                        self_kind,
+                                        ref_node.name()
+                                    ),
+                                );
+                            }
+                        }
+                    }
+
+                    retargetted_animations.push(anim_copy);
+                }
+            }
+        }
+
+        retargetted_animations
+    }
+
+    /// Tries to retarget animations from given model resource to a node hierarchy starting
+    /// from `root` on a given scene. Unlike [`Self::retarget_animations_directly`], it automatically
+    /// adds retargetted animations to the specified animation player in the hierarchy of given `root`.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `dest_animation_player` is invalid handle, or the node does not have [`AnimationPlayer`]
+    /// component.
+    fn retarget_animations_to_player(
+        &self,
+        root: Handle<Self::Node>,
+        dest_animation_player: Handle<Self::Node>,
+        graph: &mut Self::SceneGraph,
+        self_kind: ResourceKind,
+    ) -> Vec<Handle<fyrox_animation::Animation<Handle<Self::Node>>>> {
+        let mut animation_handles = Vec::new();
+
+        let animations = self.retarget_animations_directly(root, graph, self_kind);
+
+        let dest_animations = graph
+            .node_mut(dest_animation_player)
+            .component_mut::<InheritableVariable<AnimationContainer<Handle<Self::Node>>>>()
+            .unwrap();
+
+        for animation in animations {
+            animation_handles.push(dest_animations.add(animation));
+        }
+
+        animation_handles
+    }
+
+    /// Tries to retarget animations from given model resource to a node hierarchy starting
+    /// from `root` on a given scene. Unlike [`Self::retarget_animations_directly`], it automatically
+    /// adds retargetted animations to a first animation player in the hierarchy of given `root`.
+    ///
+    /// # Panic
+    ///
+    /// Panics if there's no animation player in the given hierarchy (descendant nodes of `root`).
+    fn retarget_animations(
+        &self,
+        root: Handle<Self::Node>,
+        graph: &mut Self::SceneGraph,
+        self_kind: ResourceKind,
+    ) -> Vec<Handle<fyrox_animation::Animation<Handle<Self::Node>>>> {
+        if let Some((animation_player, _)) = graph.find(root, &mut |n| {
+            n.component_ref::<InheritableVariable<AnimationContainer<Handle<Self::Node>>>>()
+                .is_some()
+        }) {
+            self.retarget_animations_to_player(root, animation_player, graph, self_kind)
+        } else {
+            Default::default()
+        }
+    }
+}
+
 /// Type alias for model resources.
 pub type ModelResource = Resource<Model>;
 
@@ -263,6 +399,26 @@ pub trait ModelResourceExtension: Sized {
     fn generate_ids(&self) -> FxHashMap<Handle<Node>, SceneNodeId>;
 }
 
+impl AnimationSource for Model {
+    type Prefab = Model;
+    type SceneGraph = Graph;
+    type Node = Node;
+
+    fn inner_graph(&self) -> &Self::SceneGraph {
+        &self.scene.graph
+    }
+}
+
+impl AnimationSource for UserInterface {
+    type Prefab = UserInterface;
+    type SceneGraph = UserInterface;
+    type Node = UiNode;
+
+    fn inner_graph(&self) -> &Self::SceneGraph {
+        self
+    }
+}
+
 impl ModelResourceExtension for ModelResource {
     fn instantiate_from<Pre>(
         model: ModelResource,
@@ -318,49 +474,13 @@ impl ModelResourceExtension for ModelResource {
     }
 
     fn retarget_animations_directly(&self, root: Handle<Node>, graph: &Graph) -> Vec<Animation> {
-        let mut retargetted_animations = Vec::new();
-
         let mut header = self.state();
         let self_kind = header.kind().clone();
         if let Some(model) = header.data() {
-            for src_node_ref in model.scene.graph.linear_iter() {
-                if let Some(src_player) = src_node_ref.query_component_ref::<AnimationPlayer>() {
-                    for src_anim in src_player.animations().iter() {
-                        let mut anim_copy = src_anim.clone();
-
-                        // Remap animation track nodes from resource to instance. This is required
-                        // because we've made a plain copy and it has tracks with node handles mapped
-                        // to nodes of internal scene.
-                        for (i, ref_track) in src_anim.tracks().iter().enumerate() {
-                            let ref_node = &model.scene.graph[ref_track.target()];
-                            let track = &mut anim_copy.tracks_mut()[i];
-                            // Find instantiated node that corresponds to node in resource
-                            match graph.find_by_name(root, ref_node.name()) {
-                                Some((instance_node, _)) => {
-                                    // One-to-one track mapping so there is [i] indexing.
-                                    track.set_target(instance_node);
-                                }
-                                None => {
-                                    track.set_target(Default::default());
-                                    Log::writeln(
-                                        MessageKind::Error,
-                                        format!(
-                                            "Failed to retarget animation {:?} for node {}",
-                                            self_kind,
-                                            ref_node.name()
-                                        ),
-                                    );
-                                }
-                            }
-                        }
-
-                        retargetted_animations.push(anim_copy);
-                    }
-                }
-            }
+            model.retarget_animations_directly(root, graph, self_kind)
+        } else {
+            Default::default()
         }
-
-        retargetted_animations
     }
 
     fn retarget_animations_to_player(
@@ -369,26 +489,20 @@ impl ModelResourceExtension for ModelResource {
         dest_animation_player: Handle<Node>,
         graph: &mut Graph,
     ) -> Vec<Handle<Animation>> {
-        let mut animation_handles = Vec::new();
-
-        let animations = self.retarget_animations_directly(root, graph);
-
-        let dest_animation_player = graph[dest_animation_player]
-            .query_component_mut::<AnimationPlayer>()
-            .unwrap();
-
-        for animation in animations {
-            animation_handles.push(dest_animation_player.animations_mut().add(animation));
+        let mut header = self.state();
+        let self_kind = header.kind().clone();
+        if let Some(model) = header.data() {
+            model.retarget_animations_to_player(root, dest_animation_player, graph, self_kind)
+        } else {
+            Default::default()
         }
-
-        animation_handles
     }
 
     fn retarget_animations(&self, root: Handle<Node>, graph: &mut Graph) -> Vec<Handle<Animation>> {
-        if let Some((animation_player, _)) = graph.find(root, &mut |n| {
-            n.query_component_ref::<AnimationPlayer>().is_some()
-        }) {
-            self.retarget_animations_to_player(root, animation_player, graph)
+        let mut header = self.state();
+        let self_kind = header.kind().clone();
+        if let Some(model) = header.data() {
+            model.retarget_animations(root, graph, self_kind)
         } else {
             Default::default()
         }

--- a/src/scene/animation/mod.rs
+++ b/src/scene/animation/mod.rs
@@ -294,7 +294,7 @@ impl DerefMut for AnimationPlayer {
 }
 
 impl NodeTrait for AnimationPlayer {
-    crate::impl_query_component!();
+    crate::impl_query_component!(animations: InheritableVariable<AnimationContainer>);
 
     fn local_bounding_box(&self) -> AxisAlignedBoundingBox {
         self.base.local_bounding_box()

--- a/src/scene/graph/mod.rs
+++ b/src/scene/graph/mod.rs
@@ -1636,6 +1636,11 @@ impl SceneGraph for Graph {
     }
 
     #[inline]
+    fn linear_iter(&self) -> impl Iterator<Item = &Self::Node> {
+        self.pool.iter()
+    }
+
+    #[inline]
     fn linear_iter_mut(&mut self) -> impl Iterator<Item = &mut Self::Node> {
         self.pool.iter_mut()
     }


### PR DESCRIPTION
This PR generalizes animation editor to support both game and ui scenes. Now it is possible to do something like this:
![ui_anim](https://github.com/FyroxEngine/Fyrox/assets/2785135/6e1360b9-a1a8-44ec-9480-2c318089dd68)
