### PR TITLE
Fixing double pixel loop. It was looping over y twice.

### DIFF
--- a/src/scene/terrain/mod.rs
+++ b/src/scene/terrain/mod.rs
@@ -1020,7 +1020,7 @@ impl Terrain {
 
             for iy in 0..chunk.height_map_size.y {
                 let kz = iy as f32 / (chunk.height_map_size.y - 1) as f32;
-                for ix in 0..chunk.height_map_size.y {
+                for ix in 0..chunk.height_map_size.x {
                     let kx = ix as f32 / (chunk.height_map_size.x - 1) as f32;
 
                     let pixel_position = chunk.local_position()


### PR DESCRIPTION
There's an apparent bug where the x height_map_size wasn't referenced, instead y was referenced twice. I had a heightmap where x < y, causing this issue to become apparent when the heightmap is modified. I didn't see any open issue or instructions that I need to open an issue first, so I just opened the PR. I'm newly unemployed, so if there's a process I'm missing please let me know. I will likely have more PRs and issues to contribute soon.