### PR TITLE
Fix creating a MenuItem in editor

### DIFF
--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -55,7 +55,7 @@ impl MenuMessage {
 /// A set of messages that can be used to manipulate a [`MenuItem`] widget at runtime.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MenuItemMessage {
-    /// Opens the menu item's popup with inner items.  
+    /// Opens the menu item's popup with inner items.
     Open,
     /// Closes the menu item's popup with inner items.
     Close,
@@ -793,7 +793,9 @@ impl<'a, 'b> MenuItemBuilder<'a, 'b> {
             .build(ctx)
         });
 
-        ctx.link(content, decorator);
+        if content.is_some() {
+            ctx.link(content, decorator);
+        }
 
         let panel;
         let popup = PopupBuilder::new(WidgetBuilder::new().with_min_size(Vector2::new(10.0, 10.0)))


### PR DESCRIPTION
Attempting to create a MenuItem in the UI editor will crash the editor (since the `MenuItemBuilder.content` is none). This PR only links the content if the content exists.

Edit: Seems to effect stable 0.33.1 too.