### PR TITLE
Slight UI Improvements

### DIFF
--- a/editor/src/menu/mod.rs
+++ b/editor/src/menu/mod.rs
@@ -77,7 +77,7 @@ pub fn create_root_menu_item(
     ctx: &mut BuildContext,
 ) -> Handle<UiNode> {
     MenuItemBuilder::new(WidgetBuilder::new().with_margin(Thickness::right(10.0)))
-        .with_content(MenuItemContent::text_no_arrow(text))
+        .with_content(MenuItemContent::text_centered(text))
         .with_items(items)
         .build(ctx)
 }

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -741,6 +741,7 @@ impl<'a, 'b> MenuItemBuilder<'a, 'b> {
                         TextBuilder::new(
                             WidgetBuilder::new()
                                 .with_margin(Thickness::left(2.0))
+                                .on_row(1)
                                 .on_column(1),
                         )
                         .with_text(text)
@@ -751,6 +752,7 @@ impl<'a, 'b> MenuItemBuilder<'a, 'b> {
                             WidgetBuilder::new()
                                 .with_horizontal_alignment(HorizontalAlignment::Right)
                                 .with_margin(Thickness::uniform(1.0))
+                                .on_row(1)
                                 .on_column(2),
                         )
                         .with_text(shortcut)
@@ -760,6 +762,7 @@ impl<'a, 'b> MenuItemBuilder<'a, 'b> {
                         VectorImageBuilder::new(
                             WidgetBuilder::new()
                                 .with_visibility(!self.items.is_empty())
+                                .on_row(1)
                                 .on_column(3)
                                 .with_foreground(BRUSH_BRIGHT)
                                 .with_horizontal_alignment(HorizontalAlignment::Center)
@@ -771,7 +774,9 @@ impl<'a, 'b> MenuItemBuilder<'a, 'b> {
                         Handle::NONE
                     }),
             )
+            .add_row(Row::stretch())
             .add_row(Row::auto())
+            .add_row(Row::stretch())
             .add_column(Column::auto())
             .add_column(Column::stretch())
             .add_column(Column::auto())

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -795,6 +795,7 @@ impl<'a, 'b> MenuItemBuilder<'a, 'b> {
             .add_column(Column::stretch())
             .add_column(Column::auto())
             .add_column(Column::strict(10.0))
+            .add_column(Column::strict(5.0))
             .build(ctx),
             Some(MenuItemContent::TextCentered(text)) => {
                 TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::left_right(5.0)))

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -642,6 +642,15 @@ pub enum MenuItemContent<'a, 'b> {
         /// Create an arrow or not.
         arrow: bool,
     },
+    /// Horizontally and Vertically centered text
+    ///
+    /// ```text
+    ///   _________________________
+    ///  |                        |
+    ///  |          text          |
+    ///  |________________________|
+    /// ```
+    TextCentered(&'a str),
     /// Allows to put any node into menu item. It allows to customize menu item how needed - i.e. put image in it, or other user
     /// control.
     Node(Handle<UiNode>),
@@ -676,6 +685,11 @@ impl<'a, 'b> MenuItemContent<'a, 'b> {
             icon: Default::default(),
             arrow: false,
         }
+    }
+
+    /// Creates a menu item content with only horizontally and vertically centered text.
+    pub fn text_centered(text: &'a str) -> Self {
+        MenuItemContent::TextCentered(text)
     }
 }
 
@@ -782,6 +796,13 @@ impl<'a, 'b> MenuItemBuilder<'a, 'b> {
             .add_column(Column::auto())
             .add_column(Column::strict(10.0))
             .build(ctx),
+            Some(MenuItemContent::TextCentered(text)) => {
+                TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::left_right(5.0)))
+                    .with_text(text)
+                    .with_horizontal_text_alignment(HorizontalAlignment::Center)
+                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                    .build(ctx)
+            }
             Some(MenuItemContent::Node(node)) => node,
         };
 

--- a/fyrox-ui/src/messagebox.rs
+++ b/fyrox-ui/src/messagebox.rs
@@ -340,7 +340,8 @@ impl<'b> MessageBoxBuilder<'b> {
                         .with_text("OK")
                         .build(ctx);
                         ok_yes
-                    }),
+                    })
+                    .with_margin(Thickness::uniform(5.0)),
             )
             .add_row(Row::stretch())
             .add_row(Row::strict(25.0))
@@ -383,7 +384,8 @@ impl<'b> MessageBoxBuilder<'b> {
                         )
                         .with_orientation(Orientation::Horizontal)
                         .build(ctx),
-                    ),
+                    )
+                    .with_margin(Thickness::uniform(5.0)),
             )
             .add_row(Row::stretch())
             .add_row(Row::strict(25.0))
@@ -436,7 +438,8 @@ impl<'b> MessageBoxBuilder<'b> {
                         )
                         .with_orientation(Orientation::Horizontal)
                         .build(ctx),
-                    ),
+                    )
+                    .with_margin(Thickness::uniform(5.0)),
             )
             .add_row(Row::stretch())
             .add_row(Row::strict(25.0))


### PR DESCRIPTION
Just added a couple of UI changes to make it feel more consistent. Some of these changes may be considered more stylish compared to others, so feel free to pick and choose.

Changed:
* MenuItemContent::Text is vertically centered (applies to all popups in the editor)
* Editor Toolbar items are both Vertically and Horizontally centered
* Popup Arrows get a slight margin from the edge of the MenuItem

Original: 
![image](https://github.com/FyroxEngine/Fyrox/assets/74568473/a2a67235-2db0-4bc7-8478-7fb95b5e4261)
Updated:
![image](https://github.com/FyroxEngine/Fyrox/assets/74568473/84736ac3-8ec9-4ccc-95e5-3529aa42a1f7)


* Added margins to messageboxes.

Original: 
![image](https://github.com/FyroxEngine/Fyrox/assets/74568473/2579cce1-589b-44d5-af56-1191f7340763)
Updated:
![image](https://github.com/FyroxEngine/Fyrox/assets/74568473/62d41eba-5ca6-4d8f-b9f5-dde45ebbc553)
