### PR TITLE
added code to make indicator size adaptive

### DIFF
--- a/fyrox-ui/src/scroll_bar.rs
+++ b/fyrox-ui/src/scroll_bar.rs
@@ -587,10 +587,10 @@ impl ScrollBarBuilder {
 
         match orientation {
             Orientation::Vertical => {
-                ctx[indicator].set_min_size(Vector2::new(0.0, 30.0));
+                ctx[indicator].set_min_size(Vector2::new(0.0, 15.0));
             }
             Orientation::Horizontal => {
-                ctx[indicator].set_min_size(Vector2::new(30.0, 0.0));
+                ctx[indicator].set_min_size(Vector2::new(15.0, 0.0));
             }
         }
 

--- a/fyrox-ui/src/scroll_viewer.rs
+++ b/fyrox-ui/src/scroll_viewer.rs
@@ -173,17 +173,37 @@ impl Control for ScrollViewer {
             let available_size_for_content = ui.node(self.scroll_panel).desired_size();
 
             let x_max = (content_size.x - available_size_for_content.x).max(0.0);
+            let x_size_ratio = if content_size.x > f32::EPSILON {
+                (available_size_for_content.x / content_size.x).min(1.0)
+            } else {
+                1.0
+            };
             ui.send_message(ScrollBarMessage::max_value(
                 self.h_scroll_bar,
                 MessageDirection::ToWidget,
                 x_max,
             ));
+            ui.send_message(ScrollBarMessage::size_ratio(
+                self.h_scroll_bar,
+                MessageDirection::ToWidget,
+                x_size_ratio,
+            ));
 
             let y_max = (content_size.y - available_size_for_content.y).max(0.0);
+            let y_size_ratio = if content_size.y > f32::EPSILON {
+                (available_size_for_content.y / content_size.y).min(1.0)
+            } else {
+                1.0
+            };
             ui.send_message(ScrollBarMessage::max_value(
                 self.v_scroll_bar,
                 MessageDirection::ToWidget,
                 y_max,
+            ));
+            ui.send_message(ScrollBarMessage::size_ratio(
+                self.v_scroll_bar,
+                MessageDirection::ToWidget,
+                y_size_ratio,
             ));
         }
 


### PR DESCRIPTION
#199 

Added code to make the `indicator` (thumb) size of the scrollbar adaptive to the `ScrollViewer`. Behavior shown below:

https://github.com/FyroxEngine/Fyrox/assets/120047549/09f05263-d381-44eb-bd9a-a2d5a93085e4

I hope the behavior is as expected. But there is an issue:
It seems to be working fine when the container is extended, but when it is shrunk below a certain size, the indicator's movement gets offset by a certain distance (can be seen in the video where the indicator doesn't touch the top arrow and extends below the bottom arrow)

Any help with this would be greatly appreciated. I hope this helps

Also, I have set the minimum size of the indicator to 15. Please let me know if this should be changed or handled differently.