### PR TITLE
Window user experience improvements and bug fixes.

### DIFF
--- a/fyrox-ui/src/window.rs
+++ b/fyrox-ui/src/window.rs
@@ -397,7 +397,7 @@ impl Control for Window {
 
         if let Some(msg) = message.data::<WidgetMessage>() {
             // Grip interaction have higher priority than other actions.
-            if self.can_resize {
+            if self.can_resize && !self.is_dragging {
                 match msg {
                     &WidgetMessage::MouseDown { pos, .. } => {
                         ui.send_message(WidgetMessage::topmost(
@@ -434,7 +434,7 @@ impl Control for Window {
                         for grip in self.grips.borrow().iter() {
                             let offset = self.screen_position();
                             let screen_bounds = grip.bounds.translate(offset);
-                            if screen_bounds.contains(pos) {
+                            if grip.is_dragging || screen_bounds.contains(pos) {
                                 new_cursor = Some(grip.cursor);
                             }
 
@@ -486,6 +486,9 @@ impl Control for Window {
                     }
                     _ => {}
                 }
+            } else {
+                // The window cannot be resized, so leave the cursor unset.
+                self.set_cursor(None);
             }
 
             if (message.destination() == self.header


### PR DESCRIPTION
I have adjusted when and where the cursor icon changes when interacting with windows.

* I have made it so that the splitter between docked windows always has the resize cursor icon instead of only sometimes. The issue was that the icon was only set by the TileBuilder, so whenever a tile was updated later the cursor icon was not updated. Now it is.
* I have made it so that resize cursor icons never appear when dragging a window. We are not resizing; we are moving, so a resize cursor icon is confusing.
* I have made it so that when a grip is being dragged, the window keeps the resize cursor icon until the drag is released. Otherwise it has the visual appearance of the drag already being released just because the mouse moved ahead of the edge of the window while dragging.
* While trying to find the problems in tile.rs, I made a few helper functions to simplify the code. I think they are an improvement.
* I created a custom Debug implementation for InheritableVariable that provides the same information in much less space. This was helpful when I was printing out debug information on widgets.