### PR TITLE
Expanding documentation for inspector module and adding ImmutableString editor.

### DIFF
--- a/fyrox-core/src/sstorage.rs
+++ b/fyrox-core/src/sstorage.rs
@@ -5,9 +5,11 @@
 
 use crate::{
     parking_lot::Mutex,
+    uuid_provider,
     visitor::{Visit, VisitResult, Visitor},
 };
 use fxhash::{FxHashMap, FxHasher};
+pub use fyrox_core_derive::TypeUuidProvider;
 use std::{
     fmt::{Debug, Display, Formatter},
     hash::{Hash, Hasher},
@@ -34,6 +36,8 @@ struct State {
 /// Most common use case for immutable strings is hash map keys in performance-critical places.
 #[derive(Clone)]
 pub struct ImmutableString(Arc<State>);
+
+uuid_provider!(ImmutableString = "452caac1-19f7-43d6-9e33-92c2c9163332");
 
 impl Display for ImmutableString {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -65,6 +69,12 @@ impl Visit for ImmutableString {
 impl Default for ImmutableString {
     fn default() -> Self {
         Self::new("")
+    }
+}
+
+impl AsRef<str> for ImmutableString {
+    fn as_ref(&self) -> &str {
+        self.deref()
     }
 }
 

--- a/fyrox-ui/src/inspector/editors/immutable_string.rs
+++ b/fyrox-ui/src/inspector/editors/immutable_string.rs
@@ -1,0 +1,73 @@
+//! Property editor for [ImmutableString] properties based upon a [TextBox](crate::text_box::TextBox) widget.
+use fyrox_core::sstorage::ImmutableString;
+
+use crate::{
+    core::algebra::Vector2,
+    formatted_text::WrapMode,
+    inspector::{
+        editors::{
+            PropertyEditorBuildContext, PropertyEditorDefinition, PropertyEditorInstance,
+            PropertyEditorMessageContext, PropertyEditorTranslationContext,
+        },
+        FieldKind, InspectorError, PropertyChanged,
+    },
+    message::{MessageDirection, UiMessage},
+    text::TextMessage,
+    text_box::TextBoxBuilder,
+    widget::WidgetBuilder,
+    Thickness, VerticalAlignment,
+};
+use std::any::TypeId;
+
+/// Property editor for [ImmutableString] properties based upon a [TextBox](crate::text_box::TextBox) widget.
+#[derive(Debug)]
+pub struct ImmutableStringPropertyEditorDefinition;
+
+impl PropertyEditorDefinition for ImmutableStringPropertyEditorDefinition {
+    fn value_type_id(&self) -> TypeId {
+        TypeId::of::<ImmutableString>()
+    }
+
+    fn create_instance(
+        &self,
+        ctx: PropertyEditorBuildContext,
+    ) -> Result<PropertyEditorInstance, InspectorError> {
+        let value = ctx.property_info.cast_value::<ImmutableString>()?;
+        Ok(PropertyEditorInstance::Simple {
+            editor: TextBoxBuilder::new(
+                WidgetBuilder::new()
+                    .with_min_size(Vector2::new(0.0, 17.0))
+                    .with_margin(Thickness::uniform(1.0)),
+            )
+            .with_wrap(WrapMode::Word)
+            .with_text(value)
+            .with_vertical_text_alignment(VerticalAlignment::Center)
+            .build(ctx.build_context),
+        })
+    }
+
+    fn create_message(
+        &self,
+        ctx: PropertyEditorMessageContext,
+    ) -> Result<Option<UiMessage>, InspectorError> {
+        let value = ctx.property_info.cast_value::<ImmutableString>()?;
+        Ok(Some(TextMessage::text(
+            ctx.instance,
+            MessageDirection::ToWidget,
+            value.to_mutable(),
+        )))
+    }
+
+    fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
+        if ctx.message.direction() == MessageDirection::FromWidget {
+            if let Some(TextMessage::Text(value)) = ctx.message.data::<TextMessage>() {
+                return Some(PropertyChanged {
+                    owner_type_id: ctx.owner_type_id,
+                    name: ctx.name.to_string(),
+                    value: FieldKind::object(ImmutableString::new(value)),
+                });
+            }
+        }
+        None
+    }
+}

--- a/fyrox-ui/src/inspector/editors/inspectable.rs
+++ b/fyrox-ui/src/inspector/editors/inspectable.rs
@@ -1,3 +1,5 @@
+//! A general-purpose property editor definition that creates
+//! a nested inspector within an [Expander](crate::expander::Expander) widget.
 use crate::{
     core::reflect::prelude::*,
     inspector::{
@@ -19,6 +21,11 @@ use std::{
     fmt::{Debug, Formatter},
 };
 
+/// A general-purpose property editor definition that creates
+/// a nested inspector within an [Expander](crate::expander::Expander) widget to allow the user
+/// to edited properties of type T.
+/// The expander is labeled with [FieldInfo::display_name].
+/// The layer_index for the inner inspector is increased by 1.
 pub struct InspectablePropertyEditorDefinition<T>
 where
     T: Reflect + 'static,
@@ -90,6 +97,9 @@ where
         Ok(PropertyEditorInstance::Custom { container, editor })
     }
 
+    /// Instead of creating a message to update its widget,
+    /// call [InspectorContext::sync] to directly send whatever messages are necessary
+    /// and return None.
     fn create_message(
         &self,
         ctx: PropertyEditorMessageContext,


### PR DESCRIPTION
In my project to create an editor for ImmutableString, I needed to learn to understand the inspector module. To help with this, I added documentation to many undocumented elements of that module. These comments were written by someone who was struggling to understand the design of the inspector module, and so hopefully they can be helpful to other people who might struggle to understand.

This also means that there may be mistakes in the documentation. I would be eager to see those mistakes corrected or the documentation expanded even further, so that I can see what I failed to understand from studying the module.