### PR TITLE
PopupMessage::Event system for copying events from Popups to their owners.

### DIFF
--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -1021,7 +1021,7 @@ impl Control for Inspector {
             }
         }
 
-        if let Some(PopupMessage::Event(popup_message)) = message.data() {
+        if let Some(PopupMessage::RelayedMessage(popup_message)) = message.data() {
             if popup_message.destination() == self.context.menu.copy_value_as_string {
                 if let Some(MenuItemMessage::Click) = popup_message.data() {
                     // The child that was originally clicked to open the menu was automatically set to be

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -8,8 +8,7 @@ use crate::{
     core::{
         algebra::Vector2,
         pool::Handle,
-        reflect::prelude::*,
-        reflect::{CastError, Reflect},
+        reflect::{prelude::*, CastError, Reflect},
         type_traits::prelude::*,
         visitor::prelude::*,
     },
@@ -23,7 +22,7 @@ use crate::{
     },
     menu::{MenuItemBuilder, MenuItemContent, MenuItemMessage},
     message::{MessageDirection, UiMessage},
-    popup::PopupBuilder,
+    popup::{PopupBuilder, PopupMessage},
     stack_panel::StackPanelBuilder,
     text::TextBuilder,
     utils::{make_arrow, make_simple_tooltip, ArrowDirection},
@@ -36,7 +35,6 @@ use fyrox_graph::BaseSceneGraph;
 use std::sync::Arc;
 use std::{
     any::{Any, TypeId},
-    cell::Cell,
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
 };
@@ -543,7 +541,6 @@ pub struct Menu {
     pub copy_value_as_string: Handle<UiNode>,
     /// The reference-counted handle of the menu as a whole.
     pub menu: Option<RcUiNodeHandle>,
-    pub target: Cell<Handle<UiNode>>,
 }
 
 /// The widget handle and associated information that represents what an [Inspector] is currently displaying.
@@ -906,7 +903,6 @@ impl InspectorContext {
             menu: Menu {
                 copy_value_as_string,
                 menu: Some(menu),
-                target: Default::default(),
             },
             entries,
             property_definitions: definition_container,
@@ -1025,6 +1021,31 @@ impl Control for Inspector {
             }
         }
 
+        if let Some(PopupMessage::Event(popup_message)) = message.data() {
+            if popup_message.destination() == self.context.menu.copy_value_as_string {
+                if let Some(MenuItemMessage::Click) = popup_message.data() {
+                    // The child that was originally clicked to open the menu was automatically set to be
+                    // the owner of the popup, and so event messages have it as the destination.
+                    let mut parent_handle = message.destination();
+
+                    // Crawl up from the destination to find the actual editor and do the copy.
+                    while let Some(parent) = ui.try_get(parent_handle) {
+                        for entry in self.context.entries.iter() {
+                            if entry.property_container == parent_handle {
+                                let _ = ui
+                                    .clipboard_mut()
+                                    .unwrap()
+                                    .set_contents(entry.property_debug_output.clone());
+                                break;
+                            }
+                        }
+
+                        parent_handle = parent.parent;
+                    }
+                }
+            }
+        }
+
         // Check each message from descendant widget and try to translate it to
         // PropertyChanged message.
         if message.flags != self.context.sync_flag {
@@ -1051,33 +1072,6 @@ impl Control for Inspector {
                             MessageDirection::FromWidget,
                             args,
                         ));
-                    }
-                }
-            }
-        }
-    }
-
-    fn preview_message(&self, ui: &UserInterface, message: &mut UiMessage) {
-        if message.destination() == self.context.menu.copy_value_as_string {
-            if let Some(MenuItemMessage::Click) = message.data() {
-                if let Some(menu_handle) = self.context.menu.menu.as_ref().map(|h| h.handle()) {
-                    let position = ui.node(menu_handle).screen_position();
-
-                    let mut parent_handle =
-                        ui.hit_test_unrestricted(position - Vector2::new(1.0, 1.0));
-
-                    while let Some(parent) = ui.try_get(parent_handle) {
-                        for entry in self.context.entries.iter() {
-                            if entry.property_container == parent_handle {
-                                let _ = ui
-                                    .clipboard_mut()
-                                    .unwrap()
-                                    .set_contents(entry.property_debug_output.clone());
-                                break;
-                            }
-                        }
-
-                        parent_handle = parent.parent;
                     }
                 }
             }
@@ -1119,7 +1113,6 @@ impl InspectorBuilder {
             widget: self
                 .widget_builder
                 .with_child(self.context.stack_panel)
-                .with_preview_messages(true)
                 .build(),
             context: self.context,
         };

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -1967,7 +1967,7 @@ impl UserInterface {
                             }
                         }
                         WidgetMessage::MouseDown { button, .. } => {
-                            if *button == MouseButton::Right {
+                            if !message.handled() && *button == MouseButton::Right {
                                 if let Some(picked) = self.nodes.try_borrow(self.picked_node) {
                                     // Get the context menu from the current node or a parent node
                                     let (context_menu, target) = if picked.context_menu().is_some()
@@ -1995,6 +1995,14 @@ impl UserInterface {
                                         self.send_message(PopupMessage::open(
                                             context_menu.handle(),
                                             MessageDirection::ToWidget,
+                                        ));
+                                        // Send Event messages to the widget that was clicked on,
+                                        // not to the widget that has the context menu.
+                                        // The Inspector widget needs to know which widget was clicked on.
+                                        self.send_message(PopupMessage::owner(
+                                            context_menu.handle(),
+                                            MessageDirection::ToWidget,
+                                            self.picked_node,
                                         ));
                                     }
                                 }

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -468,7 +468,6 @@ impl Control for MenuItem {
                 WidgetMessage::MouseUp { .. } => {
                     if !message.handled() {
                         if self.items_container.is_empty() || *self.clickable_when_not_empty {
-                            println!("Sending click from #{}", self.handle.index());
                             ui.send_message(MenuItemMessage::click(
                                 self.handle(),
                                 MessageDirection::ToWidget,

--- a/fyrox-ui/src/message.rs
+++ b/fyrox-ui/src/message.rs
@@ -251,7 +251,6 @@ where
 /// ```
 ///
 ///
-#[derive(Debug)]
 pub struct UiMessage {
     /// Useful flag to check if a message was already handled. It could be used to mark messages as "handled" to prevent
     /// any further responses to them. It is especially useful in bubble message routing, when a message is passed through
@@ -281,6 +280,30 @@ pub struct UiMessage {
 
     /// A custom user flags. Use it if `handled` flag is not enough.
     pub flags: u64,
+}
+
+impl Debug for UiMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "UiMessage({}:({})",
+            match self.direction {
+                MessageDirection::ToWidget => "To",
+                MessageDirection::FromWidget => "From",
+            },
+            self.destination
+        )?;
+        if self.handled.get() {
+            write!(f, ",handled")?;
+        }
+        if self.perform_layout.get() {
+            write!(f, ",layout")?;
+        }
+        if self.flags != 0 {
+            write!(f, ",flags:{}", self.flags)?;
+        }
+        write!(f, "):{:?}", self.data)
+    }
 }
 
 impl Clone for UiMessage {

--- a/fyrox-ui/src/popup.rs
+++ b/fyrox-ui/src/popup.rs
@@ -35,6 +35,10 @@ pub enum PopupMessage {
     /// Used to adjust position of a popup widget, so it will be on screen. Use [`PopupMessage::adjust_position`] to create
     /// the message.
     AdjustPosition,
+    /// Used to set the owner of a Popup. The owner will receive Event messages.
+    Owner(Handle<UiNode>),
+    /// Sent by the Popup to its owner when handling messages from the Popup's children.
+    Event(UiMessage),
 }
 
 impl PopupMessage {
@@ -57,6 +61,14 @@ impl PopupMessage {
     define_constructor!(
         /// Creates [`PopupMessage::AdjustPosition`] message.
         PopupMessage:AdjustPosition => fn adjust_position(), layout: true
+    );
+    define_constructor!(
+        /// Creates [`PopupMessage::Owner`] message.
+        PopupMessage:Owner => fn owner(Handle<UiNode>), layout: false
+    );
+    define_constructor!(
+        /// Creates [`PopupMessage::Event`] message.
+        PopupMessage:Event => fn event(UiMessage), layout: false
     );
 }
 
@@ -288,6 +300,8 @@ pub struct Popup {
     /// Smart placement prevents the popup from going outside of the screen bounds. It is usually used for tooltips,
     /// dropdown lists, etc. to prevent the content from being outside of the screen.
     pub smart_placement: InheritableVariable<bool>,
+    /// The destination for Event messages that relay messages from the children of this popup.
+    pub owner: Handle<UiNode>,
 }
 
 crate::define_widget_deref!(Popup);
@@ -452,6 +466,10 @@ impl Control for Popup {
                             ));
                         }
                     }
+                    PopupMessage::Owner(owner) => {
+                        self.owner = *owner;
+                    }
+                    PopupMessage::Event(_) => (),
                 }
             }
         } else if let Some(WidgetMessage::KeyDown(key)) = message.data() {
@@ -459,6 +477,16 @@ impl Control for Popup {
                 ui.send_message(PopupMessage::close(self.handle, MessageDirection::ToWidget));
                 message.set_handled(true);
             }
+        } else if self.owner.is_some()
+            && ui.is_valid_handle(self.owner)
+            && !message.handled()
+            && message.destination() != self.handle
+        {
+            ui.send_message(PopupMessage::event(
+                self.owner,
+                MessageDirection::ToWidget,
+                message.clone(),
+            ));
         }
     }
 
@@ -557,6 +585,7 @@ impl PopupBuilder {
             content: self.content.into(),
             smart_placement: self.smart_placement.into(),
             body: body.into(),
+            owner: Handle::NONE,
         }
     }
 


### PR DESCRIPTION
I have created another way to allow a widget to handle the events of popups that it opens by having the Popup widget clone the events of its children into a PopupMessage::Event(UiMessage) message.

I modified the context menu code so that when a context menu is opened, the owner of that popup is automatically set to be the widget that was under the right-click. Particularly, the widget being clicked on is the owner, not the widget that has the context menu, because sometimes the particular child that was under the mouse at time may be important information that should not be forgotten, and regardless the events will still bubble up to the widget that has the context menu.

I fixed the issue that was causing context menus to panic when they close. This was an unrelated issue, but fixing it was necessary for testing the PopupMessage::Event messages.

I added a custom Debug implementation for UiMessage, because debugging this commit required me to read many screens of UiMessage debug information and making it more compact was extremely helpful in this.