### PR TITLE
Preventing NavigationLayer from trying to change focus when tab_list is empty.

### DIFF
--- a/fyrox-ui/src/navigation.rs
+++ b/fyrox-ui/src/navigation.rs
@@ -90,29 +90,31 @@ impl Control for NavigationLayer {
                 }
             }
 
-            tab_list.sort_by_key(|entry| entry.tab_index);
+            if !tab_list.is_empty() {
+                tab_list.sort_by_key(|entry| entry.tab_index);
 
-            let focused_index = tab_list
-                .iter()
-                .position(|entry| entry.handle == ui.keyboard_focus_node)
-                .unwrap_or_default();
+                let focused_index = tab_list
+                    .iter()
+                    .position(|entry| entry.handle == ui.keyboard_focus_node)
+                    .unwrap_or_default();
 
-            let next_focused_node_index = if ui.keyboard_modifiers.shift {
-                let count = tab_list.len() as isize;
-                let mut prev = (focused_index as isize).saturating_sub(1);
-                if prev < 0 {
-                    prev += count;
+                let next_focused_node_index = if ui.keyboard_modifiers.shift {
+                    let count = tab_list.len() as isize;
+                    let mut prev = (focused_index as isize).saturating_sub(1);
+                    if prev < 0 {
+                        prev += count;
+                    }
+                    (prev % count) as usize
+                } else {
+                    focused_index.saturating_add(1) % tab_list.len()
+                };
+
+                if let Some(entry) = tab_list.get(next_focused_node_index) {
+                    ui.send_message(WidgetMessage::focus(
+                        entry.handle,
+                        MessageDirection::ToWidget,
+                    ));
                 }
-                (prev % count) as usize
-            } else {
-                focused_index.saturating_add(1) % tab_list.len()
-            };
-
-            if let Some(entry) = tab_list.get(next_focused_node_index) {
-                ui.send_message(WidgetMessage::focus(
-                    entry.handle,
-                    MessageDirection::ToWidget,
-                ));
             }
         }
     }


### PR DESCRIPTION
I discovered that tab navigation can panic due a mod 0 operation, and tracked the issue down to navigation.rs where the algorithm assumes that `tab_list` is not empty. I presume that when `tab_list` is empty, the correct thing to do is nothing.