### PR TITLE
Preventing TextBox and NumericUpDown from sending change messages when they have not really changed.

### DIFF
--- a/fyrox-ui/src/inspector/editors/immutable_string.rs
+++ b/fyrox-ui/src/inspector/editors/immutable_string.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     message::{MessageDirection, UiMessage},
     text::TextMessage,
-    text_box::TextBoxBuilder,
+    text_box::{TextBoxBuilder, TextCommitMode},
     widget::WidgetBuilder,
     Thickness, VerticalAlignment,
 };
@@ -40,6 +40,7 @@ impl PropertyEditorDefinition for ImmutableStringPropertyEditorDefinition {
                     .with_margin(Thickness::uniform(1.0)),
             )
             .with_wrap(WrapMode::Word)
+            .with_text_commit_mode(TextCommitMode::Changed)
             .with_text(value)
             .with_vertical_text_alignment(VerticalAlignment::Center)
             .build(ctx.build_context),

--- a/fyrox-ui/src/inspector/editors/string.rs
+++ b/fyrox-ui/src/inspector/editors/string.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     message::{MessageDirection, UiMessage},
     text::TextMessage,
-    text_box::TextBoxBuilder,
+    text_box::{TextBoxBuilder, TextCommitMode},
     widget::WidgetBuilder,
     Thickness, VerticalAlignment,
 };
@@ -36,6 +36,7 @@ impl PropertyEditorDefinition for StringPropertyEditorDefinition {
                     .with_margin(Thickness::uniform(1.0)),
             )
             .with_wrap(WrapMode::Word)
+            .with_text_commit_mode(TextCommitMode::Changed)
             .with_text(value)
             .with_vertical_text_alignment(VerticalAlignment::Center)
             .build(ctx.build_context),


### PR DESCRIPTION
Tabbing through an inspector should not cause the inspected object to change. To prevent this, I have created TextCommitMode::Changed which causes a record to be kept of the previous value of the field and refuses to acknowledge any editing to the field unless the result is different from the previous value.

I have modified the String property editor and ImmutableString property editor to use the new commit mode. I have also modified NumericUpDown to use the new commit mode, and modified the way that NumericUpDown parses its text to ensure that if the parsed value of the text does not change, then no change is acknowledged. This means that changing the number of 0s after the decimal point can never accidentally trigger an unwanted change in the value.

NumericUpDown was manually handling Enter-presses and Unfocus-messages rather than using the Text-message from the TextBox in order to detect changes in the text. This undermined the point of setting a TextCommitMode, so I changed NumericUpDown so that it allows its TextBox to decide when it has changed, and checks that the message has not been handled in order to avoid responding to changes that it sends to the TextBox.

I made it so that pressing Enter in a TextBox does not cause it to become unfocused. That would be awkward when using tab navigation.