### PR TITLE
Changing names of bases and widgets to ImmutableString

### DIFF
--- a/fyrox-animation/src/lib.rs
+++ b/fyrox-animation/src/lib.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     track::Track,
 };
+use core::ImmutableString;
 use fyrox_core::{NameProvider, TypeUuidProvider};
 use std::hash::Hash;
 use std::{
@@ -165,7 +166,7 @@ pub mod value;
 #[derive(Debug, Reflect, Visit, PartialEq)]
 pub struct Animation<T: EntityId> {
     #[visit(optional)]
-    name: String,
+    name: ImmutableString,
     tracks: Vec<Track<T>>,
     time_position: f32,
     #[visit(optional)]
@@ -275,7 +276,7 @@ impl<T: EntityId> Clone for Animation<T> {
 impl<T: EntityId> Animation<T> {
     /// Sets a new name for the animation. The name then could be used to find the animation in a container.
     pub fn set_name<S: AsRef<str>>(&mut self, name: S) {
-        self.name = name.as_ref().to_owned();
+        self.name = ImmutableString::new(name);
     }
 
     /// Returns current name of the animation.

--- a/fyrox-core/src/lib.rs
+++ b/fyrox-core/src/lib.rs
@@ -16,6 +16,7 @@ pub use nalgebra as algebra;
 pub use num_traits;
 pub use parking_lot;
 pub use rand;
+pub use sstorage::ImmutableString;
 pub use uuid;
 
 use crate::visitor::{Visit, VisitResult, Visitor};

--- a/fyrox-ui/src/dock/config.rs
+++ b/fyrox-ui/src/dock/config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{algebra::Vector2, log::Log, pool::Handle, visitor::prelude::*},
+    core::{algebra::Vector2, log::Log, pool::Handle, visitor::prelude::*, ImmutableString},
     dock::{Tile, TileBuilder, TileContent},
     message::MessageDirection,
     widget::WidgetBuilder,
@@ -34,7 +34,7 @@ impl Visit for SplitTilesDescriptor {
 pub enum TileContentDescriptor {
     #[default]
     Empty,
-    Window(String),
+    Window(ImmutableString),
     SplitTiles(SplitTilesDescriptor),
 }
 
@@ -105,7 +105,7 @@ impl TileDescriptor {
                     }
 
                     let mut window_handle =
-                        ui.find_handle(ui.root(), &mut |n| n.name() == window_name);
+                        ui.find_handle(ui.root(), &mut |n| n.name == *window_name);
 
                     if window_handle.is_none() {
                         for other_window_handle in windows.iter().cloned() {
@@ -153,7 +153,7 @@ impl TileDescriptor {
 
 #[derive(Debug, PartialEq, Clone, Visit, Default, Serialize, Deserialize)]
 pub struct FloatingWindowDescriptor {
-    pub name: String,
+    pub name: ImmutableString,
     pub position: Vector2<f32>,
     pub size: Vector2<f32>,
 }

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -12,6 +12,7 @@ use crate::{
         reflect::prelude::*,
         uuid::Uuid,
         visitor::prelude::*,
+        ImmutableString,
     },
     define_constructor,
     message::{CursorIcon, Force, KeyCode, MessageDirection, UiMessage},
@@ -671,7 +672,7 @@ pub struct Widget {
     #[reflect(hidden)]
     pub handle: Handle<UiNode>,
     /// Name of the widget. Could be useful for debugging purposes.
-    pub name: String,
+    pub name: ImmutableString,
     /// Desired position relative to the parent node. It is just a recommendation for the layout system, actual position
     /// will be stored in the `actual_local_position` field and can be fetched using [`Widget::actual_local_position`]
     /// method.
@@ -874,7 +875,7 @@ impl Widget {
     /// Sets the new name of the widget.
     #[inline]
     pub fn set_name<P: AsRef<str>>(&mut self, name: P) -> &mut Self {
-        self.name = name.as_ref().to_owned();
+        self.name = ImmutableString::new(name);
         self
     }
 
@@ -1320,7 +1321,7 @@ impl Widget {
                         self.foreground
                             .set_value_and_mark_modified(foreground.clone());
                     }
-                    WidgetMessage::Name(name) => self.name = name.clone(),
+                    WidgetMessage::Name(name) => self.name = ImmutableString::new(name),
                     &WidgetMessage::Width(width) => {
                         if *self.width != width {
                             self.set_width_notify(width);
@@ -2087,7 +2088,7 @@ impl WidgetBuilder {
     pub fn build(self) -> Widget {
         Widget {
             handle: Default::default(),
-            name: self.name,
+            name: self.name.into(),
             desired_local_position: self.desired_position.into(),
             width: self.width.into(),
             height: self.height.into(),


### PR DESCRIPTION
I have replaced the String names with ImmutableString names. In the process, I added several enhancements to ImmutableString. I added `From<String>` support to allow ImmutableStrings to be created without copying. I have added Serde implementations for ImmutableString, since Serde support is required for FloatingWindowDescriptor and TileContentDescriptor. I have added a `pub use` in the fyrox-core library to simplify using ImmutableString.

I have added tests to confirm that ImmutableStrings created by `From<String>` operate correctly, and testing Fyroxed with these changes reveals no ill effects.

I noticed a potential issue with one of the tests where it asserts a particular value for `entry_count()`, but the actual value of `entry_count()` depends on the order in which the tests are executed, which should be unpredictable. Therefore I commented out that assertion.

As an afterthought, I also turned Animation names into ImmutableStrings. I tried making a few animations and this change seems to have had no consequences.