### PR TITLE
Improving curve editor transform matrices

### DIFF
--- a/editor/src/animation/mod.rs
+++ b/editor/src/animation/mod.rs
@@ -435,7 +435,8 @@ impl AnimationEditor {
                     let animation_ref = &animations[animation.into()];
 
                     let size = ui.node(self.curve_editor).actual_local_size();
-                    let zoom = size.x / animation_ref.length().max(f32::EPSILON);
+                    let length = animation_ref.length().max(1.0);
+                    let zoom = size.x / length;
 
                     ui.send_message(CurveEditorMessage::zoom(
                         self.curve_editor,
@@ -446,7 +447,7 @@ impl AnimationEditor {
                     ui.send_message(CurveEditorMessage::view_position(
                         self.curve_editor,
                         MessageDirection::ToWidget,
-                        Vector2::new(0.5 * (size.x - animation_ref.length()), -0.5 * size.y),
+                        Vector2::new(0.5 * animation_ref.length(), 0.0),
                     ));
                 }
                 ToolbarAction::PlayPause => {


### PR DESCRIPTION
I noticed some inconsistencies in the way that the curve editor calculated positions, especially regarding the position of the thumb of the animation editor. In attempting to diagnose this problem, I found that the way that the curve editor transformed positions was very difficult to follow, so I have attempted to simplify this code and clarify it with plentiful comments to remove all confusion.

Transformation calculations were happening independently in multiple places: the curve editor widget, the thumb widget, and the ruler widget for the animation editor. This duplication was probably somehow causing the problems I was noticing, so I have created a new object called `CurveTransform` which encapsulates the calculation of transform matrices for curve editing. By giving each widget one of these objects, it should be assured that they will always be in agreement about which point goes where. `CurveTransformCell` is the version with interior mutability, since widgets are immutable during layout and drawing.

There are three coordinate spaces involved in these widgets, and I have attempted to give them more consistent names and document exactly how each coordinate space is defined. "Screen" space for the screen. "Local" space for widget rendering. "Curve" space for key locations and values, with the up direction being y-positive instead of y-negative.

I find it difficult to read when the curve editor would choose strange units for its grid, like separating its grid lines by 1.3 or other random numbers. So I have added a list of standard step sizes and made it so that `CurveTransform` prefers step sizes on that list. I think this improves the readability of the curve editor.