### PR TITLE
Improving animation selection and showing unselected curves.

### DIFF
--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -1060,17 +1060,24 @@ impl SceneController for GameScene {
                 (callback)(effect as &dyn Reflect);
             }
         } else if let Some(selection) = selection.as_animation() {
-            if let Some(animation) = scene
+            if let Some(player) = scene
                 .graph
                 .try_get_of_type::<AnimationPlayer>(selection.animation_player)
-                .and_then(|player| player.animations().try_get(selection.animation))
             {
-                if let Some(animation::selection::SelectedEntity::Signal(id)) =
-                    selection.entities.first()
-                {
-                    if let Some(signal) = animation.signals().iter().find(|s| s.id == *id) {
-                        (callback)(signal as &dyn Reflect);
+                if let Some(animation) = player.animations().try_get(selection.animation) {
+                    if let Some(animation::selection::SelectedEntity::Signal(id)) =
+                        selection.entities.first()
+                    {
+                        if let Some(signal) = animation.signals().iter().find(|s| s.id == *id) {
+                            (callback)(signal as &dyn Reflect);
+                        } else {
+                            (callback)(player as &dyn Reflect);
+                        }
+                    } else {
+                        (callback)(player as &dyn Reflect);
                     }
+                } else {
+                    (callback)(player as &dyn Reflect);
                 }
             }
         } else if let Some(selection) = selection.as_absm() {
@@ -1331,7 +1338,7 @@ impl PartialEq for Selection {
         if let (Some(this), Some(other)) = (self.0.as_ref(), other.0.as_ref()) {
             this.eq_ref(&**other)
         } else {
-            false
+            matches!((&self.0, &other.0), (None, None))
         }
     }
 }

--- a/editor/src/utils/mod.rs
+++ b/editor/src/utils/mod.rs
@@ -15,25 +15,27 @@ pub mod doc;
 pub mod path_fixer;
 pub mod ragdoll;
 
+/// True if `a` and `b` have the same length, and every element of `a` is equal to some element of `b`
+/// and every element of `b` is equal to some element of `a`.
 pub fn is_slice_equal_permutation<T: PartialEq>(a: &[T], b: &[T]) -> bool {
-    if a.is_empty() && !b.is_empty() {
-        false
-    } else {
-        // TODO: Find a way to do this faster.
-        for source in a.iter() {
-            let mut found = false;
-            for other in b.iter() {
-                if other == source {
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                return false;
+    a.len() == b.len() && is_slice_subset_permutation(a, b) && is_slice_subset_permutation(b, a)
+}
+
+/// True if every elmenet of `a` is equal to some element of `b`.
+pub fn is_slice_subset_permutation<T: PartialEq>(a: &[T], b: &[T]) -> bool {
+    for source in a.iter() {
+        let mut found = false;
+        for other in b.iter() {
+            if other == source {
+                found = true;
+                break;
             }
         }
-        true
+        if !found {
+            return false;
+        }
     }
+    true
 }
 
 pub fn window_content(window: Handle<UiNode>, ui: &UserInterface) -> Handle<UiNode> {
@@ -130,4 +132,39 @@ pub fn is_native_scene(path: &Path) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_subset() {
+        assert!(is_slice_subset_permutation(&[], &[1, 2, 3]));
+    }
+    #[test]
+    fn subset() {
+        assert!(is_slice_subset_permutation(&[2, 3], &[1, 2, 3]));
+    }
+    #[test]
+    fn not_subset() {
+        assert!(!is_slice_subset_permutation(&[1, 2, 3], &[1, 2]));
+    }
+    #[test]
+    fn not_empty() {
+        assert!(!is_slice_subset_permutation(&[1, 2], &[]));
+    }
+    #[test]
+    fn equal() {
+        assert!(is_slice_equal_permutation(&[1, 2], &[1, 2]));
+        assert!(is_slice_equal_permutation(&[1, 2], &[2, 1]));
+    }
+    #[test]
+    fn not_equal() {
+        assert!(!is_slice_equal_permutation(&[1, 2], &[1]));
+        assert!(!is_slice_equal_permutation(&[1], &[2, 1]));
+        assert!(!is_slice_equal_permutation(&[1, 2], &[2, 3]));
+        assert!(!is_slice_equal_permutation(&[1, 1], &[1, 2]));
+        assert!(!is_slice_equal_permutation(&[1, 2], &[2, 2]));
+    }
 }


### PR DESCRIPTION
This includes several improvements related to selection and animations:

* AnimationEditor remembers the handles of the most recently selected AnimationPlayer and Animation so that it can continue to treat them as if they are currently selected, even while the user may be selecting other things. This involved adding two additional fields to AnimationEditor and modifying `fetch_selection`.
* The animation curve editor is now enabled whenever an animation is selected, since there may potentially be visible curves even if no curve is selected.
* Instead of checking whether the selection is empty, the inspector now always tries `first_selected_entity` and clears itself if no entity is found. This allows `first_selected_entity` to potentially find entities to inspect even in empty selections, especially when the selection is an AnimationSelection with an empty item list. The inspector can keep inspecting the AnimationPlayer in spite of the selection being empty.
* The CurveEditor can now show curves that are not currently being edited. I have called these "background curves," since they serve as references for the user while editing other curves and signals. Background curves are uncolored and do not have handles.
* Fixed bug in `is_slice_equal_permutation` which was affecting when the selection was recognized as having changed. Added tests to ensure that `is_slice_equal_permutation` is working correctly.
* Made it so that PartialEq for Selection recognizes None == None. I presume this is how it was intended to work. 