### PR TITLE
Changing AABB validity to include zero-size dimensions to allow camera fitting to work with 2D objects.

### DIFF
--- a/editor/src/camera/mod.rs
+++ b/editor/src/camera/mod.rs
@@ -187,7 +187,7 @@ impl CameraController {
         let mut aabb = AxisAlignedBoundingBox::default();
         for descendant in scene.graph.traverse_iter(handle) {
             let descendant_aabb = descendant.local_bounding_box();
-            if descendant_aabb.is_valid() {
+            if !descendant_aabb.is_invalid_or_degenerate() {
                 aabb.add_box(descendant_aabb.transform(&descendant.global_transform()))
             }
         }

--- a/editor/src/camera/mod.rs
+++ b/editor/src/camera/mod.rs
@@ -187,7 +187,7 @@ impl CameraController {
         let mut aabb = AxisAlignedBoundingBox::default();
         for descendant in scene.graph.traverse_iter(handle) {
             let descendant_aabb = descendant.local_bounding_box();
-            if !descendant_aabb.is_invalid_or_degenerate() {
+            if descendant_aabb.is_valid() {
                 aabb.add_box(descendant_aabb.transform(&descendant.global_transform()))
             }
         }

--- a/fyrox-math/src/aabb.rs
+++ b/fyrox-math/src/aabb.rs
@@ -439,7 +439,7 @@ mod test {
         assert!(!_box.is_valid());
 
         _box.add_point(Vector3::new(1.0, 1.0, 1.0));
-        assert!(!_box.is_valid());
+        assert!(_box.is_valid());
 
         _box.add_point(Vector3::new(-1.0, -1.0, -1.0));
         assert!(_box.is_valid());

--- a/fyrox-math/src/aabb.rs
+++ b/fyrox-math/src/aabb.rs
@@ -144,9 +144,9 @@ impl AxisAlignedBoundingBox {
             x.iter().all(|e| e.is_nan() || e.is_infinite())
         }
 
-        self.max.x > self.min.x
-            && self.max.y > self.min.y
-            && self.max.z > self.min.z
+        self.max.x >= self.min.x
+            && self.max.y >= self.min.y
+            && self.max.z >= self.min.z
             && !is_nan_or_inf(&self.min)
             && !is_nan_or_inf(&self.max)
     }


### PR DESCRIPTION
I noticed that camera fitting tended to fail with some objects in my scene and I tracked the problem down to how the fitting algorithm excludes certain AABBs as "invalid" when the only problem with them is that they have zero length in one dimension. I think what validity is *really* supposed to check for that an AABB is not negative in any of its dimensions, so I changed the test for positive into a test for not-negative.