### PR TITLE
Change Keybinds to Industry Standard

### DIFF
--- a/fyrox-animation/src/spritesheet/mod.rs
+++ b/fyrox-animation/src/spritesheet/mod.rs
@@ -21,9 +21,9 @@ use strum_macros::{AsRefStr, EnumString, VariantNames};
 pub mod signal;
 
 /// Trait for anything that can be used as a texture.
-pub trait SpriteSheetTexture: Clone + Visit + Reflect + 'static {}
+pub trait SpriteSheetTexture: PartialEq + Clone + Visit + Reflect + 'static {}
 
-impl<T: Clone + Visit + Reflect + 'static> SpriteSheetTexture for T {}
+impl<T: PartialEq + Clone + Visit + Reflect + 'static> SpriteSheetTexture for T {}
 
 /// Animation playback status.
 #[derive(Visit, Reflect, Copy, Clone, Eq, PartialEq, Debug, AsRefStr, EnumString, VariantNames)]
@@ -170,6 +170,17 @@ where
     events: VecDeque<Event>,
 }
 
+impl<T: SpriteSheetTexture> PartialEq for SpriteSheetAnimation<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.frames_container == other.frames_container
+            && self.current_frame == other.current_frame
+            && self.speed == other.speed
+            && self.looping == other.looping
+            && self.signals == other.signals
+            && self.texture == other.texture
+    }
+}
+
 impl<T> TypeUuidProvider for SpriteSheetAnimation<T>
 where
     T: SpriteSheetTexture,
@@ -261,7 +272,7 @@ where
     /// # };
     /// # use fyrox_core::{reflect::prelude::*, visitor::prelude::*};
     /// #
-    /// #[derive(Clone, Reflect, Visit, Debug)]
+    /// #[derive(PartialEq, Clone, Reflect, Visit, Debug)]
     /// struct MyTexture {}
     ///
     /// fn extract_animations() {
@@ -554,7 +565,7 @@ mod test {
     };
     use fyrox_core::{algebra::Vector2, math::Rect, reflect::prelude::*, visitor::prelude::*};
 
-    #[derive(Clone, Reflect, Visit, Debug)]
+    #[derive(PartialEq, Clone, Reflect, Visit, Debug)]
     struct MyTexture {}
 
     #[test]

--- a/fyrox-animation/src/spritesheet/signal.rs
+++ b/fyrox-animation/src/spritesheet/signal.rs
@@ -6,7 +6,7 @@ use fyrox_core::uuid_provider;
 
 /// Animation signal is used as a point at which to notify external observers that animation just
 /// started to play a specific frame.
-#[derive(Visit, Reflect, Debug, Clone)]
+#[derive(PartialEq, Visit, Reflect, Debug, Clone)]
 pub struct Signal {
     /// Signal id. It should be used to distinguish different signals. For example, `JUMP` signal
     /// can have `id = 0`, while `CROUCH` signal - `id = 1`, etc.


### PR DESCRIPTION
Since Unity and Unreal Engine bind Q to down and E to up, the old key binds in Fyrox seem very counterintuitive. Therefore, I have modified the key binds to make E up rather than down and vice versa.