### PR TITLE
New terrain version with height texture margins and normals in shader

### DIFF
--- a/fyrox-impl/src/material/shader/standard/terrain.shader
+++ b/fyrox-impl/src/material/shader/standard/terrain.shader
@@ -135,13 +135,24 @@
                     // Each node has tex coords in [0; 1] range, here we must scale and offset it
                     // to match the actual position.
                     vec2 actualTexCoords = vec2(vertexTexCoord * nodeUvOffsets.zw + nodeUvOffsets.xy);
-                    float height = texture(heightMapTexture, actualTexCoords).r;
+                    vec2 heightSize = vec2(textureSize(heightMapTexture, 0));
+                    vec2 innerSize = heightSize - 3.0;
+                    vec2 pixelSize = 1.0 / heightSize;
+                    vec2 heightCoords = (actualTexCoords * innerSize + 1.5) * pixelSize;
+                    float height = texture(heightMapTexture, heightCoords).r;
                     vec4 finalVertexPosition = vec4(vertexPosition.x, height, vertexPosition.z, 1.0);
+                    float hx0 = texture(heightMapTexture, heightCoords + ivec2(-1, 0) * pixelSize, 0).r;
+                    float hx1 = texture(heightMapTexture, heightCoords + ivec2(1, 0) * pixelSize, 0).r;
+                    float hy0 = texture(heightMapTexture, heightCoords + ivec2(0, -1) * pixelSize, 0).r;
+                    float hy1 = texture(heightMapTexture, heightCoords + ivec2(0, 1) * pixelSize, 0).r;
+                    vec2 pixelFactor = heightSize / nodeUvOffsets.zw;
+                    vec3 n = vec3(hx0-hx1, 2.0, hy0-hy1) * vec3(pixelFactor.x, 1.0, pixelFactor.y);
+                    vec3 tan = vec3(n.y, -n.x, 0.0);
 
                     mat3 nm = mat3(fyrox_worldMatrix);
-                    normal = normalize(nm * vertexNormal);
-                    tangent = normalize(nm * vertexTangent.xyz);
-                    binormal = normalize(vertexTangent.w * cross(normal, tangent));
+                    normal = normalize(nm * n);
+                    tangent = normalize(nm * tan);
+                    binormal = normalize(-1.0 * cross(normal, tangent));
                     texCoord = actualTexCoords;
                     position = vec3(fyrox_worldMatrix * finalVertexPosition);
                     secondTexCoord = vertexSecondTexCoord;
@@ -206,8 +217,8 @@
 
                     outColor = diffuseColor * texture(diffuseTexture, tc);
 
-                    vec4 n = normalize(texture(normalTexture, tc) * 2.0 - 1.0);
-                    outNormal = vec4(normalize(tangentSpace * n.xyz) * 0.5 + 0.5, 1.0);
+                    vec3 n = normalize(texture(normalTexture, tc).xyz * 2.0 - 1.0);
+                    outNormal = vec4(normalize(tangentSpace * n), 1.0);
 
                     outMaterial.x = texture(metallicTexture, tc).r;
                     outMaterial.y = texture(roughnessTexture, tc).r;
@@ -277,7 +288,11 @@
                 void main()
                 {
                     vec2 actualTexCoords = vec2(vertexTexCoord * nodeUvOffsets.zw + nodeUvOffsets.xy);
-                    float height = texture(heightMapTexture, actualTexCoords).r;
+                    vec2 heightSize = vec2(textureSize(heightMapTexture, 0));
+                    vec2 innerSize = heightSize - 3.0;
+                    vec2 pixelSize = 1.0 / heightSize;
+                    vec2 heightCoords = (actualTexCoords * innerSize + 1.5) * pixelSize;
+                    float height = texture(heightMapTexture, heightCoords).r;
                     vec4 finalVertexPosition = vec4(vertexPosition.x, height, vertexPosition.z, 1.0);
 
                     gl_Position = fyrox_worldViewProjection * finalVertexPosition;
@@ -339,7 +354,11 @@
                 void main()
                 {
                     vec2 actualTexCoords = vec2(vertexTexCoord * nodeUvOffsets.zw + nodeUvOffsets.xy);
-                    float height = texture(heightMapTexture, actualTexCoords).r;
+                    vec2 heightSize = vec2(textureSize(heightMapTexture, 0));
+                    vec2 innerSize = heightSize - 3.0;
+                    vec2 pixelSize = 1.0 / heightSize;
+                    vec2 heightCoords = (actualTexCoords * innerSize + 1.5) * pixelSize;
+                    float height = texture(heightMapTexture, heightCoords).r;
                     vec4 finalVertexPosition = vec4(vertexPosition.x, height, vertexPosition.z, 1.0);
 
                     gl_Position = fyrox_worldViewProjection * finalVertexPosition;
@@ -398,7 +417,11 @@
                 void main()
                 {
                     vec2 actualTexCoords = vec2(vertexTexCoord * nodeUvOffsets.zw + nodeUvOffsets.xy);
-                    float height = texture(heightMapTexture, actualTexCoords).r;
+                    vec2 heightSize = vec2(textureSize(heightMapTexture, 0));
+                    vec2 innerSize = heightSize - 3.0;
+                    vec2 pixelSize = 1.0 / heightSize;
+                    vec2 heightCoords = (actualTexCoords * innerSize + 1.5) * pixelSize;
+                    float height = texture(heightMapTexture, heightCoords).r;
                     vec4 finalVertexPosition = vec4(vertexPosition.x, height, vertexPosition.z, 1.0);
 
                     gl_Position = fyrox_worldViewProjection * finalVertexPosition;
@@ -459,7 +482,11 @@
                 void main()
                 {
                     vec2 actualTexCoords = vec2(vertexTexCoord * nodeUvOffsets.zw + nodeUvOffsets.xy);
-                    float height = texture(heightMapTexture, actualTexCoords).r;
+                    vec2 heightSize = vec2(textureSize(heightMapTexture, 0));
+                    vec2 innerSize = heightSize - 3.0;
+                    vec2 pixelSize = 1.0 / heightSize;
+                    vec2 heightCoords = (actualTexCoords * innerSize + 1.5) * pixelSize;
+                    float height = texture(heightMapTexture, heightCoords).r;
                     vec4 finalVertexPosition = vec4(vertexPosition.x, height, vertexPosition.z, 1.0);
 
                     gl_Position = fyrox_worldViewProjection * finalVertexPosition;

--- a/fyrox-impl/src/material/shader/standard/terrain.shader
+++ b/fyrox-impl/src/material/shader/standard/terrain.shader
@@ -218,7 +218,7 @@
                     outColor = diffuseColor * texture(diffuseTexture, tc);
 
                     vec3 n = normalize(texture(normalTexture, tc).xyz * 2.0 - 1.0);
-                    outNormal = vec4(normalize(tangentSpace * n), 1.0);
+                    outNormal = vec4(normalize(tangentSpace * n) * 0.5 + 0.5, 1.0);
 
                     outMaterial.x = texture(metallicTexture, tc).r;
                     outMaterial.y = texture(roughnessTexture, tc).r;

--- a/fyrox-impl/src/scene/terrain/mod.rs
+++ b/fyrox-impl/src/scene/terrain/mod.rs
@@ -173,7 +173,6 @@ impl<'a> std::ops::Index<Vector2<i32>> for ChunkHeightData<'a> {
         let row_size = self.row_size();
         let x = (position.x + 1) as usize;
         let y = (position.y + 1) as usize;
-        // self.0.data_of_type().unwrap()[y * width + x]
         match self.0.data_of_type::<f32>() {
             Some(d) => &d[y * row_size + x],
             None => panic!("Height data type error: {:?}", self.0),
@@ -1332,7 +1331,7 @@ impl TypeUuidProvider for Terrain {
 }
 
 impl Terrain {
-    /// The height map of a chunk must have one-pixel margins around the edges which do not correpond
+    /// The height map of a chunk must have one-pixel margins around the edges which do not correspond
     /// to vertices in the terrain of that chunk, but are still needed for calculating the normal of
     /// the edge vertices.
     /// The normal for each vertex is derived from the heights of the four neighbor vertices, which means


### PR DESCRIPTION
Previously, terrain rendering had no normal data, with normals always pointing directly up. In order to resolve this problem, I have increased the terrain's version number from 1 to 2, and in the new version all height textures have a one-pixel margin with data that is copied from the neighboring chunks. This allows each terrain vertex to calculate its normal value based on the nearby heights.

This required a significant increase in complexity for the terrain shader and the terrain node in order to correctly account for the margins. During this process I have encountered numerous problems and fixed each one, but due to the complexity of the the whole project it is difficult to be totally confident that there are no unknown issues still remaining. At best I can say that everything *seems* to finally be working correctly, and it is so important for terrain to have correct normals.

While I was updating the visit method for the terrain, I modified the version system so that the terrain node no longer stores its version number. All terrain nodes currently in memory should always have the most current version. The version number is now just stored in the visitor, because that is all that is required in order for future terrain nodes to do conversions to update older versions.

I created a `validate` method for terrain nodes to alert users to the very particular requirements for height textures sizes and block sizes. It is practically impossible to allow total freedom in choosing these sizes without issues, so we should be firm that height textures need to be a power of 2 plus 3 on each dimension, both to allow room for the margins and to allow the texture to be recursively split into quads. For similar reasons, blocks should be a power of 2 plus 1 in each dimension, and obviously blocks should not be larger than the height texture.

I removed the `update_height_pixel` method that I previously created since it was originally misguided, unnecessary, and making it work with the new new height textures would have added more complexity and potential for bugs in an already error-prone project.