### PR TITLE
Terrain holes

### DIFF
--- a/fyrox-impl/src/material/shader/standard/terrain.shader
+++ b/fyrox-impl/src/material/shader/standard/terrain.shader
@@ -44,6 +44,10 @@
             kind: Sampler(default: None, fallback: White),
         ),
         (
+            name: "holeMaskTexture",
+            kind: Sampler(default: None, fallback: White),
+        ),
+        (
             name: "nodeUvOffsets",
             kind: Vector4((0.0, 0.0, 0.0, 0.0)),
         ),
@@ -180,6 +184,7 @@
                 uniform uint layerIndex;
                 uniform vec3 emissionStrength;
                 uniform sampler2D maskTexture;
+                uniform sampler2D holeMaskTexture;
                 uniform vec4 diffuseColor;
                 uniform float parallaxCenter;
                 uniform float parallaxScale;
@@ -198,6 +203,8 @@
 
                 void main()
                 {
+                    if (texture(holeMaskTexture, texCoord).r < 0.5) discard;
+
                     mat3 tangentSpace = mat3(tangent, binormal, normal);
                     vec3 toFragment = normalize(position - fyrox_cameraPosition);
 
@@ -304,6 +311,7 @@
                r#"
                 uniform sampler2D diffuseTexture;
                 uniform vec4 diffuseColor;
+                uniform sampler2D holeMaskTexture;
 
                 out vec4 FragColor;
 
@@ -311,6 +319,7 @@
 
                 void main()
                 {
+                    if (texture(holeMaskTexture, texCoord).r < 0.5) discard;
                     FragColor = diffuseColor * texture(diffuseTexture, texCoord);
                 }
                "#,
@@ -369,11 +378,13 @@
             fragment_shader:
                 r#"
                 uniform sampler2D diffuseTexture;
+                uniform sampler2D holeMaskTexture;
 
                 in vec2 texCoord;
 
                 void main()
                 {
+                    if (texture(holeMaskTexture, texCoord).r < 0.5) discard;
                     if (texture(diffuseTexture, texCoord).a < 0.2) discard;
                 }
                 "#,
@@ -432,11 +443,13 @@
             fragment_shader:
                 r#"
                 uniform sampler2D diffuseTexture;
+                uniform sampler2D holeMaskTexture;
 
                 in vec2 texCoord;
 
                 void main()
                 {
+                    if (texture(holeMaskTexture, texCoord).r < 0.5) discard;
                     if (texture(diffuseTexture, texCoord).a < 0.2) discard;
                 }
                 "#,
@@ -498,6 +511,7 @@
             fragment_shader:
                 r#"
                 uniform sampler2D diffuseTexture;
+                uniform sampler2D holeMaskTexture;
 
                 uniform vec3 fyrox_lightPosition;
 
@@ -508,6 +522,7 @@
 
                 void main()
                 {
+                    if (texture(holeMaskTexture, texCoord).r < 0.5) discard;
                     if (texture(diffuseTexture, texCoord).a < 0.2) discard;
                     depth = length(fyrox_lightPosition - worldPosition);
                 }


### PR DESCRIPTION
Introducing holes to the terrain. This involves:

* A new command: `ModifyTerrainHolesCommand` which is almost exactly like `ModifyTerrainHeightCommand`.
* A new brush target `HoleMask`.
* Modifications to the standard terrain shader to allow it to accept the hole mask and to discard pixels within the holes.
* Modifications to how terrain colliders are generated, including ensuring that the collider is aligned with the terrain so long as the collider node is at the same position as the terrain node.
* Modifications to how terrain textures are resizes so that the hole mask texture size is kept synchronized with the height map texture size.

Nothing has been done to help the collider stay in sync with changes to the terrain. That is can be work for a future commit.