### PR TITLE
fix an invalid editor window size on second startup at the hidpi display

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -90,7 +90,7 @@ use crate::{
             watcher::FileSystemWatcher,
             TypeUuidProvider,
         },
-        dpi::{LogicalSize, PhysicalPosition},
+        dpi::{PhysicalPosition, PhysicalSize},
         engine::{Engine, EngineInitParams, GraphicsContextParams, SerializationContext},
         event::{Event, WindowEvent},
         event_loop::{EventLoop, EventLoopWindowTarget},
@@ -561,7 +561,7 @@ impl Editor {
             )),
         }
 
-        let inner_size = LogicalSize::new(
+        let inner_size = PhysicalSize::new(
             settings.windows.window_size.x,
             settings.windows.window_size.y,
         );


### PR DESCRIPTION
Probably was broken in the `811a13426ddb808e778c6ac436671eef87aab9af` commit for the #453 issue, but issue still not fixed.
The window_size field is used as the `PhysicalSize` in all other cases.

Editor start with a size greater than a display size if it takes the window size from the `settings.ron`.
![image](https://github.com/user-attachments/assets/676eb391-865b-4907-b535-26cd09486dc6)

Maybe the problem of the #453 what the `logical_size` is [used](https://github.com/FyroxEngine/Fyrox/blob/4c9a41f273d2c82e48528bae7388d81fb16dca5c/editor/src/lib.rs#L2795) for the `user_interfaces` actions when in other places in code the `PhysicalSize` was passed to render related code? What if some of that places also needs in the `LogicalSize` instead of the `PhysicalSize`?

Host PC info:
OS: Windows 11 23H2
Display: 1920x1080 scaling 150%, 2560x1440 scaling 150%