### PR TITLE
Ensure vector images have a set size

### DIFF
--- a/fyrox-ui/src/check_box.rs
+++ b/fyrox-ui/src/check_box.rs
@@ -331,20 +331,23 @@ impl CheckBoxBuilder {
     /// Finishes check box building and adds it to the user interface.
     pub fn build(self, ctx: &mut BuildContext) -> Handle<UiNode> {
         let check_mark = self.check_mark.unwrap_or_else(|| {
+            let size = 7.0;
+            let half_size = size * 0.5;
+
             BorderBuilder::new(
                 WidgetBuilder::new()
                     .with_background(BRUSH_BRIGHT_BLUE)
                     .with_child(
                         VectorImageBuilder::new(
                             WidgetBuilder::new()
-                                .with_margin(Thickness::uniform(3.0))
                                 .with_vertical_alignment(VerticalAlignment::Center)
                                 .with_horizontal_alignment(HorizontalAlignment::Center)
+                                // Give some padding to ensure primitives don't get too cut off
+                                .with_width(size + 1.0)
+                                .with_height(size + 1.0)
                                 .with_foreground(BRUSH_TEXT),
                         )
                         .with_primitives({
-                            let size = 8.0;
-                            let half_size = size * 0.5;
                             vec![
                                 Primitive::Line {
                                     begin: Vector2::new(0.0, half_size),

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -955,6 +955,8 @@ impl<'a, 'b> MenuItemBuilder<'a, 'b> {
                                 .with_visibility(!self.items.is_empty())
                                 .on_row(1)
                                 .on_column(3)
+                                .with_width(8.0)
+                                .with_height(8.0)
                                 .with_foreground(BRUSH_BRIGHT)
                                 .with_horizontal_alignment(HorizontalAlignment::Center)
                                 .with_vertical_alignment(VerticalAlignment::Center),

--- a/fyrox-ui/src/searchbar.rs
+++ b/fyrox-ui/src/searchbar.rs
@@ -235,14 +235,10 @@ impl SearchBarBuilder {
                                 .with_content(
                                     VectorImageBuilder::new(
                                         WidgetBuilder::new()
-                                            .with_margin(Thickness {
-                                                left: 2.0,
-                                                top: 2.0,
-                                                right: 0.0,
-                                                bottom: 0.0,
-                                            })
                                             .with_horizontal_alignment(HorizontalAlignment::Center)
                                             .with_vertical_alignment(VerticalAlignment::Center)
+                                            .with_height(8.0)
+                                            .with_width(8.0)
                                             .with_foreground(BRUSH_BRIGHTEST),
                                     )
                                     .with_primitives(make_cross_primitive(8.0, 2.0))

--- a/fyrox-ui/src/tab_control.rs
+++ b/fyrox-ui/src/tab_control.rs
@@ -153,7 +153,7 @@ pub struct Tab {
 ///                 header: TextBuilder::new(WidgetBuilder::new())
 ///                             .with_text("First")
 ///                             .build(ctx),
-///                             
+///
 ///                 content: TextBuilder::new(WidgetBuilder::new())
 ///                             .with_text("First tab's contents!")
 ///                             .build(ctx),
@@ -166,7 +166,7 @@ pub struct Tab {
 ///                 header: TextBuilder::new(WidgetBuilder::new())
 ///                             .with_text("Second")
 ///                             .build(ctx),
-///                             
+///
 ///                 content: TextBuilder::new(WidgetBuilder::new())
 ///                             .with_text("Second tab's contents!")
 ///                             .build(ctx),
@@ -431,14 +431,10 @@ impl Header {
                                 .with_content(
                                     VectorImageBuilder::new(
                                         WidgetBuilder::new()
-                                            .with_margin(Thickness {
-                                                left: 2.0,
-                                                top: 2.0,
-                                                right: 0.0,
-                                                bottom: 0.0,
-                                            })
                                             .with_horizontal_alignment(HorizontalAlignment::Center)
                                             .with_vertical_alignment(VerticalAlignment::Center)
+                                            .with_width(8.0)
+                                            .with_height(8.0)
                                             .with_foreground(BRUSH_BRIGHTEST),
                                     )
                                     .with_primitives(make_cross_primitive(8.0, 2.0))

--- a/fyrox-ui/src/utils.rs
+++ b/fyrox-ui/src/utils.rs
@@ -86,6 +86,8 @@ pub fn make_arrow_non_uniform_size(
     VectorImageBuilder::new(
         WidgetBuilder::new()
             .with_foreground(BRUSH_BRIGHT)
+            .with_width(width)
+            .with_height(height)
             .with_horizontal_alignment(HorizontalAlignment::Center)
             .with_vertical_alignment(VerticalAlignment::Center),
     )
@@ -125,6 +127,8 @@ pub fn make_cross(ctx: &mut BuildContext, size: f32, thickness: f32) -> Handle<U
         WidgetBuilder::new()
             .with_horizontal_alignment(HorizontalAlignment::Center)
             .with_vertical_alignment(VerticalAlignment::Center)
+            .with_width(size)
+            .with_height(size)
             .with_foreground(BRUSH_BRIGHT),
     )
     .with_primitives(make_cross_primitive(size, thickness))

--- a/fyrox-ui/src/vector_image.rs
+++ b/fyrox-ui/src/vector_image.rs
@@ -47,7 +47,7 @@ pub enum Primitive {
         /// Points of the triangle in local coordinates.
         points: [Vector2<f32>; 3],
     },
-    /// A line of fixed thickness between two points.  
+    /// A line of fixed thickness between two points.
     Line {
         /// Beginning of the line in local coordinates.
         begin: Vector2<f32>,

--- a/fyrox-ui/src/window.rs
+++ b/fyrox-ui/src/window.rs
@@ -129,7 +129,7 @@ pub enum WindowMessage {
 
     /// Safe border size defines "part" of a window that should always be on screen when dragged.
     /// It is used to prevent moving window outside of main application window bounds, to still
-    /// be able to drag it.  
+    /// be able to drag it.
     SafeBorderSize(Option<Vector2<f32>>),
 }
 
@@ -1099,6 +1099,8 @@ enum HeaderButton {
 }
 
 fn make_mark(ctx: &mut BuildContext, button: HeaderButton) -> Handle<UiNode> {
+    let size = 12.0;
+
     VectorImageBuilder::new(
         WidgetBuilder::new()
             .with_horizontal_alignment(HorizontalAlignment::Center)
@@ -1107,11 +1109,8 @@ fn make_mark(ctx: &mut BuildContext, button: HeaderButton) -> Handle<UiNode> {
                 HeaderButton::Minimize => VerticalAlignment::Bottom,
                 HeaderButton::Maximize => VerticalAlignment::Center,
             })
-            .with_margin(match button {
-                HeaderButton::Close => Thickness::uniform(0.0),
-                HeaderButton::Minimize => Thickness::bottom(3.0),
-                HeaderButton::Maximize => Thickness::bottom(0.0),
-            })
+            .with_width(size)
+            .with_height(size)
             .with_foreground(BRUSH_BRIGHT),
     )
     .with_primitives(match button {
@@ -1119,25 +1118,26 @@ fn make_mark(ctx: &mut BuildContext, button: HeaderButton) -> Handle<UiNode> {
             vec![
                 Primitive::Line {
                     begin: Vector2::new(0.0, 0.0),
-                    end: Vector2::new(12.0, 12.0),
+                    end: Vector2::new(size, size),
                     thickness: 1.0,
                 },
                 Primitive::Line {
-                    begin: Vector2::new(12.0, 0.0),
-                    end: Vector2::new(0.0, 12.0),
+                    begin: Vector2::new(size, 0.0),
+                    end: Vector2::new(0.0, size),
                     thickness: 1.0,
                 },
             ]
         }
         HeaderButton::Minimize => {
+            let bottom_spacing = 3.0;
+
             vec![Primitive::Line {
-                begin: Vector2::new(0.0, 0.0),
-                end: Vector2::new(12.0, 0.0),
+                begin: Vector2::new(0.0, size - bottom_spacing),
+                end: Vector2::new(size, size - bottom_spacing),
                 thickness: 1.0,
             }]
         }
         HeaderButton::Maximize => {
-            let size = 12.0;
             let thickness = 1.25;
             let half_thickness = thickness * 0.5;
 


### PR DESCRIPTION
Helps avoid the use of margins to center vector images and allows most of the other vector images to remain centered (most noticeable in the checkbox and window close button)