### PR TITLE
support a saving/restoring the maximized flag of the editor's window

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -563,6 +563,7 @@ impl Editor {
         );
 
         let mut window_attributes = WindowAttributes::default();
+        window_attributes.maximized = settings.windows.window_maximized;
         window_attributes.inner_size = Some(inner_size.into());
         window_attributes.position = Some(
             PhysicalPosition::new(
@@ -2780,13 +2781,9 @@ impl Editor {
                                 );
                             }
 
-                            let logical_size = size.to_logical(
-                                self.engine
-                                    .graphics_context
-                                    .as_initialized_ref()
-                                    .window
-                                    .scale_factor(),
-                            );
+                            let window = &self.engine.graphics_context.as_initialized_ref().window;
+
+                            let logical_size = size.to_logical(window.scale_factor());
                             self.engine.user_interfaces.first_mut().send_message(
                                 WidgetMessage::width(
                                     self.root_grid,
@@ -2806,6 +2803,8 @@ impl Editor {
                                 self.settings.windows.window_size.x = size.width as f32;
                                 self.settings.windows.window_size.y = size.height as f32;
                             }
+
+                            self.settings.windows.window_maximized = window.is_maximized();
                         }
                         WindowEvent::Focused(focused) => {
                             self.focused = *focused;

--- a/editor/src/settings/windows.rs
+++ b/editor/src/settings/windows.rs
@@ -31,6 +31,8 @@ pub struct WindowsSettings {
     #[serde(default)]
     pub window_size: Vector2<f32>,
     #[serde(default)]
+    pub window_maximized: bool,
+    #[serde(default)]
     #[reflect(hidden)]
     pub layout: Option<DockingManagerLayoutDescriptor>,
 }
@@ -40,6 +42,7 @@ impl Default for WindowsSettings {
         Self {
             window_position: Vector2::new(0.0, 0.0),
             window_size: Vector2::new(1024.0, 768.0),
+            window_maximized: true,
             layout: None,
         }
     }


### PR DESCRIPTION
**NOTE**: after merging this PR the editor's window will be maximized by default settings at a startup.