### PR TITLE
post_update callback for Plugin

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -3015,7 +3015,7 @@ fn update(editor: &mut Editor, window_target: &EventLoopWindowTarget<()>) {
 
         editor
             .engine
-            .post_update(FIXED_TIMESTEP, &Default::default());
+            .post_update(FIXED_TIMESTEP, &Default::default(), &mut editor.game_loop_data.lag, window_target);
 
         if need_reload_plugins {
             let on_plugin_reloaded = |plugin: &dyn Plugin| {

--- a/fyrox-impl/src/plugin/mod.rs
+++ b/fyrox-impl/src/plugin/mod.rs
@@ -300,6 +300,9 @@ pub trait Plugin: BasePlugin + Visit + Reflect {
     /// info).
     fn update(&mut self, #[allow(unused_variables)] context: &mut PluginContext) {}
 
+    /// called after all Plugin and Script updates
+    fn post_update(&mut self, #[allow(unused_variables)] context: &mut PluginContext) {}
+
     /// The method is called when the main window receives an event from the OS. The main use of
     /// the method is to respond to some external events, for example an event from keyboard or
     /// gamepad. See [`Event`] docs for more info.


### PR DESCRIPTION
It's necessary to create IM-style "Input" abstraction like [this](https://docs.unity3d.com/ScriptReference/Input.html). To be more precise, fully-functional IM-style Input assumes keeping the state of which button was pressed or released at exactly this frame, which is not possible without the event that either called before all events or after all updates.