### PR TITLE
Cloning physics when cloning Graph to persist Scene settings when sav…

### DIFF
--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -506,6 +506,17 @@ pub struct PhysicsWorld {
     debug_render_pipeline: Mutex<DebugRenderPipeline>,
 }
 
+impl Clone for PhysicsWorld {
+    fn clone(&self) -> Self {
+        PhysicsWorld {
+            enabled: self.enabled.clone(),
+            integration_parameters: self.integration_parameters.clone(),
+            gravity: self.gravity.clone(),
+            ..Default::default()
+        }
+    }
+}
+
 fn isometry_from_global_transform(transform: &Matrix4<f32>) -> Isometry2<f32> {
     Isometry2 {
         translation: Translation2::new(transform[12], transform[13]),

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -1340,6 +1340,8 @@ impl Graph {
     {
         let mut copy = Self {
             sound_context: self.sound_context.deep_clone(),
+            physics: self.physics.clone(),
+            physics2d: self.physics2d.clone(),
             ..Default::default()
         };
 

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -1016,6 +1016,17 @@ pub struct PhysicsWorld {
     debug_render_pipeline: Mutex<DebugRenderPipeline>,
 }
 
+impl Clone for PhysicsWorld {
+    fn clone(&self) -> Self {
+        PhysicsWorld {
+            enabled: self.enabled.clone(),
+            integration_parameters: self.integration_parameters.clone(),
+            gravity: self.gravity.clone(),
+            ..Default::default()
+        }
+    }
+}
+
 fn isometry_from_global_transform(transform: &Matrix4<f32>) -> Isometry3<f32> {
     Isometry3 {
         translation: Translation3::new(transform[12], transform[13], transform[14]),


### PR DESCRIPTION
…ing Scene from the editor

Trying to fix : https://github.com/FyroxEngine/Fyrox/issues/696

This clones properties that are not `#[visit(skip)]` because it's the same mechanism as far as I understand it.

As mentioned in the issue, this might not fit the engine design and there might be other properties in the scene that were forgotten to clone.

*By the way, since Visiting is a form of cloning, isn't there a way to implement automatically Clone based on Visit impl (via macro or extending trait) ?*