### PR TITLE
Introducing Fyrox Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![docs.rs](https://img.shields.io/badge/docs-website-blue)](https://docs.rs/Fyrox/)
 [![Discord](https://img.shields.io/discord/756573453561102427)](https://discord.gg/xENF5Uh)
 [![Lines of code](https://tokei.rs/b1/github/FyroxEngine/Fyrox)](https://github.com/FyroxEngine/Fyrox)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Fyrox%20Guru-006BFF)](https://gurubase.io/g/fyrox)
 
 A feature-rich, production-ready, general purpose 2D/3D game engine written in Rust with a scene editor.
 _Formerly known as rg3d_


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Fyrox Guru](https://gurubase.io/g/fyrox) to Gurubase. Fyrox Guru uses the data from this repo and data from the [docs](https://fyrox-book.github.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Fyrox Guru", which highlights that Fyrox now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Fyrox Guru in Gurubase, just let me know that's totally fine.
