### PR TITLE
Animation tracks data resource

### DIFF
--- a/editor/src/absm/mod.rs
+++ b/editor/src/absm/mod.rs
@@ -571,8 +571,8 @@ impl AbsmEditor {
 
                         let mut animation_targets = FxHashSet::default();
                         for animation in animations.iter_mut() {
-                            for track in animation.tracks() {
-                                animation_targets.insert(track.target());
+                            for track_binding in animation.track_bindings().values() {
+                                animation_targets.insert(track_binding.target());
                             }
                         }
 

--- a/editor/src/absm/toolbar.rs
+++ b/editor/src/absm/toolbar.rs
@@ -255,8 +255,8 @@ impl Toolbar {
                         animation_container_ref(graph, selection.absm_node_handle)
                     {
                         for animation in animations.iter() {
-                            for track in animation.tracks() {
-                                unique_nodes.insert(track.target());
+                            for track_binding in animation.track_bindings().values() {
+                                unique_nodes.insert(track_binding.target());
                             }
                         }
                     }

--- a/editor/src/animation/command/mod.rs
+++ b/editor/src/animation/command/mod.rs
@@ -119,6 +119,7 @@ pub struct RemoveTrackCommand<N: Debug + 'static> {
     animation_player: Handle<N>,
     animation: Handle<Animation<Handle<N>>>,
     id: Uuid,
+    #[allow(clippy::type_complexity)]
     track: Option<(usize, (TrackBinding<Handle<N>>, Track))>,
 }
 

--- a/editor/src/animation/command/mod.rs
+++ b/editor/src/animation/command/mod.rs
@@ -38,6 +38,7 @@ use crate::{
     scene::{commands::GameSceneContext, Selection},
     ui_scene::commands::UiSceneContext,
 };
+use fyrox::generic_animation::track::TrackBinding;
 use std::{
     fmt::Debug,
     ops::{IndexMut, Range},
@@ -73,19 +74,22 @@ pub fn fetch_animations_container<N: Debug + 'static>(
 pub struct AddTrackCommand<N: Debug + 'static> {
     animation_player: Handle<N>,
     animation: Handle<Animation<Handle<N>>>,
-    track: Option<Track<Handle<N>>>,
+    track: Option<Track>,
+    binding: TrackBinding<Handle<N>>,
 }
 
 impl<N: Debug + 'static> AddTrackCommand<N> {
     pub fn new(
         animation_player: Handle<N>,
         animation: Handle<Animation<Handle<N>>>,
-        track: Track<Handle<N>>,
+        track: Track,
+        binding: TrackBinding<Handle<N>>,
     ) -> Self {
         Self {
             animation_player,
             animation,
             track: Some(track),
+            binding,
         }
     }
 }
@@ -97,12 +101,16 @@ impl<N: Debug + 'static> CommandTrait for AddTrackCommand<N> {
 
     fn execute(&mut self, context: &mut dyn CommandContext) {
         fetch_animations_container(self.animation_player, context)[self.animation]
-            .add_track(self.track.take().unwrap());
+            .add_track_with_binding(self.binding.clone(), self.track.take().unwrap());
     }
 
     fn revert(&mut self, context: &mut dyn CommandContext) {
-        self.track =
-            fetch_animations_container(self.animation_player, context)[self.animation].pop_track();
+        let (binding, track) = fetch_animations_container(self.animation_player, context)
+            [self.animation]
+            .pop_track_with_binding()
+            .unwrap();
+        self.binding = binding;
+        self.track = Some(track);
     }
 }
 
@@ -111,7 +119,7 @@ pub struct RemoveTrackCommand<N: Debug + 'static> {
     animation_player: Handle<N>,
     animation: Handle<Animation<Handle<N>>>,
     id: Uuid,
-    track: Option<(usize, Track<Handle<N>>)>,
+    track: Option<(usize, (TrackBinding<Handle<N>>, Track))>,
 }
 
 impl<N: Debug + 'static> RemoveTrackCommand<N> {
@@ -138,17 +146,22 @@ impl<N: Debug + 'static> CommandTrait for RemoveTrackCommand<N> {
         let animation =
             &mut fetch_animations_container(self.animation_player, context)[self.animation];
         let index = animation
+            .tracks_data()
+            .state()
+            .data()
+            .unwrap()
             .tracks_mut()
             .iter()
             .position(|t| t.id() == self.id)
             .unwrap();
-        self.track = Some((index, animation.remove_track(index)));
+        self.track = Some((index, animation.remove_track_with_binding(index).unwrap()));
     }
 
     fn revert(&mut self, context: &mut dyn CommandContext) {
-        let (index, track) = self.track.take().unwrap();
-        fetch_animations_container(self.animation_player, context)[self.animation]
-            .insert_track(index, track);
+        let (index, (binding, track)) = self.track.take().unwrap();
+        let animation =
+            &mut fetch_animations_container(self.animation_player, context)[self.animation];
+        animation.insert_track_with_binding(index, binding, track);
     }
 }
 
@@ -161,9 +174,13 @@ pub struct ReplaceTrackCurveCommand<N: Debug + 'static> {
 
 impl<N: Debug + 'static> ReplaceTrackCurveCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
-        for track in
-            fetch_animations_container(self.animation_player, context)[self.animation].tracks_mut()
-        {
+        let animation =
+            &mut fetch_animations_container(self.animation_player, context)[self.animation];
+
+        let mut tracks_data_state = animation.tracks_data().state();
+        let tracks_data = tracks_data_state.data().unwrap();
+
+        for track in tracks_data.tracks_mut() {
             for curve in track.data_container_mut().curves_mut() {
                 if curve.id() == self.curve.id() {
                     std::mem::swap(&mut self.curve, curve);
@@ -601,9 +618,8 @@ pub struct SetTrackEnabledCommand<N: Debug + 'static> {
 impl<N: Debug + 'static> SetTrackEnabledCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
         let track = fetch_animation(self.animation_player_handle, self.animation_handle, context)
-            .tracks_mut()
-            .iter_mut()
-            .find(|t| t.id() == self.track)
+            .track_bindings_mut()
+            .get_mut(&self.track)
             .unwrap();
 
         let old = track.is_enabled();
@@ -637,9 +653,8 @@ pub struct SetTrackTargetCommand<N: Debug + 'static> {
 impl<N: Debug + 'static> SetTrackTargetCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
         let track = fetch_animation(self.animation_player_handle, self.animation_handle, context)
-            .tracks_mut()
-            .iter_mut()
-            .find(|t| t.id() == self.track)
+            .track_bindings_mut()
+            .get_mut(&self.track)
             .unwrap();
 
         let old = track.target();
@@ -663,28 +678,33 @@ impl<N: Debug + 'static> CommandTrait for SetTrackTargetCommand<N> {
 }
 
 #[derive(Debug)]
-pub struct SetTrackBindingCommand<N: Debug + 'static> {
+pub struct SetTrackValueBindingCommand<N: Debug + 'static> {
     pub animation_player_handle: Handle<N>,
     pub animation_handle: Handle<Animation<Handle<N>>>,
     pub track: Uuid,
     pub binding: ValueBinding,
 }
 
-impl<N: Debug + 'static> SetTrackBindingCommand<N> {
+impl<N: Debug + 'static> SetTrackValueBindingCommand<N> {
     fn swap(&mut self, context: &mut dyn CommandContext) {
-        let track = fetch_animation(self.animation_player_handle, self.animation_handle, context)
+        let animation =
+            fetch_animation(self.animation_player_handle, self.animation_handle, context);
+        let mut tracks_data_state = animation.tracks_data().state();
+        let tracks_data = tracks_data_state.data().unwrap();
+
+        let track = tracks_data
             .tracks_mut()
             .iter_mut()
             .find(|t| t.id() == self.track)
             .unwrap();
 
-        let old = track.binding().clone();
-        track.set_binding(self.binding.clone());
+        let old = track.value_binding().clone();
+        track.set_value_binding(self.binding.clone());
         self.binding = old;
     }
 }
 
-impl<N: Debug + 'static> CommandTrait for SetTrackBindingCommand<N> {
+impl<N: Debug + 'static> CommandTrait for SetTrackValueBindingCommand<N> {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Set Track Binding".to_string()
     }

--- a/editor/src/animation/mod.rs
+++ b/editor/src/animation/mod.rs
@@ -468,9 +468,9 @@ impl AnimationEditor {
                         animation.rewind();
 
                         let animation_targets = animation
-                            .tracks()
-                            .iter()
-                            .map(|t| t.target())
+                            .track_bindings()
+                            .values()
+                            .map(|binding| binding.target())
                             .collect::<FxHashSet<_>>();
 
                         self.enter_preview_mode(
@@ -689,6 +689,11 @@ impl AnimationEditor {
                 self.track_list
                     .sync_to_model(animation, graph, &selection, ui);
 
+                let animation_tracks_data_state = animation.tracks_data().state();
+                let Some(animation_tracks_data) = animation_tracks_data_state.data_ref() else {
+                    return;
+                };
+
                 send_sync_message(
                     ui,
                     CurveEditorMessage::hightlight_zones(
@@ -729,7 +734,8 @@ impl AnimationEditor {
                         SelectedEntity::Track(track_id) => {
                             // If a track is selected, show all its curves at once. This way it will
                             // be easier to edit complex values, such as Vector2/3/4.
-                            if let Some(track) = animation
+
+                            if let Some(track) = animation_tracks_data
                                 .tracks()
                                 .iter()
                                 .find(|track| &track.id() == track_id)
@@ -748,7 +754,7 @@ impl AnimationEditor {
                         }
                         SelectedEntity::Curve(curve_id) => {
                             if let Some((index, selected_curve)) =
-                                animation.tracks().iter().find_map(|t| {
+                                animation_tracks_data.tracks().iter().find_map(|t| {
                                     t.data_container().curves_ref().iter().enumerate().find_map(
                                         |(i, c)| {
                                             if &c.id() == curve_id {
@@ -772,7 +778,7 @@ impl AnimationEditor {
                     }
                 }
                 let mut background_curves = Vec::<Curve>::new();
-                for track in animation.tracks() {
+                for track in animation_tracks_data.tracks() {
                     for curve in track.data_container().curves_ref() {
                         if !selected_curves.iter().any(|(_, c)| c.id == curve.id) {
                             background_curves.push(curve.clone());

--- a/fyrox-animation/Cargo.toml
+++ b/fyrox-animation/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.72"
 
 [dependencies]
 fyrox-core = { version = "0.28.1", path = "../fyrox-core" }
+fyrox-resource = { version = "0.12.0", path = "../fyrox-resource" }
 strum = "0.26.1"
 strum_macros = "0.26.1"
 fxhash = "0.2.1"

--- a/fyrox-animation/src/lib.rs
+++ b/fyrox-animation/src/lib.rs
@@ -226,18 +226,18 @@ pub type AnimationTracksDataResource = Resource<AnimationTracksData>;
 /// a guide **only** if you need to create procedural animations:
 ///
 /// ```rust
-/// use fyrox_animation::{
-///     container::{TrackDataContainer, TrackValueKind},
-///     track::Track,
-///     value::ValueBinding,
-///     Animation,
-///     core::{
-///         math::curve::{Curve, CurveKey, CurveKeyKind},
-///         pool::Handle,
-///     },
-/// };
-/// use fyrox_core::pool::ErasedHandle;
-///
+/// # use fyrox_animation::{
+/// #     container::{TrackDataContainer, TrackValueKind},
+/// #     track::Track,
+/// #     value::ValueBinding,
+/// #     Animation,
+/// #     core::{
+/// #         math::curve::{Curve, CurveKey, CurveKeyKind},
+/// #         pool::Handle,
+/// #     },
+/// # };
+/// # use fyrox_animation::track::TrackBinding;
+/// # use fyrox_core::pool::ErasedHandle;
 /// fn create_animation(target: ErasedHandle) -> Animation<ErasedHandle> {
 ///     let mut frames_container = TrackDataContainer::new(TrackValueKind::Vector3);
 ///
@@ -248,13 +248,12 @@ pub type AnimationTracksDataResource = Resource<AnimationTracksData>;
 ///         CurveKey::new(1.0, 3.0, CurveKeyKind::Linear),
 ///     ]);
 ///
-///     // Create a track that will animated the node using the curve above.
+///     // Create a track that will animate the node using the curve above.
 ///     let mut track = Track::new(frames_container, ValueBinding::Position);
-///     track.set_target(target);
 ///
 ///     // Finally create an animation and set its time slice and turn it on.
 ///     let mut animation = Animation::default();
-///     animation.add_track_with_binding(track);
+///     animation.add_track_with_binding(TrackBinding::new(target), track);
 ///     animation.set_time_slice(0.0..1.0);
 ///     animation.set_enabled(true);
 ///

--- a/fyrox-animation/src/track.rs
+++ b/fyrox-animation/src/track.rs
@@ -28,24 +28,62 @@ use crate::{
 };
 use std::fmt::Debug;
 
+#[derive(Debug, Visit, Reflect, Clone, PartialEq)]
+pub struct TrackBinding<T: EntityId> {
+    pub enabled: bool,
+    pub target: T,
+}
+
+impl<T: EntityId> Default for TrackBinding<T> {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            target: Default::default(),
+        }
+    }
+}
+
+impl<T: EntityId> TrackBinding<T> {
+    /// Sets a handle of a node that will be animated.
+    pub fn set_target(&mut self, target: T) {
+        self.target = target;
+    }
+
+    /// Returns a handle of a node that will be animated.
+    pub fn target(&self) -> T {
+        self.target
+    }
+
+    /// Enables or disables the track. Disabled tracks won't animate their nodes/properties.
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    /// Returns `true` if the track is enabled, `false` - otherwise.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Sets target of the track.
+    pub fn with_target(mut self, target: T) -> Self {
+        self.target = target;
+        self
+    }
+}
+
 /// Track is responsible in animating a property of a single scene node. The track consists up to 4 parametric curves
 /// that contains the actual property data. Parametric curves allows the engine to perform various interpolations between
 /// key values.
 #[derive(Debug, Reflect, Clone, PartialEq)]
-pub struct Track<T: EntityId> {
+pub struct Track {
     binding: ValueBinding,
     frames: TrackDataContainer,
-    enabled: bool,
-    target: T,
     id: Uuid,
 }
 
-impl<T: EntityId> Visit for Track<T> {
+impl Visit for Track {
     fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
         let mut region = visitor.enter_region(name)?;
-
-        self.target.visit("Node", &mut region)?;
-        self.enabled.visit("Enabled", &mut region)?;
 
         let _ = self.binding.visit("Binding", &mut region); // Backward compatibility
         let _ = self.id.visit("Id", &mut region); // Backward compatibility
@@ -55,19 +93,17 @@ impl<T: EntityId> Visit for Track<T> {
     }
 }
 
-impl<T: EntityId> Default for Track<T> {
+impl Default for Track {
     fn default() -> Self {
         Self {
             binding: ValueBinding::Position,
             frames: TrackDataContainer::default(),
-            enabled: true,
-            target: Default::default(),
             id: Uuid::new_v4(),
         }
     }
 }
 
-impl<T: EntityId> Track<T> {
+impl Track {
     /// Creates a new track that will animate a property in the given binding. The `container` must have enough parametric
     /// curves to be able to produces property values.
     pub fn new(container: TrackDataContainer, binding: ValueBinding) -> Self {
@@ -105,12 +141,6 @@ impl<T: EntityId> Track<T> {
         }
     }
 
-    /// Sets target of the track.
-    pub fn with_target(mut self, target: T) -> Self {
-        self.target = target;
-        self
-    }
-
     /// Sets new track binding. See [`ValueBinding`] docs for more info.
     pub fn set_binding(&mut self, binding: ValueBinding) {
         self.binding = binding;
@@ -119,16 +149,6 @@ impl<T: EntityId> Track<T> {
     /// Returns current track binding.
     pub fn binding(&self) -> &ValueBinding {
         &self.binding
-    }
-
-    /// Sets a handle of a node that will be animated.
-    pub fn set_target(&mut self, target: T) {
-        self.target = target;
-    }
-
-    /// Returns a handle of a node that will be animated.
-    pub fn target(&self) -> T {
-        self.target
     }
 
     /// Returns a reference to the data container.
@@ -152,16 +172,6 @@ impl<T: EntityId> Track<T> {
             binding: self.binding.clone(),
             value: v,
         })
-    }
-
-    /// Enables or disables the track. Disabled tracks won't animate their nodes/properties.
-    pub fn set_enabled(&mut self, enabled: bool) {
-        self.enabled = enabled;
-    }
-
-    /// Returns `true` if the track is enabled, `false` - otherwise.
-    pub fn is_enabled(&self) -> bool {
-        self.enabled
     }
 
     /// Returns length of the track in seconds.

--- a/fyrox-animation/src/track.rs
+++ b/fyrox-animation/src/track.rs
@@ -44,6 +44,14 @@ impl<T: EntityId> Default for TrackBinding<T> {
 }
 
 impl<T: EntityId> TrackBinding<T> {
+    /// Creates a new enabled track binding.
+    pub fn new(target: T) -> Self {
+        Self {
+            enabled: true,
+            target,
+        }
+    }
+
     /// Sets a handle of a node that will be animated.
     pub fn set_target(&mut self, target: T) {
         self.target = target;
@@ -142,12 +150,12 @@ impl Track {
     }
 
     /// Sets new track binding. See [`ValueBinding`] docs for more info.
-    pub fn set_binding(&mut self, binding: ValueBinding) {
+    pub fn set_value_binding(&mut self, binding: ValueBinding) {
         self.binding = binding;
     }
 
     /// Returns current track binding.
-    pub fn binding(&self) -> &ValueBinding {
+    pub fn value_binding(&self) -> &ValueBinding {
         &self.binding
     }
 

--- a/fyrox-animation/src/track.rs
+++ b/fyrox-animation/src/track.rs
@@ -28,9 +28,15 @@ use crate::{
 };
 use std::fmt::Debug;
 
+/// Track binding contains a handle to a target object that will be animated by an animation track.
+/// Additionally, the binding could be disabled to temporarily prevent animation from affecting the
+/// target.
 #[derive(Debug, Visit, Reflect, Clone, PartialEq)]
 pub struct TrackBinding<T: EntityId> {
+    /// The binding could be disabled to temporarily prevent animation from affecting the target.
     pub enabled: bool,
+    /// A target bound to a track. The actual track id is stored as a key in hash map of bindings in
+    /// the animation.
     pub target: T,
 }
 

--- a/fyrox-animation/src/track.rs
+++ b/fyrox-animation/src/track.rs
@@ -76,9 +76,9 @@ impl<T: EntityId> TrackBinding<T> {
 /// key values.
 #[derive(Debug, Reflect, Clone, PartialEq)]
 pub struct Track {
-    binding: ValueBinding,
-    frames: TrackDataContainer,
-    id: Uuid,
+    pub(super) binding: ValueBinding,
+    pub(super) frames: TrackDataContainer,
+    pub(super) id: Uuid,
 }
 
 impl Visit for Track {

--- a/fyrox-animation/src/value.rs
+++ b/fyrox-animation/src/value.rs
@@ -300,9 +300,10 @@ impl TrackValue {
 /// cases for the most used properties and a generic one for arbitrary properties. Arbitrary properties are set using
 /// reflection system, while the special cases handles bindings to standard properties (such as position, scaling, or
 /// rotation) for optimization. Reflection is quite slow to be used as the universal property setting mechanism.  
-#[derive(Clone, Visit, Reflect, Debug, PartialEq, Eq)]
+#[derive(Default, Clone, Visit, Reflect, Debug, PartialEq, Eq)]
 pub enum ValueBinding {
     /// A binding to position of a scene node.
+    #[default]
     Position,
     /// A binding to scale of a scene node.
     Scale,

--- a/fyrox-impl/src/resource/fbx/mod.rs
+++ b/fyrox-impl/src/resource/fbx/mod.rs
@@ -78,6 +78,7 @@ use crate::{
     utils::{self, raw_mesh::RawMeshBuilder},
 };
 use fxhash::{FxHashMap, FxHashSet};
+use fyrox_animation::track::TrackBinding;
 use fyrox_resource::io::ResourceIo;
 use fyrox_resource::untyped::ResourceKind;
 use std::{cmp::Ordering, path::Path};
@@ -782,9 +783,9 @@ async fn convert_model(
             add_vec3_key(&mut scale_track, model.scale);
         }
 
-        animation.add_track(node_handle, translation_track);
-        animation.add_track(node_handle, rotation_track);
-        animation.add_track(node_handle, scale_track);
+        animation.add_track_with_binding(TrackBinding::new(node_handle), translation_track);
+        animation.add_track_with_binding(TrackBinding::new(node_handle), rotation_track);
+        animation.add_track_with_binding(TrackBinding::new(node_handle), scale_track);
     }
 
     animation.fit_length_to_content();

--- a/fyrox-impl/src/resource/fbx/mod.rs
+++ b/fyrox-impl/src/resource/fbx/mod.rs
@@ -750,7 +750,6 @@ async fn convert_model(
 
         // Convert to engine format
         let mut translation_track = Track::new_position();
-        translation_track.set_target(node_handle);
         if let Some(lcl_translation) = lcl_translation {
             fill_track(
                 &mut translation_track,
@@ -764,7 +763,6 @@ async fn convert_model(
         }
 
         let mut rotation_track = Track::new_rotation();
-        rotation_track.set_target(node_handle);
         if let Some(lcl_rotation) = lcl_rotation {
             fill_track(
                 &mut rotation_track,
@@ -778,16 +776,15 @@ async fn convert_model(
         }
 
         let mut scale_track = Track::new_scale();
-        scale_track.set_target(node_handle);
         if let Some(lcl_scale) = lcl_scale {
             fill_track(&mut scale_track, fbx_scene, lcl_scale, model.scale, |v| v);
         } else {
             add_vec3_key(&mut scale_track, model.scale);
         }
 
-        animation.add_track(translation_track);
-        animation.add_track(rotation_track);
-        animation.add_track(scale_track);
+        animation.add_track(node_handle, translation_track);
+        animation.add_track(node_handle, rotation_track);
+        animation.add_track(node_handle, scale_track);
     }
 
     animation.fit_length_to_content();
@@ -829,7 +826,7 @@ async fn convert(
     }
 
     // Do not create animation player if there's no animation content.
-    if !animation.tracks().is_empty() {
+    if !animation.tracks_data().data_ref().tracks().is_empty() {
         let mut animations_container = AnimationContainer::new();
         animations_container.add(animation);
         AnimationPlayerBuilder::new(BaseBuilder::new().with_name("AnimationPlayer"))

--- a/fyrox-impl/src/resource/gltf/animation.rs
+++ b/fyrox-impl/src/resource/gltf/animation.rs
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use super::iter::*;
+use super::simplify::*;
 use crate::core::algebra::{Quaternion, Unit, UnitQuaternion, Vector3};
 use crate::core::log::Log;
 use crate::core::math::curve::{Curve, CurveKey, CurveKeyKind};
@@ -30,14 +32,12 @@ use crate::scene::animation::Animation;
 use crate::scene::graph::Graph;
 use crate::scene::mesh::Mesh;
 use crate::scene::node::Node;
+use fyrox_animation::track::TrackBinding;
 use fyrox_graph::BaseSceneGraph;
 use gltf::animation::util::ReadOutputs;
 use gltf::animation::Channel;
 use gltf::animation::{Interpolation, Property};
 use gltf::Buffer;
-
-use super::iter::*;
-use super::simplify::*;
 
 type Result<T> = std::result::Result<T, ()>;
 
@@ -225,7 +225,7 @@ impl ImportedAnimation {
         result.set_time_slice(self.start..self.end);
         for t in self.tracks {
             let (node, track) = t.into_track();
-            result.add_track(node, track);
+            result.add_track_with_binding(TrackBinding::new(node), track);
         }
         result
     }

--- a/fyrox-impl/src/resource/gltf/animation.rs
+++ b/fyrox-impl/src/resource/gltf/animation.rs
@@ -185,15 +185,15 @@ impl ImportedTrack {
             false
         }
     }
-    fn into_track(self) -> Track<Handle<Node>> {
+    fn into_track(self) -> (Handle<Node>, Track) {
         let mut data = TrackDataContainer::new(self.target.kind());
         for (i, curve) in self.curves.into_vec().into_iter().enumerate() {
             data.curves_mut()[i] = Curve::from(curve);
         }
-        let mut track = Track::new(data, self.target.value_binding());
-        track.set_target(self.target.handle);
-        track.set_enabled(true);
-        track
+        (
+            self.target.handle,
+            Track::new(data, self.target.value_binding()),
+        )
     }
 }
 
@@ -224,7 +224,8 @@ impl ImportedAnimation {
         result.set_name(self.name);
         result.set_time_slice(self.start..self.end);
         for t in self.tracks {
-            result.add_track(t.into_track());
+            let (node, track) = t.into_track();
+            result.add_track(node, track);
         }
         result
     }

--- a/fyrox-impl/src/scene/animation/mod.rs
+++ b/fyrox-impl/src/scene/animation/mod.rs
@@ -217,7 +217,7 @@ impl BoundValueCollectionExt for BoundValueCollection {
 ///
 ///     // Finally create an animation and set its time slice and turn it on.
 ///     let mut animation = Animation::default();
-///     animation.add_track(track);
+///     animation.add_track_with_binding(track);
 ///     animation.set_time_slice(0.0..0.6);
 ///     animation.set_enabled(true);
 ///     animation

--- a/fyrox-impl/src/scene/animation/mod.rs
+++ b/fyrox-impl/src/scene/animation/mod.rs
@@ -48,7 +48,7 @@ pub mod spritesheet;
 /// Scene specific animation.
 pub type Animation = crate::generic_animation::Animation<Handle<Node>>;
 /// Scene specific animation track.
-pub type Track = crate::generic_animation::track::Track<Handle<Node>>;
+pub type Track = crate::generic_animation::track::Track;
 /// Scene specific animation container.
 pub type AnimationContainer = crate::generic_animation::AnimationContainer<Handle<Node>>;
 /// Scene specific animation pose.

--- a/fyrox-impl/src/scene/animation/mod.rs
+++ b/fyrox-impl/src/scene/animation/mod.rs
@@ -190,6 +190,7 @@ impl BoundValueCollectionExt for BoundValueCollection {
 /// next code snippet is for you.
 ///
 /// ```rust
+/// # use fyrox_animation::track::TrackBinding;
 /// # use fyrox_impl::{
 /// #     core::{
 /// #         math::curve::{Curve, CurveKey, CurveKeyKind},
@@ -211,13 +212,12 @@ impl BoundValueCollectionExt for BoundValueCollection {
 ///         CurveKey::new(0.6, 0.0, CurveKeyKind::Linear),
 ///     ]);
 ///
-///     // Create a track that will animated the node using the curve above.
+///     // Create a track that will animate the node using the curve above.
 ///     let mut track = Track::new(frames_container, ValueBinding::Position);
-///     track.set_target(animated_node);
-///
+
 ///     // Finally create an animation and set its time slice and turn it on.
 ///     let mut animation = Animation::default();
-///     animation.add_track_with_binding(track);
+///     animation.add_track_with_binding(TrackBinding::new(animated_node),track);
 ///     animation.set_time_slice(0.0..0.6);
 ///     animation.set_enabled(true);
 ///     animation

--- a/fyrox-resource/src/lib.rs
+++ b/fyrox-resource/src/lib.rs
@@ -139,6 +139,14 @@ where
             None
         }
     }
+
+    pub fn data_ref(&self) -> Option<&T> {
+        if let ResourceState::Ok(ref data) = self.guard.state {
+            ResourceData::as_any(&**data).downcast_ref::<T>()
+        } else {
+            None
+        }
+    }
 }
 
 /// A resource of particular data type. It is a typed wrapper around [`UntypedResource`] which

--- a/fyrox-ui/src/animation.rs
+++ b/fyrox-ui/src/animation.rs
@@ -65,7 +65,7 @@ impl AnimationPlayerMessage {
 /// UI-specific animation.
 pub type Animation = crate::generic_animation::Animation<Handle<UiNode>>;
 /// UI-specific animation track.
-pub type Track = crate::generic_animation::track::Track<Handle<UiNode>>;
+pub type Track = crate::generic_animation::track::Track;
 /// UI-specific animation container.
 pub type AnimationContainer = crate::generic_animation::AnimationContainer<Handle<UiNode>>;
 /// UI-specific animation pose.


### PR DESCRIPTION
This PR splits animation in two parts:

1) The animation itself, that holds the required runtime information such as playback time, time slice, track bindings etc.
2) The animation tracks data resource, that holds (mostly) immutable data of animation tracks. This resource could be shared across multiple animations to reduce memory consumption.