### PR TITLE
add Zed editor option into editor settings

### DIFF
--- a/editor/src/plugins/inspector/editors/script.rs
+++ b/editor/src/plugins/inspector/editors/script.rs
@@ -172,6 +172,7 @@ impl Control for ScriptPropertyEditor {
                                     }
                                     ScriptEditor::XCode => Some("xcode"),
                                     ScriptEditor::Emacs => Some("emacs"),
+                                    ScriptEditor::Zed => Some("zed"),
                                     ScriptEditor::SystemDefault => None,
                                 };
 

--- a/editor/src/settings/general.rs
+++ b/editor/src/settings/general.rs
@@ -134,6 +134,7 @@ pub enum ScriptEditor {
     VSCode,
     Emacs,
     XCode,
+    Zed,
 }
 
 uuid_provider!(ScriptEditor = "d0c942e8-24e4-40f2-ad2e-1b9f189d3ca2");


### PR DESCRIPTION
This adds the Zed Editor option into settings. This should work for every OS except NixOS because it defaults to "zeditor" alias.