### PR TITLE
Fixing crash on deletion of tile set property layer.

### DIFF
--- a/fyrox-impl/src/scene/tilemap/tileset.rs
+++ b/fyrox-impl/src/scene/tilemap/tileset.rs
@@ -399,7 +399,8 @@ impl TileSetPage {
                     );
                 }
             }
-            _ => panic!(),
+            TileSetPageSource::Transform(_) => (),
+            TileSetPageSource::Animation(_) => (),
         }
     }
     /// Take all the colliders for the given collider id, remove them from the page, and put them into the given hash map.


### PR DESCRIPTION
I foolishly wrote a method to panic when the obvious correct thing for it to do was to simply do nothing. This PR corrects that and prevents a pointless crash that I have just noticed when executing the `RemovePropertyLayerCommand` for a tile set.