### PR TITLE
add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@
 history.bin
 settings.ron
 
+# Nix/NixOS
+.direnv/
+.envrc
+!flake.lock
+
 # from https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore
 .vscode/*
 !.vscode/settings.json

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1740074384,
+        "narHash": "sha256-T2eO9ognlph94/TyAu1uILo38fZG1G4S5FQxG+YBDv0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d291a120b6524911249b198baf3ec3e07ff57e04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    nixpkgs,
+    rust-overlay,
+    ...
+  }:
+  let
+    overlays = [
+      (import rust-overlay)
+    ];
+
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+
+    forAllSystems = f:
+      nixpkgs.lib.genAttrs systems
+      (system: f { pkgs = import nixpkgs { inherit system overlays; }; });
+  in
+  {
+    devShells = forAllSystems ({ pkgs }: with pkgs; {
+      default = mkShell rec {
+        buildInputs = [
+          rust-bin.stable.latest.default
+
+          pkg-config
+          xorg.libxcb
+          alsa-lib
+          wayland
+          libxkbcommon
+          libGL
+        ];
+        LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}";
+      };
+    });
+  };
+}


### PR DESCRIPTION
Wasn't sure why there was a `*.lock* entry in the .gitignore so I added a separate entry to include flake.lock. If Fyrox doesn't generate any .lock files outside of the target/ directory would it make more sense to change it to only exclude Cargo.lock files instead?