### PR TITLE
Adding empty tiles to tile map brush

### DIFF
--- a/editor/src/plugins/tilemap/autotile.rs
+++ b/editor/src/plugins/tilemap/autotile.rs
@@ -184,6 +184,9 @@ impl BrushMacro for AutoTileMacro {
         message: &UiMessage,
         editor: &mut Editor,
     ) {
+        let Some(cell) = context.cell else {
+            return;
+        };
         let ui = editor.engine.user_interfaces.first_mut();
         for r in context.instances_with_uuid(*self.uuid()) {
             let instance = r.try_cast::<AutoTileInstance>().unwrap();
@@ -200,14 +203,11 @@ impl BrushMacro for AutoTileMacro {
                 .widgets
                 .value_field
                 .on_ui_message(prop, message, ui);
-            let cell = context.cell.unwrap();
             let cell_data = settings.cells.get(&cell).cloned().unwrap_or_default();
             if let Some(&TileSetPropertyValueMessage(TileSetPropertyValueElement::I8(v))) =
                 message.data()
             {
-                if message.destination() == settings.widgets.value_field.handle()
-                    && context.cell.is_some()
-                {
+                if message.destination() == settings.widgets.value_field.handle() {
                     drop(settings);
                     editor.message_sender.do_command(SetCellCommand {
                         brush: context.brush.clone(),

--- a/editor/src/plugins/tilemap/brush_macro.rs
+++ b/editor/src/plugins/tilemap/brush_macro.rs
@@ -53,7 +53,7 @@ const UNKNOWN_PROPERTY: &str = "UNKNOWN PROPERTY";
 
 /// An Arc Mutex reference to a [`BrushMacroList`] that allows multiple objects
 /// to share access to a common macro list. Among the things that need to share
-/// the list are the [`TileMapInteractionMode`] and the [`TileSetEditor`].
+/// the list are the tile map interaction mode and the [`TileSetEditor`].
 #[derive(Default, Clone)]
 pub struct BrushMacroListRef(Arc<Mutex<BrushMacroList>>);
 
@@ -295,7 +295,7 @@ pub trait BrushMacro: 'static + Send + Sync {
     /// None is returned if no command is necessary, such as if the cell is already included
     /// or no cell is selected. Adding the currently selected cell will naturally require
     /// the widgets that edit the data to change, but that will wait until
-    /// [`BrushMacro::sync_cell_editor`] is called.
+    /// [`BrushMacro::sync_cell_editors`] is called.
     fn create_cell(&self, context: &BrushMacroCell) -> Option<Command>;
     /// Create a command to modify the given instances's data to remove the given cell.
     /// None is returned if no command is necessary, such as if the cell is already excluded
@@ -326,7 +326,7 @@ pub trait BrushMacro: 'static + Send + Sync {
     /// None is returned if this macro needs no widgets because cell data cannot be edited.
     /// If no cell is selected or if the cell is not part of the macro, then the widgets
     /// should stil be created but they should be invisible. They can be made visible
-    /// when [`BrushMacro::sync_cell_editor`] is called.
+    /// when [`BrushMacro::sync_cell_editors`] is called.
     fn build_cell_editor(
         &mut self,
         context: &BrushMacroCell,

--- a/editor/src/plugins/tilemap/palette.rs
+++ b/editor/src/plugins/tilemap/palette.rs
@@ -1638,7 +1638,7 @@ pub struct PaletteWidgetBuilder {
 impl PaletteWidgetBuilder {
     /// Build a [`PaletteWidget`] with the given sender and [`TileDrawStateRef`].
     /// The state is a shared reference that the palette will keep for its lifetime so that
-    /// it can cooperate with other palettes and with the [`TileMapInteractionMode`].
+    /// it can cooperate with other palettes and with the tile map interaction mode.
     pub fn new(
         widget_builder: WidgetBuilder,
         sender: MessageSender,

--- a/editor/src/plugins/tilemap/panel_preview.rs
+++ b/editor/src/plugins/tilemap/panel_preview.rs
@@ -81,6 +81,9 @@ fn draw_tile(
     tile: &TileRenderData,
     drawing_context: &mut DrawingContext,
 ) {
+    if tile.is_empty() {
+        return;
+    }
     let color = tile.color;
     if let Some(material_bounds) = &tile.material_bounds {
         if let Some(texture) = material_bounds

--- a/fyrox-impl/src/scene/tilemap/mod.rs
+++ b/fyrox-impl/src/scene/tilemap/mod.rs
@@ -167,6 +167,9 @@ impl TileMapRenderContext<'_, '_> {
     /// and then [`TileMapRenderContext::set_tile_visible`] should be used to set the position to false
     /// to prevent any future effects from rendering at this position.
     pub fn draw_tile(&mut self, position: Vector2<i32>, handle: TileDefinitionHandle) {
+        if handle.is_empty() {
+            return;
+        }
         let Some(data) = self.tile_set.get_tile_render_data(handle.into()) else {
             return;
         };
@@ -176,6 +179,9 @@ impl TileMapRenderContext<'_, '_> {
     /// Render the given tile data at the given cell position. This makes it possible to render
     /// a tile that is not in the tile map's tile set.
     pub fn push_tile(&mut self, position: Vector2<i32>, data: &TileRenderData) {
+        if data.is_empty() {
+            return;
+        }
         let color = data.color;
         if let Some(tile_bounds) = data.material_bounds.as_ref() {
             let material = &tile_bounds.material;
@@ -876,14 +882,37 @@ pub struct TileRenderData {
     pub material_bounds: Option<TileMaterialBounds>,
     /// The color to use to render the tile
     pub color: Color,
+    /// This data represents the empty tile
+    empty: bool,
 }
 
 impl TileRenderData {
+    /// Create a TileRenderData
+    pub fn new(material_bounds: Option<TileMaterialBounds>, color: Color) -> Self {
+        Self {
+            material_bounds,
+            color,
+            empty: false,
+        }
+    }
+    /// Create an empty TileRenderData
+    pub fn empty() -> Self {
+        Self {
+            material_bounds: None,
+            color: Color::WHITE,
+            empty: true,
+        }
+    }
+    /// True if the render data is for the empty tile.
+    pub fn is_empty(&self) -> bool {
+        self.empty
+    }
     /// Returns TileRenderData to represent an error due to render data being unavailable.
-    pub fn missing_data() -> TileRenderData {
+    pub fn missing_data() -> Self {
         Self {
             material_bounds: None,
             color: Color::HOT_PINK,
+            empty: false,
         }
     }
 }

--- a/fyrox-impl/src/scene/tilemap/tile_source.rs
+++ b/fyrox-impl/src/scene/tilemap/tile_source.rs
@@ -114,11 +114,15 @@ impl Ord for TileDefinitionHandle {
 impl Display for TileDefinitionHandle {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "({},{}):({},{})",
-            self.page.x, self.page.y, self.tile.x, self.tile.y
-        )
+        if self.is_empty() {
+            f.write_str("Empty")
+        } else {
+            write!(
+                f,
+                "({},{}):({},{})",
+                self.page.x, self.page.y, self.tile.x, self.tile.y
+            )
+        }
     }
 }
 
@@ -190,6 +194,9 @@ impl TileDefinitionHandle {
     /// The first two numbers are the page coodrinates. The second two numbers are the tile coordinates.
     /// None is returned if there are more than four numbers, fewer than four numbers, or any number produces an error in parsing.
     pub fn parse(s: &str) -> Option<Self> {
+        if s.eq_ignore_ascii_case("Empty") {
+            return Some(Self::EMPTY);
+        }
         let mut iter = s
             .split(|c: char| c != '-' && !c.is_ascii_digit())
             .filter(|w| !w.is_empty());

--- a/fyrox-impl/src/scene/tilemap/tileset.rs
+++ b/fyrox-impl/src/scene/tilemap/tileset.rs
@@ -1705,7 +1705,9 @@ impl TileSet {
         trans: OrthoTransformation,
         handle: TileDefinitionHandle,
     ) -> Option<TileRenderData> {
-        if let Some(handle) = self.get_transformed_version(trans, handle) {
+        if handle.is_empty() {
+            Some(TileRenderData::empty())
+        } else if let Some(handle) = self.get_transformed_version(trans, handle) {
             self.get_tile_render_data(handle.into())
         } else {
             Some(self.get_tile_render_data(handle.into())?.transformed(trans))
@@ -1725,11 +1727,14 @@ impl TileSet {
             .or_else(|| Some(TileRenderData::missing_data()))
     }
     fn inner_get_render_data(&self, position: ResourceTilePosition) -> Option<TileRenderData> {
-        if self.is_valid_tile(self.redirect_handle(position)?) {
-            Some(TileRenderData {
-                material_bounds: Some(self.get_tile_bounds(position)?),
-                color: self.get_tile_data(position)?.color,
-            })
+        let handle = self.redirect_handle(position)?;
+        if handle.is_empty() {
+            Some(TileRenderData::empty())
+        } else if self.is_valid_tile(handle) {
+            Some(TileRenderData::new(
+                Some(self.get_tile_bounds(position)?),
+                self.get_tile_data(position)?.color,
+            ))
         } else {
             Some(TileRenderData::missing_data())
         }

--- a/fyrox-impl/src/scene/tilemap/update.rs
+++ b/fyrox-impl/src/scene/tilemap/update.rs
@@ -249,22 +249,22 @@ impl TileDataUpdate {
     pub fn modify_render<'a>(&self, source: &'a TileRenderData) -> Option<Cow<'a, TileRenderData>> {
         match self {
             TileDataUpdate::Erase => None,
-            TileDataUpdate::MaterialTile(tile_data) => Some(Cow::Owned(TileRenderData {
-                material_bounds: source.material_bounds.clone(),
-                color: tile_data.color,
-            })),
-            TileDataUpdate::FreeformTile(def) => Some(Cow::Owned(TileRenderData {
-                material_bounds: Some(def.material_bounds.clone()),
-                color: def.data.color,
-            })),
-            TileDataUpdate::Color(color) => Some(Cow::Owned(TileRenderData {
-                material_bounds: source.material_bounds.clone(),
-                color: *color,
-            })),
-            TileDataUpdate::Material(material_bounds) => Some(Cow::Owned(TileRenderData {
-                material_bounds: Some(material_bounds.clone()),
-                color: source.color,
-            })),
+            TileDataUpdate::MaterialTile(tile_data) => Some(Cow::Owned(TileRenderData::new(
+                source.material_bounds.clone(),
+                tile_data.color,
+            ))),
+            TileDataUpdate::FreeformTile(def) => Some(Cow::Owned(TileRenderData::new(
+                Some(def.material_bounds.clone()),
+                def.data.color,
+            ))),
+            TileDataUpdate::Color(color) => Some(Cow::Owned(TileRenderData::new(
+                source.material_bounds.clone(),
+                *color,
+            ))),
+            TileDataUpdate::Material(material_bounds) => Some(Cow::Owned(TileRenderData::new(
+                Some(material_bounds.clone()),
+                source.color,
+            ))),
             _ => Some(Cow::Borrowed(source)),
         }
     }


### PR DESCRIPTION
I have enhanced tile map editing by allowing tile sets and brushes to explicitly work with empty tile handles as if they were actual tiles, so when they are drawn to the tile map they erase instead of adding tiles.

* Tile handle parsing now accepts "empty" as a valid handle.
* The eraser icon is now drawn to represent cells that contain the empty tile handle.

This allows tile map animations to have empty frames without needing to have a transparent tile, and allows autotiling to work when erasing tiles instead of just drawing tiles.