### PR TITLE
Multithreaded wave function collapse

### DIFF
--- a/fyrox-autotile/src/lib.rs
+++ b/fyrox-autotile/src/lib.rs
@@ -353,6 +353,14 @@ impl<V> ProbabilitySet<V> {
     pub fn iter(&self) -> impl Iterator<Item = (f32, &V)> {
         self.content.iter().map(|(f, v)| (*f, v))
     }
+    /// The number of elements in the set.
+    pub fn len(&self) -> usize {
+        self.content.len()
+    }
+    /// True if the set has no elements.
+    pub fn is_empty(&self) -> bool {
+        self.content.is_empty()
+    }
     /// Remove the content of the set.
     pub fn clear(&mut self) {
         self.total = 0.0;
@@ -371,6 +379,15 @@ impl<V> ProbabilitySet<V> {
     /// that element divided by this total.
     pub fn total_frequency(&self) -> f32 {
         self.total
+    }
+
+    /// The mean of the frequencies of all the elements of the set.
+    pub fn average_frequency(&self) -> f32 {
+        let size = self.content.len();
+        if size == 0 {
+            return 0.0;
+        }
+        self.total / (size as f32)
     }
 
     /// Choose a value from the set using the given random number generator.

--- a/fyrox-impl/src/scene/tilemap/autotile.rs
+++ b/fyrox-impl/src/scene/tilemap/autotile.rs
@@ -181,7 +181,7 @@ impl TileSetWfcConstraint {
                 }
             }
         }
-        self.finalize();
+        self.finalize_with_terrain_normalization(PatternBits::center);
         Ok(())
     }
 }
@@ -481,7 +481,7 @@ impl TileSetWfcPropagator {
         Ok(())
     }
     /// Modify the given tile map update based on the result of the
-    /// auto-tiler.
+    /// autotiler.
     pub fn apply_autotile_to_update<R: Rng + ?Sized>(
         &self,
         rng: &mut R,
@@ -503,6 +503,21 @@ impl TileSetWfcPropagator {
                 Some(StampElement { handle, brush_cell })
             };
             _ = update.insert(*pos, handle);
+        }
+    }
+    /// Modify the given tile map data based on the result of the
+    /// autotiler.
+    pub fn apply_autotile_to_data<R: Rng + ?Sized>(
+        &self,
+        rng: &mut R,
+        value_map: &TileSetWfcConstraint,
+        data: &mut TileMapData,
+    ) {
+        for (pos, pat) in self.assigned_patterns() {
+            let Some(&handle) = value_map.get_random(rng, pat) else {
+                continue;
+            };
+            data.set(*pos, handle);
         }
     }
 }


### PR DESCRIPTION
I have added multi-threading to Wave Function Collapse by creating the `WaveFunctionTaskCommand` that starts a new thread each time the command is executed until the Wave Function Collapse finishes or reaches the maximum attempts. This makes it safe to allow WFC to have a very large maximum number of attempts.

I have also tinkered with how WFC calculates probabilities so that terrains that have a large number of tiles will not be given an advantage over terrains with a small number of tiles. I hope this is an improvement, but WFC is very difficult for me to test due to its random nature. It is difficult for me to be sure that it is working correctly because I am not sure what it *should* do exactly.

I have tried to faithfully re-implement the algorithm from [fast-wfc](https://github.com/math-fehr/fast-wfc), but if I have made some mistake I am not sure how I would ever discover that mistake. Regardless, it seems to work well enough to be useful.