### PR TITLE
Improvements to autotiling

### DIFF
--- a/editor/src/plugins/tilemap/brush_macro.rs
+++ b/editor/src/plugins/tilemap/brush_macro.rs
@@ -343,7 +343,12 @@ pub trait BrushMacro: 'static + Send + Sync {
     /// stored in the current brush when the user presses the mouse button down to begin a stroke
     /// and gives the macros a chance to prepare themselves for the series of [`amend_update`](BrushMacro::amend_update)
     /// calls that will follow.
-    fn begin_update(&mut self, context: &BrushMacroInstance, tile_map: &TileMapContext);
+    fn begin_update(
+        &mut self,
+        context: &BrushMacroInstance,
+        stamp: &Stamp,
+        tile_map: &TileMapContext,
+    );
     /// This is called for every macro instance whenever the user uses a brush to update a tile map.
     /// - `context`: The macro instance.
     /// - `update`: The change that the user is attempting to make to the tile map. Modify this to

--- a/editor/src/plugins/tilemap/interaction_mode.rs
+++ b/editor/src/plugins/tilemap/interaction_mode.rs
@@ -287,10 +287,13 @@ fn macro_begin(
     tile_map_context: &TileMapContext,
     update: &mut TransTilesUpdate,
     macro_update: &mut MacroTilesUpdate,
-    brush: &TileMapBrushResource,
+    stamp: &Stamp,
     macros: &mut BrushMacroList,
     macro_instances: &mut Vec<(Uuid, Option<UntypedResource>)>,
 ) {
+    let Some(brush) = stamp.brush() else {
+        return;
+    };
     let tile_map_handle = tile_map_context.node;
     let Some(tile_map) = tile_map_context.engine.scenes[tile_map_context.scene].graph
         [tile_map_handle]
@@ -324,7 +327,7 @@ fn macro_begin(
             continue;
         };
         context.settings = settings;
-        brush_macro.begin_update(&context, tile_map_context);
+        brush_macro.begin_update(&context, stamp, tile_map_context);
         brush_macro.amend_update(&context, macro_update, tile_map);
     }
     macro_update.fill_trans_tiles_update(update);
@@ -545,7 +548,7 @@ impl InteractionMode for TileMapInteractionMode {
                     let update = &mut self.update_effect.lock().update;
                     draw(update, tiles, mode, &state, grid_coord, grid_coord);
                     drop(tiles_guard);
-                    if let Some(brush) = state.stamp.brush() {
+                    if state.stamp.brush().is_some() {
                         let tile_map = TileMapContext {
                             node: self.tile_map,
                             scene: scene_handle,
@@ -555,7 +558,7 @@ impl InteractionMode for TileMapInteractionMode {
                             &tile_map,
                             update,
                             &mut self.macro_update,
-                            brush,
+                            &state.stamp,
                             &mut self.brush_macro_list.lock(),
                             &mut self.macro_instance_list,
                         );

--- a/editor/src/plugins/tilemap/wfc.rs
+++ b/editor/src/plugins/tilemap/wfc.rs
@@ -617,7 +617,13 @@ impl BrushMacro for WfcMacro {
 
     fn sync_cell_editors(&mut self, _context: &MacroMessageContext, _ui: &mut UserInterface) {}
 
-    fn begin_update(&mut self, _context: &BrushMacroInstance, _tile_map: &TileMapContext) {}
+    fn begin_update(
+        &mut self,
+        _context: &BrushMacroInstance,
+        _stamp: &Stamp,
+        _tile_map: &TileMapContext,
+    ) {
+    }
 
     fn amend_update(
         &mut self,

--- a/fyrox-autotile/src/auto.rs
+++ b/fyrox-autotile/src/auto.rs
@@ -475,6 +475,10 @@ impl<Ter, Pat, Tile> Default for AutoTileContext<Ter, Pat, Tile> {
 }
 
 impl<Ter: Eq + Hash, Pat: Eq + Hash + Clone, Tile> AutoTileContext<Ter, Pat, Tile> {
+    /// True if this context contains no patterns.
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
     /// Make the context empty in preparation for building a new context.
     pub fn clear(&mut self) {
         for (_, mut list) in self.patterns.drain() {


### PR DESCRIPTION
There is a cost to having macros on a tile map brush because every time the brush is used to draw on the tile map each macro gets its chance to amend the update. To reduce this cost, I have modified the `begin_update` method to allow macros to determine whether they should be involved in the current tile map draw operation. In the future it may be wise to allow macros to be disabled without deleting them.

I also noticed a flaw in how wave function collapse handles edges. When a tile around the edge of the WFC area had 0.0 probability and was therefore excluded from the WFC, the edge constraining method would cause the entire WFC to fail, because the tile that the edge was set to was an impossible tile, and therefore all possible tiles were eliminated.

To fix this I modified the edge constraining algorithm to not reuse the method for constraining cells within the WFC, and instead handle edge constraining specially.

My first attempt to fix this was simply to allow 0.0 probability tiles into the WFC algorithm, but this made me realize that the algorithm breaks if a tile has a 0.0 probability, so I added a warning about this in a doc comment.