### PR TITLE
Improved Tile Set Editing

### DIFF
--- a/editor/src/plugins/tilemap/autotile.rs
+++ b/editor/src/plugins/tilemap/autotile.rs
@@ -291,17 +291,6 @@ impl BrushMacro for AutoTileMacro {
         }))
     }
 
-    fn remove_cell(&self, context: &BrushMacroCellContext) -> Option<Command> {
-        let instance = context.settings()?;
-        let cell = context.cell?;
-        Some(Command::new(SetCellCommand {
-            brush: context.brush.clone(),
-            cell,
-            instance,
-            data: None,
-        }))
-    }
-
     fn move_cells(
         &self,
         from: Box<[TileDefinitionHandle]>,

--- a/editor/src/plugins/tilemap/brush_macro.rs
+++ b/editor/src/plugins/tilemap/brush_macro.rs
@@ -297,10 +297,6 @@ pub trait BrushMacro: 'static + Send + Sync {
     /// the widgets that edit the data to change, but that will wait until
     /// [`BrushMacro::sync_cell_editors`] is called.
     fn create_cell(&self, context: &BrushMacroCellContext) -> Option<Command>;
-    /// Create a command to modify the given instances's data to remove the given cell.
-    /// None is returned if no command is necessary, such as if the cell is already excluded
-    /// or no cell is selected.
-    fn remove_cell(&self, context: &BrushMacroCellContext) -> Option<Command>;
     /// Create a command to move cell data from the given cells to the given cells.
     /// The two lists of cells should always be the same length.
     /// This method works on multiple cells at once because `from` and `to` may

--- a/editor/src/plugins/tilemap/brush_macro.rs
+++ b/editor/src/plugins/tilemap/brush_macro.rs
@@ -156,8 +156,8 @@ pub struct MacroMessageContext {
     pub cell: Option<TileDefinitionHandle>,
 }
 
-impl From<BrushMacroCell> for MacroMessageContext {
-    fn from(value: BrushMacroCell) -> Self {
+impl From<BrushMacroCellContext> for MacroMessageContext {
+    fn from(value: BrushMacroCellContext) -> Self {
         Self {
             brush: value.brush,
             cell: value.cell,
@@ -192,7 +192,7 @@ impl MacroMessageContext {
 /// such as adding a new cell to the macro, removing a cell, or building the widgets
 /// for editing the settings of a cell.
 #[derive(Debug, Clone)]
-pub struct BrushMacroCell {
+pub struct BrushMacroCellContext {
     /// The brush that has an instance of the macro.
     pub brush: TileMapBrushResource,
     /// The configuration for an instance of the macro.
@@ -201,8 +201,8 @@ pub struct BrushMacroCell {
     pub cell: Option<TileDefinitionHandle>,
 }
 
-impl From<BrushMacroCell> for BrushMacroInstance {
-    fn from(value: BrushMacroCell) -> Self {
+impl From<BrushMacroCellContext> for BrushMacroInstance {
+    fn from(value: BrushMacroCellContext) -> Self {
         Self {
             brush: value.brush,
             settings: value.settings,
@@ -210,7 +210,7 @@ impl From<BrushMacroCell> for BrushMacroInstance {
     }
 }
 
-impl BrushMacroCell {
+impl BrushMacroCellContext {
     /// A typed reference to the configuration resource.
     pub fn settings<T>(&self) -> Option<Resource<T>>
     where
@@ -296,11 +296,51 @@ pub trait BrushMacro: 'static + Send + Sync {
     /// or no cell is selected. Adding the currently selected cell will naturally require
     /// the widgets that edit the data to change, but that will wait until
     /// [`BrushMacro::sync_cell_editors`] is called.
-    fn create_cell(&self, context: &BrushMacroCell) -> Option<Command>;
+    fn create_cell(&self, context: &BrushMacroCellContext) -> Option<Command>;
     /// Create a command to modify the given instances's data to remove the given cell.
     /// None is returned if no command is necessary, such as if the cell is already excluded
     /// or no cell is selected.
-    fn remove_cell(&self, context: &BrushMacroCell) -> Option<Command>;
+    fn remove_cell(&self, context: &BrushMacroCellContext) -> Option<Command>;
+    /// Create a command to move cell data from the given cells to the given cells.
+    /// The two lists of cells should always be the same length.
+    /// This method works on multiple cells at once because `from` and `to` may
+    /// share some cells in common, in which case correctly moving the cells
+    /// requires first removing all the cells from `from`, then inserting all
+    /// the cells into `to`.
+    fn move_cells(
+        &self,
+        from: Box<[TileDefinitionHandle]>,
+        to: Box<[TileDefinitionHandle]>,
+        context: &BrushMacroInstance,
+    ) -> Option<Command>;
+    /// Create a command to move cell data from the given pages to the given pages.
+    /// The two lists of pages should always be the same length.
+    /// This method works on multiple pages at once because `from` and `to` may
+    /// share some pages in common, in which case correctly moving the pages
+    /// requires first removing all the pages from `from`, then inserting all
+    /// the pages into `to`.
+    fn move_pages(
+        &self,
+        from: Box<[Vector2<i32>]>,
+        to: Box<[Vector2<i32>]>,
+        context: &BrushMacroInstance,
+    ) -> Option<Command>;
+    /// Create a command to modify the given instances's data to copy the given cell.
+    /// None is returned if no command is necessary, such as if the macro has no cell data.
+    fn copy_cell(
+        &self,
+        source: Option<TileDefinitionHandle>,
+        destination: TileDefinitionHandle,
+        context: &BrushMacroInstance,
+    ) -> Option<Command>;
+    /// Create a command to modify the given instances's data to copy the given page.
+    /// None is returned if no command is necessary, such as if the macro has no cell data.
+    fn copy_page(
+        &self,
+        source: Option<Vector2<i32>>,
+        destination: Vector2<i32>,
+        context: &BrushMacroInstance,
+    ) -> Option<Command>;
     /// Modify the given `cell_set` to include the handles of all the cells that are part of
     /// the given instance of this macro. This is necessary for the brush editor to accurately
     /// update itself.
@@ -329,7 +369,7 @@ pub trait BrushMacro: 'static + Send + Sync {
     /// when [`BrushMacro::sync_cell_editors`] is called.
     fn build_cell_editor(
         &mut self,
-        context: &BrushMacroCell,
+        context: &BrushMacroCellContext,
         ctx: &mut BuildContext,
     ) -> Option<Handle<UiNode>>;
     /// Send the necessary messages to update the cell editor widgets to edit the data for

--- a/editor/src/plugins/tilemap/commands.rs
+++ b/editor/src/plugins/tilemap/commands.rs
@@ -1127,13 +1127,26 @@ pub struct ModifyPageIconCommand {
     pub tile_set: TileSetResource,
     pub page: Vector2<i32>,
     pub icon: TileDefinitionHandle,
+    error: bool,
 }
 
 impl ModifyPageIconCommand {
+    pub fn new(tile_set: TileSetResource, page: Vector2<i32>, icon: TileDefinitionHandle) -> Self {
+        Self {
+            tile_set,
+            page,
+            icon,
+            error: false,
+        }
+    }
     fn swap(&mut self) {
+        if self.error {
+            return;
+        }
         let mut tile_set = self.tile_set.data_ref();
         let Some(page) = &mut tile_set.pages.get_mut(&self.page) else {
             Log::err("Modify icon of non-existent tile page.");
+            self.error = true;
             return;
         };
         std::mem::swap(&mut self.icon, &mut page.icon);
@@ -1160,13 +1173,30 @@ pub struct ModifyBrushPageIconCommand {
     pub brush: TileMapBrushResource,
     pub page: Vector2<i32>,
     pub icon: TileDefinitionHandle,
+    error: bool,
 }
 
 impl ModifyBrushPageIconCommand {
+    pub fn new(
+        brush: TileMapBrushResource,
+        page: Vector2<i32>,
+        icon: TileDefinitionHandle,
+    ) -> Self {
+        Self {
+            brush,
+            page,
+            icon,
+            error: false,
+        }
+    }
     fn swap(&mut self) {
+        if self.error {
+            return;
+        }
         let mut brush = self.brush.data_ref();
         let Some(page) = &mut brush.pages.get_mut(&self.page) else {
             Log::err("Modify icon of non-existent tile page.");
+            self.error = true;
             return;
         };
         std::mem::swap(&mut self.icon, &mut page.icon);

--- a/editor/src/plugins/tilemap/macro_inspector.rs
+++ b/editor/src/plugins/tilemap/macro_inspector.rs
@@ -231,7 +231,7 @@ fn make_items(
             });
             continue;
         }
-        let brush_macro_cell = BrushMacroCell {
+        let brush_macro_cell = BrushMacroCellContext {
             brush: brush.clone(),
             settings: instance.settings.clone(),
             cell,
@@ -410,15 +410,10 @@ impl MacroInspector {
                     let settings = instance.settings.clone();
                     drop(brush_guard);
                     let command = if cell_sets.cell_has_macro(cell, i) {
-                        let cell = Some(cell);
-                        brush_macro.remove_cell(&BrushMacroCell {
-                            brush,
-                            settings,
-                            cell,
-                        })
+                        brush_macro.copy_cell(None, cell, &BrushMacroInstance { brush, settings })
                     } else {
                         let cell = Some(cell);
-                        brush_macro.create_cell(&BrushMacroCell {
+                        brush_macro.create_cell(&BrushMacroCellContext {
                             brush,
                             settings,
                             cell,

--- a/editor/src/plugins/tilemap/mod.rs
+++ b/editor/src/plugins/tilemap/mod.rs
@@ -59,7 +59,6 @@ use fyrox::gui::style::Style;
 use fyrox::gui::text::TextBuilder;
 use fyrox::gui::{message::KeyCode, texture::TextureResource};
 use fyrox::gui::{HorizontalAlignment, VerticalAlignment};
-use fyrox::scene::tilemap::brush::TileMapBrushResource;
 use fyrox::scene::tilemap::tileset::{TileSetPropertyLayer, ELEMENT_MATCH_HIGHLIGHT_COLOR};
 use fyrox::scene::tilemap::{StampElement, TileMapEffectRef};
 pub use handle_editor::*;
@@ -547,7 +546,7 @@ impl TileDrawState {
     #[inline]
     pub fn update_stamp<F>(
         &mut self,
-        brush: Option<TileMapBrushResource>,
+        book: Option<TileBook>,
         tile_set: Option<TileSetResource>,
         tile_handle: F,
     ) where
@@ -555,7 +554,7 @@ impl TileDrawState {
     {
         self.tile_set = tile_set;
         self.stamp.build(
-            brush,
+            book,
             self.selection
                 .positions
                 .iter()

--- a/editor/src/plugins/tilemap/tile_inspector.rs
+++ b/editor/src/plugins/tilemap/tile_inspector.rs
@@ -1181,20 +1181,12 @@ impl TileInspector {
             TileBook::Empty => return,
             TileBook::TileSet(tile_set) => state
                 .page_positions()
-                .map(|position| ModifyPageIconCommand {
-                    tile_set: tile_set.clone(),
-                    page: position,
-                    icon,
-                })
+                .map(|position| ModifyPageIconCommand::new(tile_set.clone(), position, icon))
                 .map(Command::new)
                 .collect::<Vec<_>>(),
             TileBook::Brush(brush) => state
                 .page_positions()
-                .map(|position| ModifyBrushPageIconCommand {
-                    brush: brush.clone(),
-                    page: position,
-                    icon,
-                })
+                .map(|position| ModifyBrushPageIconCommand::new(brush.clone(), position, icon))
                 .map(Command::new)
                 .collect::<Vec<_>>(),
         };

--- a/editor/src/plugins/tilemap/tileset.rs
+++ b/editor/src/plugins/tilemap/tileset.rs
@@ -292,6 +292,7 @@ impl TileSetEditor {
         .with_resource(tile_book.clone())
         .with_kind(TilePaletteStage::Pages)
         .with_editable(true)
+        .with_macro_list(macro_list.clone())
         .build(ctx);
 
         let tiles_palette = PaletteWidgetBuilder::new(
@@ -305,6 +306,7 @@ impl TileSetEditor {
         .with_resource(tile_book.clone())
         .with_kind(TilePaletteStage::Tiles)
         .with_editable(true)
+        .with_macro_list(macro_list.clone())
         .with_macro_cells(brush_macro_cell_sets.clone())
         .build(ctx);
 

--- a/editor/src/plugins/tilemap/wfc.rs
+++ b/editor/src/plugins/tilemap/wfc.rs
@@ -442,17 +442,6 @@ impl BrushMacro for WfcMacro {
         )))
     }
 
-    fn remove_cell(&self, context: &BrushMacroCellContext) -> Option<Command> {
-        let instance = context.settings()?;
-        let cell = context.cell?;
-        Some(Command::new(SetCellCommand {
-            brush: context.brush.clone(),
-            cell,
-            instance,
-            included: false,
-        }))
-    }
-
     fn copy_cell(
         &self,
         source: Option<TileDefinitionHandle>,

--- a/editor/src/plugins/tilemap/wfc.rs
+++ b/editor/src/plugins/tilemap/wfc.rs
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use std::hash::Hash;
+
 use fyrox::{
     asset::{
         untyped::{ResourceKind, UntypedResource},
@@ -45,7 +47,7 @@ use fyrox::{
 };
 
 use crate::{
-    command::{Command, CommandContext, CommandTrait},
+    command::{Command, CommandContext, CommandGroup, CommandTrait},
     send_sync_message,
 };
 
@@ -399,7 +401,7 @@ impl BrushMacro for WfcMacro {
         cell_set.extend(data.cells.iter());
     }
 
-    fn create_cell(&self, context: &BrushMacroCell) -> Option<Command> {
+    fn create_cell(&self, context: &BrushMacroCellContext) -> Option<Command> {
         let instance = context.settings()?;
         let cell = context.cell?;
         Some(Command::new(SetCellCommand {
@@ -410,7 +412,37 @@ impl BrushMacro for WfcMacro {
         }))
     }
 
-    fn remove_cell(&self, context: &BrushMacroCell) -> Option<Command> {
+    fn move_cells(
+        &self,
+        from: Box<[TileDefinitionHandle]>,
+        to: Box<[TileDefinitionHandle]>,
+        context: &BrushMacroInstance,
+    ) -> Option<Command> {
+        let instance = context.settings()?;
+        Some(Command::new(MoveCellsCommand::new(
+            context.brush.clone(),
+            from,
+            to,
+            instance,
+        )))
+    }
+
+    fn move_pages(
+        &self,
+        from: Box<[Vector2<i32>]>,
+        to: Box<[Vector2<i32>]>,
+        context: &BrushMacroInstance,
+    ) -> Option<Command> {
+        let instance = context.settings()?;
+        Some(Command::new(MovePagesCommand::new(
+            context.brush.clone(),
+            from,
+            to,
+            instance,
+        )))
+    }
+
+    fn remove_cell(&self, context: &BrushMacroCellContext) -> Option<Command> {
         let instance = context.settings()?;
         let cell = context.cell?;
         Some(Command::new(SetCellCommand {
@@ -419,6 +451,69 @@ impl BrushMacro for WfcMacro {
             instance,
             included: false,
         }))
+    }
+
+    fn copy_cell(
+        &self,
+        source: Option<TileDefinitionHandle>,
+        destination: TileDefinitionHandle,
+        context: &BrushMacroInstance,
+    ) -> Option<Command> {
+        let instance = context.settings::<WfcInstance>()?;
+        let guard = instance.data_ref();
+        let included = if let Some(source) = source {
+            guard.cells.contains(&source)
+        } else {
+            false
+        };
+        Some(Command::new(SetCellCommand {
+            brush: context.brush.clone(),
+            cell: destination,
+            instance: instance.clone(),
+            included,
+        }))
+    }
+
+    fn copy_page(
+        &self,
+        source: Option<Vector2<i32>>,
+        destination: Vector2<i32>,
+        context: &BrushMacroInstance,
+    ) -> Option<Command> {
+        let instance = context.settings::<WfcInstance>()?;
+        let guard = instance.data_ref();
+        let used = guard
+            .cells
+            .iter()
+            .filter(|h| Some(h.page()) == source)
+            .map(|h| h.tile())
+            .collect::<Vec<_>>();
+        let commands = guard
+            .cells
+            .iter()
+            .filter_map(|handle| {
+                if Some(handle.page()) == source {
+                    let cell = TileDefinitionHandle::try_new(destination, handle.tile())?;
+                    Some(Command::new(SetCellCommand {
+                        brush: context.brush.clone(),
+                        cell,
+                        instance: instance.clone(),
+                        included: true,
+                    }))
+                } else if handle.page() == destination && !used.contains(&handle.tile()) {
+                    Some(Command::new(SetCellCommand {
+                        brush: context.brush.clone(),
+                        cell: *handle,
+                        instance: instance.clone(),
+                        included: false,
+                    }))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        (!commands.is_empty())
+            .then(|| Command::new(CommandGroup::from(commands).with_custom_name("Set Page Macros")))
     }
 
     fn build_instance_editor(
@@ -550,7 +645,7 @@ impl BrushMacro for WfcMacro {
 
     fn build_cell_editor(
         &mut self,
-        _context: &BrushMacroCell,
+        _context: &BrushMacroCellContext,
         _ctx: &mut BuildContext,
     ) -> Option<Handle<UiNode>> {
         None
@@ -663,13 +758,11 @@ impl BrushMacro for WfcMacro {
         let mut propagator = TileSetWfcPropagator::default();
         propagator.fill_from(constraint.deref());
         for (&p, v) in update.iter() {
-            if let Some(StampElement {
-                brush_cell: Some(cell),
-                ..
-            }) = v
-            {
-                if instance.cells.contains(cell) {
-                    propagator.add_cell(p);
+            if let Some(StampElement { source, .. }) = v {
+                if let Some(cell) = source.and_then(|s| s.handle()) {
+                    if instance.cells.contains(&cell) {
+                        propagator.add_cell(p);
+                    }
                 }
             }
         }
@@ -726,6 +819,142 @@ impl SetCellCommand {
 impl CommandTrait for SetCellCommand {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
         "Update Wave Function Collapse Cell".into()
+    }
+
+    fn execute(&mut self, _context: &mut dyn CommandContext) {
+        self.swap();
+    }
+
+    fn revert(&mut self, _context: &mut dyn CommandContext) {
+        self.swap();
+    }
+}
+
+#[derive(Debug)]
+struct MoveCellsCommand {
+    pub brush: TileMapBrushResource,
+    pub from: Box<[TileDefinitionHandle]>,
+    pub to: Box<[TileDefinitionHandle]>,
+    pub instance: Resource<WfcInstance>,
+    data: Box<[bool]>,
+}
+
+impl MoveCellsCommand {
+    fn new(
+        brush: TileMapBrushResource,
+        from: Box<[TileDefinitionHandle]>,
+        to: Box<[TileDefinitionHandle]>,
+        instance: Resource<WfcInstance>,
+    ) -> Self {
+        Self {
+            data: vec![false; from.len()].into_boxed_slice(),
+            brush,
+            from,
+            to,
+            instance,
+        }
+    }
+    fn swap(&mut self) {
+        let mut instance = self.instance.data_ref();
+        for (&from, data) in self.from.iter().zip(self.data.iter_mut()) {
+            swap_set_entry(&mut instance.cells, from, data);
+        }
+        for (&to, data) in self.to.iter().zip(self.data.iter_mut()) {
+            swap_set_entry(&mut instance.cells, to, data);
+        }
+        std::mem::swap(&mut self.from, &mut self.to);
+        self.brush.data_ref().change_flag.set();
+    }
+}
+
+fn swap_set_entry<T: Hash + Eq>(set: &mut FxHashSet<T>, value: T, contains: &mut bool) {
+    let old_contains = set.contains(&value);
+    if old_contains == *contains {
+        return;
+    };
+    if *contains {
+        set.insert(value);
+    } else {
+        set.remove(&value);
+    }
+    *contains = old_contains;
+}
+
+impl CommandTrait for MoveCellsCommand {
+    fn name(&mut self, _context: &dyn CommandContext) -> String {
+        "Update Autotile Cell".into()
+    }
+
+    fn execute(&mut self, _context: &mut dyn CommandContext) {
+        self.swap();
+    }
+
+    fn revert(&mut self, _context: &mut dyn CommandContext) {
+        self.swap();
+    }
+}
+
+#[derive(Debug)]
+struct MovePagesCommand {
+    pub brush: TileMapBrushResource,
+    pub from: Box<[Vector2<i32>]>,
+    pub to: Box<[Vector2<i32>]>,
+    pub instance: Resource<WfcInstance>,
+    data: Box<[FxHashSet<Vector2<i32>>]>,
+}
+
+impl MovePagesCommand {
+    fn new(
+        brush: TileMapBrushResource,
+        from: Box<[Vector2<i32>]>,
+        to: Box<[Vector2<i32>]>,
+        instance: Resource<WfcInstance>,
+    ) -> Self {
+        Self {
+            data: vec![FxHashSet::default(); from.len()].into_boxed_slice(),
+            brush,
+            from,
+            to,
+            instance,
+        }
+    }
+    fn swap(&mut self) {
+        let mut instance = self.instance.data_ref();
+        for (&from, data) in self.from.iter().zip(self.data.iter_mut()) {
+            swap_page(&mut instance.cells, from, data);
+        }
+        for (&to, data) in self.to.iter().zip(self.data.iter_mut()) {
+            swap_page(&mut instance.cells, to, data);
+        }
+        std::mem::swap(&mut self.from, &mut self.to);
+        self.brush.data_ref().change_flag.set();
+    }
+}
+
+fn swap_page(
+    set: &mut FxHashSet<TileDefinitionHandle>,
+    position: Vector2<i32>,
+    data: &mut FxHashSet<Vector2<i32>>,
+) {
+    let mut new_data = FxHashSet::default();
+    set.retain(|h| {
+        if h.page() != position {
+            true
+        } else {
+            new_data.insert(h.tile());
+            false
+        }
+    });
+    set.extend(
+        data.drain()
+            .filter_map(|p| TileDefinitionHandle::try_new(position, p)),
+    );
+    *data = new_data;
+}
+
+impl CommandTrait for MovePagesCommand {
+    fn name(&mut self, _context: &dyn CommandContext) -> String {
+        "Update Autotile Cell".into()
     }
 
     fn execute(&mut self, _context: &mut dyn CommandContext) {

--- a/fyrox-impl/src/scene/tilemap/autotile.rs
+++ b/fyrox-impl/src/scene/tilemap/autotile.rs
@@ -325,15 +325,11 @@ impl TileSetAutoTiler {
             else {
                 continue;
             };
-            let brush_cell = update
-                .get(pos)
-                .cloned()
-                .flatten()
-                .and_then(|el| el.brush_cell);
+            let source = update.get(pos).cloned().flatten().and_then(|el| el.source);
             let handle = if handle.is_empty() {
                 None
             } else {
-                Some(StampElement { handle, brush_cell })
+                Some(StampElement { handle, source })
             };
             _ = update.insert(*pos, handle);
         }
@@ -492,15 +488,11 @@ impl TileSetWfcPropagator {
             let Some(&handle) = value_map.get_random(rng, pat) else {
                 continue;
             };
-            let brush_cell = update
-                .get(pos)
-                .cloned()
-                .flatten()
-                .and_then(|el| el.brush_cell);
+            let source = update.get(pos).cloned().flatten().and_then(|el| el.source);
             let handle = if handle.is_empty() {
                 None
             } else {
-                Some(StampElement { handle, brush_cell })
+                Some(StampElement { handle, source })
             };
             _ = update.insert(*pos, handle);
         }

--- a/fyrox-impl/src/scene/tilemap/brush.rs
+++ b/fyrox-impl/src/scene/tilemap/brush.rs
@@ -494,16 +494,19 @@ impl TileMapBrush {
 
     /// The stamp element for the given position, if the tile in that cell is used
     /// to create a stamp. The [`StampElement::handle`] refers to the location of the tile within the
-    /// tile set, while the [`StampElement::brush_cell`] refers to the location of the tile within
+    /// tile set, while the [`StampElement::source`] refers to the location of the tile within
     /// the brush.
     pub fn stamp_element(&self, position: ResourceTilePosition) -> Option<StampElement> {
         match position.stage() {
-            TilePaletteStage::Pages => self.redirect_handle(position).map(|h| h.into()),
+            TilePaletteStage::Pages => self.redirect_handle(position).map(|handle| StampElement {
+                handle,
+                source: Some(position),
+            }),
             TilePaletteStage::Tiles => {
                 let page = self.pages.get(&position.page())?;
                 Some(StampElement {
                     handle: *page.tiles.get(&position.stage_position())?,
-                    brush_cell: position.handle(),
+                    source: Some(position),
                 })
             }
         }

--- a/fyrox-impl/src/scene/tilemap/mod.rs
+++ b/fyrox-impl/src/scene/tilemap/mod.rs
@@ -736,11 +736,10 @@ impl TileBook {
             TileBook::Brush(r) => r.state().data()?.redirect_handle(position),
         }
     }
-    /// The StampElement for the given position in this resource. For tile sets the element's
-    /// [`StampElement::brush_cell`] is None.
-    /// For brushes, the [`StampElement::handle`] refers to the location of the tile within the
-    /// tile set, while the [`StampElement::brush_cell`] refers to the location of the tile within
-    /// the brush.
+    /// The StampElement for the given position in this resource.
+    /// For brushes, the [`StampElement::handle`] refers to the ultimate location of the tile within the
+    /// tile set, while the [`StampElement::source`] refers to the location of the tile within
+    /// the brush or tile set that was used to create the stamp.
     pub fn get_stamp_element(&self, position: ResourceTilePosition) -> Option<StampElement> {
         match self {
             TileBook::Empty => None,

--- a/fyrox-impl/src/scene/tilemap/mod.rs
+++ b/fyrox-impl/src/scene/tilemap/mod.rs
@@ -409,6 +409,17 @@ pub enum ResourceTilePosition {
     Tile(Vector2<i32>, Vector2<i32>),
 }
 
+impl Display for ResourceTilePosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResourceTilePosition::Page(p) => write!(f, "Page({},{})", p.x, p.y),
+            ResourceTilePosition::Tile(page, pos) => {
+                write!(f, "({},{}):({},{})", page.x, page.y, pos.x, pos.y)
+            }
+        }
+    }
+}
+
 impl From<TileDefinitionHandle> for ResourceTilePosition {
     fn from(value: TileDefinitionHandle) -> Self {
         Self::Tile(value.page(), value.tile())
@@ -733,11 +744,7 @@ impl TileBook {
     pub fn get_stamp_element(&self, position: ResourceTilePosition) -> Option<StampElement> {
         match self {
             TileBook::Empty => None,
-            TileBook::TileSet(r) => r
-                .state()
-                .data()?
-                .redirect_handle(position)
-                .map(|h| h.into()),
+            TileBook::TileSet(r) => r.state().data()?.stamp_element(position),
             TileBook::Brush(r) => r.state().data()?.stamp_element(position),
         }
     }

--- a/fyrox-impl/src/scene/tilemap/tileset.rs
+++ b/fyrox-impl/src/scene/tilemap/tileset.rs
@@ -1345,6 +1345,17 @@ pub struct TileSet {
 }
 
 impl TileSet {
+    /// The stamp element for the given position, if the tile in that cell is used
+    /// to create a stamp. The [`StampElement::handle`] refers to the location of the tile within the
+    /// tile set, while the [`StampElement::source`] refers to the location of the tile within
+    /// the brush.
+    pub fn stamp_element(&self, position: ResourceTilePosition) -> Option<StampElement> {
+        self.redirect_handle(position).map(|handle| StampElement {
+            handle,
+            source: Some(position),
+        })
+    }
+
     /// Iterate all valid tile handles.
     pub fn all_tiles(&self) -> TileSetHandleIterator {
         TileSetHandleIterator::new(Some(self.pages.iter()))

--- a/fyrox-impl/src/scene/tilemap/update.rs
+++ b/fyrox-impl/src/scene/tilemap/update.rs
@@ -618,9 +618,9 @@ impl Debug for MacroTilesUpdate {
         f.write_str("MacroTilesUpdate")?;
         for (p, v) in self.0.iter() {
             write!(f, " ({:2},{:2})->", p.x, p.y)?;
-            if let Some(StampElement { handle, brush_cell }) = v {
+            if let Some(StampElement { handle, source }) = v {
                 write!(f, "{handle}")?;
-                if let Some(cell) = brush_cell {
+                if let Some(cell) = source {
                     write!(f, "[{cell}]")?;
                 }
             } else {
@@ -737,7 +737,7 @@ impl TransTilesUpdate {
                     *pos,
                     Some(StampElement {
                         handle,
-                        brush_cell: element.brush_cell,
+                        source: element.source,
                     }),
                 );
             } else {


### PR DESCRIPTION
I have removed some limitations on Tile Set editing and Brush editing to give the Tile Set editor a more consistent and powerful interface:

* Pages can now be drawn/erased in the page area of the editor just as tiles could already be drawn in the tile area. Select a page or group of pages as a stamp, and then use the drawing tools to draw copies of those pages in the page area, and this will create copies of those pages wherever you draw them, including the whole content of the pages. Prior to this, there was no way to duplicate a page
* Brush macros objects now have methods for moving and copying macro data in tiles and in pages. Formerly, when a tile was moved, copied, or deleted, the associated macro data would not be affected. Now macro data stays with a tile and can be copied with a tile. This includes copying a brush page, so that the macro data of the cells on that page can now be copied along with the page.

This project involved extensive use of `CommandGroup`. I added a method to `CommandGroup` that it surely should have had: `push_command` which allows you to push a `Command` into the group. There is no reason why that should not be allowed. I also added some doc comments to help explain `CommandGroup`.