### PR TITLE
Moving control panels to Inspector

### DIFF
--- a/editor/src/audio/preview.rs
+++ b/editor/src/audio/preview.rs
@@ -18,8 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use fyrox::gui::widget::WidgetMessage;
+
 use crate::fyrox::graph::SceneGraph;
-use crate::fyrox::gui::HorizontalAlignment;
 use crate::fyrox::{
     core::pool::Handle,
     engine::Engine,
@@ -31,7 +32,6 @@ use crate::fyrox::{
         scroll_bar::{ScrollBarBuilder, ScrollBarMessage},
         text::TextBuilder,
         widget::WidgetBuilder,
-        window::{WindowBuilder, WindowMessage, WindowTitle},
         BuildContext, Thickness, UiNode, VerticalAlignment,
     },
     scene::{
@@ -53,129 +53,124 @@ pub struct AudioPreviewPanel {
     rewind: Handle<UiNode>,
     time: Handle<UiNode>,
     sounds_state: Vec<(Handle<Node>, Node)>,
-    scene_viewer_frame: Handle<UiNode>,
 }
 
 impl AudioPreviewPanel {
-    pub fn new(scene_viewer_frame: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
+    pub fn new(inspector_head: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
         let preview;
         let play;
         let pause;
         let stop;
         let rewind;
         let time;
-        let window = WindowBuilder::new(
+        let window = GridBuilder::new(
             WidgetBuilder::new()
-                .with_name("AudioPreviewPanel")
-                .with_width(300.0)
-                .with_height(70.0),
-        )
-        .with_title(WindowTitle::text("Audio Preview Panel"))
-        .open(false)
-        .with_content(
-            GridBuilder::new(
-                WidgetBuilder::new()
-                    .with_child(
-                        GridBuilder::new(
-                            WidgetBuilder::new()
-                                .on_row(0)
-                                .with_child({
-                                    preview = CheckBoxBuilder::new(
-                                        WidgetBuilder::new()
-                                            .with_vertical_alignment(VerticalAlignment::Center)
-                                            .with_margin(Thickness::uniform(1.0)),
-                                    )
-                                    .with_content(
-                                        TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .on_column(0)
-                                                .with_vertical_alignment(VerticalAlignment::Center),
-                                        )
-                                        .with_text("Preview")
-                                        .build(ctx),
-                                    )
-                                    .build(ctx);
-                                    preview
-                                })
-                                .with_child({
-                                    play = ButtonBuilder::new(
-                                        WidgetBuilder::new()
-                                            .on_column(1)
-                                            .with_margin(Thickness::uniform(1.0)),
-                                    )
-                                    .with_text("Play")
-                                    .build(ctx);
-                                    play
-                                })
-                                .with_child({
-                                    pause = ButtonBuilder::new(
-                                        WidgetBuilder::new()
-                                            .on_column(2)
-                                            .with_margin(Thickness::uniform(1.0)),
-                                    )
-                                    .with_text("Pause")
-                                    .build(ctx);
-                                    pause
-                                })
-                                .with_child({
-                                    stop = ButtonBuilder::new(
-                                        WidgetBuilder::new()
-                                            .on_column(3)
-                                            .with_margin(Thickness::uniform(1.0)),
-                                    )
-                                    .with_text("Stop")
-                                    .build(ctx);
-                                    stop
-                                })
-                                .with_child({
-                                    rewind = ButtonBuilder::new(
-                                        WidgetBuilder::new()
-                                            .on_column(4)
-                                            .with_margin(Thickness::uniform(1.0)),
-                                    )
-                                    .with_text("Rewind")
-                                    .build(ctx);
-                                    rewind
-                                }),
-                        )
-                        .add_row(Row::stretch())
-                        .add_column(Column::strict(80.0))
-                        .add_column(Column::stretch())
-                        .add_column(Column::stretch())
-                        .add_column(Column::stretch())
-                        .add_column(Column::stretch())
-                        .build(ctx),
-                    )
-                    .with_child(
-                        GridBuilder::new(
-                            WidgetBuilder::new()
-                                .on_row(1)
-                                .with_child(
+                .with_visibility(false)
+                .with_child(
+                    GridBuilder::new(
+                        WidgetBuilder::new()
+                            .on_row(0)
+                            .with_child({
+                                preview = CheckBoxBuilder::new(
+                                    WidgetBuilder::new()
+                                        .with_vertical_alignment(VerticalAlignment::Center)
+                                        .with_margin(Thickness::uniform(1.0)),
+                                )
+                                .with_content(
                                     TextBuilder::new(
-                                        WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
+                                        WidgetBuilder::new()
+                                            .on_column(0)
+                                            .with_vertical_alignment(VerticalAlignment::Center),
                                     )
-                                    .with_text("Time, s")
+                                    .with_text("Preview")
                                     .build(ctx),
                                 )
-                                .with_child({
-                                    time = ScrollBarBuilder::new(WidgetBuilder::new().on_column(1))
-                                        .with_min(0.0)
-                                        .build(ctx);
-                                    time
-                                }),
-                        )
-                        .add_column(Column::auto())
-                        .add_column(Column::stretch())
-                        .add_row(Row::strict(20.0))
-                        .build(ctx),
-                    ),
-            )
-            .add_column(Column::stretch())
-            .add_row(Row::stretch())
-            .add_row(Row::strict(20.0))
-            .build(ctx),
+                                .build(ctx);
+                                preview
+                            })
+                            .with_child({
+                                play = ButtonBuilder::new(
+                                    WidgetBuilder::new()
+                                        .on_column(1)
+                                        .with_margin(Thickness::uniform(1.0)),
+                                )
+                                .with_text("Play")
+                                .build(ctx);
+                                play
+                            })
+                            .with_child({
+                                pause = ButtonBuilder::new(
+                                    WidgetBuilder::new()
+                                        .on_column(2)
+                                        .with_margin(Thickness::uniform(1.0)),
+                                )
+                                .with_text("Pause")
+                                .build(ctx);
+                                pause
+                            })
+                            .with_child({
+                                stop = ButtonBuilder::new(
+                                    WidgetBuilder::new()
+                                        .on_column(3)
+                                        .with_margin(Thickness::uniform(1.0)),
+                                )
+                                .with_text("Stop")
+                                .build(ctx);
+                                stop
+                            })
+                            .with_child({
+                                rewind = ButtonBuilder::new(
+                                    WidgetBuilder::new()
+                                        .on_column(4)
+                                        .with_margin(Thickness::uniform(1.0)),
+                                )
+                                .with_text("Rewind")
+                                .build(ctx);
+                                rewind
+                            }),
+                    )
+                    .add_row(Row::stretch())
+                    .add_column(Column::strict(80.0))
+                    .add_column(Column::stretch())
+                    .add_column(Column::stretch())
+                    .add_column(Column::stretch())
+                    .add_column(Column::stretch())
+                    .build(ctx),
+                )
+                .with_child(
+                    GridBuilder::new(
+                        WidgetBuilder::new()
+                            .on_row(1)
+                            .with_child(
+                                TextBuilder::new(
+                                    WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
+                                )
+                                .with_text("Time, s")
+                                .build(ctx),
+                            )
+                            .with_child({
+                                time = ScrollBarBuilder::new(WidgetBuilder::new().on_column(1))
+                                    .with_min(0.0)
+                                    .build(ctx);
+                                time
+                            }),
+                    )
+                    .add_column(Column::auto())
+                    .add_column(Column::stretch())
+                    .add_row(Row::strict(20.0))
+                    .build(ctx),
+                ),
         )
+        .add_column(Column::stretch())
+        .add_row(Row::stretch())
+        .add_row(Row::strict(20.0))
         .build(ctx);
+
+        ctx.send_message(WidgetMessage::link(
+            window,
+            MessageDirection::ToWidget,
+            inspector_head,
+        ));
 
         Self {
             window,
@@ -186,7 +181,6 @@ impl AudioPreviewPanel {
             rewind,
             time,
             sounds_state: vec![],
-            scene_viewer_frame,
         }
     }
 
@@ -211,29 +205,14 @@ impl AudioPreviewPanel {
                     .nodes
                     .iter()
                     .any(|n| scene.graph.try_get_of_type::<Sound>(*n).is_some());
-                if any_sound_selected {
-                    engine
-                        .user_interfaces
-                        .first_mut()
-                        .send_message(WindowMessage::open_and_align(
-                            self.window,
-                            MessageDirection::ToWidget,
-                            self.scene_viewer_frame,
-                            HorizontalAlignment::Right,
-                            VerticalAlignment::Top,
-                            Thickness::top_right(5.0),
-                            false,
-                            false,
-                        ));
-                } else {
-                    engine
-                        .user_interfaces
-                        .first_mut()
-                        .send_message(WindowMessage::close(
-                            self.window,
-                            MessageDirection::ToWidget,
-                        ));
-                }
+                engine
+                    .user_interfaces
+                    .first_mut()
+                    .send_message(WidgetMessage::visibility(
+                        self.window,
+                        MessageDirection::ToWidget,
+                        any_sound_selected,
+                    ));
             }
         }
     }

--- a/editor/src/audio/preview.rs
+++ b/editor/src/audio/preview.rs
@@ -45,7 +45,7 @@ use crate::{
 };
 
 pub struct AudioPreviewPanel {
-    pub window: Handle<UiNode>,
+    pub root_widget: Handle<UiNode>,
     preview: Handle<UiNode>,
     play: Handle<UiNode>,
     pause: Handle<UiNode>,
@@ -63,7 +63,7 @@ impl AudioPreviewPanel {
         let stop;
         let rewind;
         let time;
-        let window = GridBuilder::new(
+        let root_widget = GridBuilder::new(
             WidgetBuilder::new()
                 .with_visibility(false)
                 .with_child(
@@ -167,13 +167,13 @@ impl AudioPreviewPanel {
         .build(ctx);
 
         ctx.send_message(WidgetMessage::link(
-            window,
+            root_widget,
             MessageDirection::ToWidget,
             inspector_head,
         ));
 
         Self {
-            window,
+            root_widget,
             preview,
             play,
             pause,
@@ -209,7 +209,7 @@ impl AudioPreviewPanel {
                     .user_interfaces
                     .first_mut()
                     .send_message(WidgetMessage::visibility(
-                        self.window,
+                        self.root_widget,
                         MessageDirection::ToWidget,
                         any_sound_selected,
                     ));

--- a/editor/src/camera/panel.rs
+++ b/editor/src/camera/panel.rs
@@ -18,21 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use fyrox::gui::widget::WidgetMessage;
+
 use crate::{
     fyrox::{
         core::pool::Handle,
         engine::Engine,
         graph::SceneGraph,
+        gui::Thickness,
         gui::{
             check_box::{CheckBoxBuilder, CheckBoxMessage},
             message::{MessageDirection, UiMessage},
             stack_panel::StackPanelBuilder,
             text::TextBuilder,
             widget::WidgetBuilder,
-            window::{WindowBuilder, WindowMessage, WindowTitle},
             BuildContext, Orientation, UiNode, VerticalAlignment,
         },
-        gui::{HorizontalAlignment, Thickness},
         scene::{camera::Camera, node::Node},
     },
     scene::{GameScene, Selection},
@@ -43,48 +44,42 @@ pub struct CameraPreviewControlPanel {
     pub window: Handle<UiNode>,
     preview: Handle<UiNode>,
     cameras_state: Vec<(Handle<Node>, Node)>,
-    scene_viewer_frame: Handle<UiNode>,
 }
 
 impl CameraPreviewControlPanel {
-    pub fn new(scene_viewer_frame: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
+    pub fn new(inspector_head: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
         let preview;
-        let window = WindowBuilder::new(
+        let window = StackPanelBuilder::new(
             WidgetBuilder::new()
-                .with_width(200.0)
-                .with_height(50.0)
-                .with_name("CameraPanel"),
-        )
-        .with_title(WindowTitle::text("Camera Preview"))
-        .with_content(
-            StackPanelBuilder::new(
-                WidgetBuilder::new()
-                    .with_margin(Thickness::uniform(1.0))
-                    .with_child({
-                        preview = CheckBoxBuilder::new(WidgetBuilder::new())
-                            .with_content(
-                                TextBuilder::new(
-                                    WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
-                                )
-                                .with_text("Preview")
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .build(ctx),
+                .with_visibility(false)
+                .with_margin(Thickness::uniform(1.0))
+                .with_child({
+                    preview = CheckBoxBuilder::new(WidgetBuilder::new())
+                        .with_content(
+                            TextBuilder::new(
+                                WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
                             )
-                            .build(ctx);
-                        preview
-                    }),
-            )
-            .with_orientation(Orientation::Vertical)
-            .build(ctx),
+                            .with_text("Preview")
+                            .with_vertical_text_alignment(VerticalAlignment::Center)
+                            .build(ctx),
+                        )
+                        .build(ctx);
+                    preview
+                }),
         )
-        .open(false)
+        .with_orientation(Orientation::Vertical)
         .build(ctx);
+
+        ctx.send_message(WidgetMessage::link(
+            window,
+            MessageDirection::ToWidget,
+            inspector_head,
+        ));
 
         Self {
             window,
             cameras_state: Default::default(),
             preview,
-            scene_viewer_frame,
         }
     }
 
@@ -109,29 +104,14 @@ impl CameraPreviewControlPanel {
                     .nodes
                     .iter()
                     .any(|n| scene.graph.try_get_of_type::<Camera>(*n).is_some());
-                if any_camera {
-                    engine
-                        .user_interfaces
-                        .first_mut()
-                        .send_message(WindowMessage::open_and_align(
-                            self.window,
-                            MessageDirection::ToWidget,
-                            self.scene_viewer_frame,
-                            HorizontalAlignment::Right,
-                            VerticalAlignment::Top,
-                            Thickness::top_right(5.0),
-                            false,
-                            false,
-                        ));
-                } else {
-                    engine
-                        .user_interfaces
-                        .first_mut()
-                        .send_message(WindowMessage::close(
-                            self.window,
-                            MessageDirection::ToWidget,
-                        ));
-                }
+                engine
+                    .user_interfaces
+                    .first_mut()
+                    .send_message(WidgetMessage::visibility(
+                        self.window,
+                        MessageDirection::ToWidget,
+                        any_camera,
+                    ));
             }
         }
     }

--- a/editor/src/camera/panel.rs
+++ b/editor/src/camera/panel.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 
 pub struct CameraPreviewControlPanel {
-    pub window: Handle<UiNode>,
+    pub root_widget: Handle<UiNode>,
     preview: Handle<UiNode>,
     cameras_state: Vec<(Handle<Node>, Node)>,
 }
@@ -49,7 +49,7 @@ pub struct CameraPreviewControlPanel {
 impl CameraPreviewControlPanel {
     pub fn new(inspector_head: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
         let preview;
-        let window = StackPanelBuilder::new(
+        let root_widget = StackPanelBuilder::new(
             WidgetBuilder::new()
                 .with_visibility(false)
                 .with_margin(Thickness::uniform(1.0))
@@ -71,13 +71,13 @@ impl CameraPreviewControlPanel {
         .build(ctx);
 
         ctx.send_message(WidgetMessage::link(
-            window,
+            root_widget,
             MessageDirection::ToWidget,
             inspector_head,
         ));
 
         Self {
-            window,
+            root_widget,
             cameras_state: Default::default(),
             preview,
         }
@@ -108,7 +108,7 @@ impl CameraPreviewControlPanel {
                     .user_interfaces
                     .first_mut()
                     .send_message(WidgetMessage::visibility(
-                        self.window,
+                        self.root_widget,
                         MessageDirection::ToWidget,
                         any_camera,
                     ));

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -873,10 +873,10 @@ impl Editor {
                                 .build(ctx)
                         }))
                         .with_floating_windows(vec![
-                            particle_system_control_panel.window,
-                            camera_control_panel.window,
-                            mesh_control_panel.window,
-                            audio_preview_panel.window,
+                            particle_system_control_panel.root_widget,
+                            camera_control_panel.root_widget,
+                            mesh_control_panel.root_widget,
+                            audio_preview_panel.root_widget,
                             navmesh_panel.window,
                             doc_window.window,
                             light_panel.window,

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -746,10 +746,10 @@ impl Editor {
         );
         let inspector_plugin = InspectorPlugin::new(ctx, message_sender.clone());
         let particle_system_control_panel =
-            ParticleSystemPreviewControlPanel::new(scene_viewer.frame(), ctx);
-        let camera_control_panel = CameraPreviewControlPanel::new(scene_viewer.frame(), ctx);
-        let mesh_control_panel = MeshControlPanel::new(scene_viewer.frame(), ctx);
-        let audio_preview_panel = AudioPreviewPanel::new(scene_viewer.frame(), ctx);
+            ParticleSystemPreviewControlPanel::new(inspector_plugin.head, ctx);
+        let camera_control_panel = CameraPreviewControlPanel::new(inspector_plugin.head, ctx);
+        let mesh_control_panel = MeshControlPanel::new(inspector_plugin.head, ctx);
+        let audio_preview_panel = AudioPreviewPanel::new(inspector_plugin.head, ctx);
         let doc_window = DocWindow::new(ctx);
         let node_removal_dialog = NodeRemovalDialog::new(ctx);
         let scene_settings = SceneSettingsWindow::new(ctx, message_sender.clone());

--- a/editor/src/mesh.rs
+++ b/editor/src/mesh.rs
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use fyrox::gui::widget::WidgetMessage;
+
 use crate::{
     command::{Command, CommandGroup},
     fyrox::{
@@ -31,7 +33,7 @@ use crate::{
             utils::make_simple_tooltip,
             widget::WidgetBuilder,
             window::{WindowBuilder, WindowMessage, WindowTitle},
-            BuildContext, HorizontalAlignment, Thickness, UiNode, VerticalAlignment,
+            BuildContext, Thickness, UiNode,
         },
         scene::{
             base::BaseBuilder,
@@ -56,7 +58,6 @@ use crate::{
 };
 
 pub struct MeshControlPanel {
-    scene_viewer_frame: Handle<UiNode>,
     pub window: Handle<UiNode>,
     create_trimesh_collider: Handle<UiNode>,
     create_convex_collider: Handle<UiNode>,
@@ -88,7 +89,7 @@ fn meshes_iter<'a>(
 }
 
 impl MeshControlPanel {
-    pub fn new(scene_viewer_frame: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
+    pub fn new(inspector_head: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
         let create_trimesh_collider = make_button(
             "Create Trimesh Collider",
             "Creates a new trimesh collider and attaches it to the selected mesh(es)",
@@ -119,29 +120,24 @@ impl MeshControlPanel {
             rigid body.",
             ctx,
         );
-        let window = WindowBuilder::new(
+        let window = StackPanelBuilder::new(
             WidgetBuilder::new()
-                .with_width(210.0)
-                .with_height(200.0)
-                .with_name("MeshControlPanel"),
-        )
-        .open(false)
-        .with_title(WindowTitle::text("Mesh Control Panel"))
-        .with_content(
-            StackPanelBuilder::new(
-                WidgetBuilder::new()
-                    .with_child(create_trimesh_collider)
-                    .with_child(create_convex_collider)
-                    .with_child(create_trimesh_rigid_body)
-                    .with_child(add_convex_collider)
-                    .with_child(add_trimesh_collider),
-            )
-            .build(ctx),
+                .with_visibility(false)
+                .with_child(create_trimesh_collider)
+                .with_child(create_convex_collider)
+                .with_child(create_trimesh_rigid_body)
+                .with_child(add_convex_collider)
+                .with_child(add_trimesh_collider),
         )
         .build(ctx);
 
+        ctx.send_message(WidgetMessage::link(
+            window,
+            MessageDirection::ToWidget,
+            inspector_head,
+        ));
+
         Self {
-            scene_viewer_frame,
             window,
             create_trimesh_collider,
             create_convex_collider,
@@ -285,29 +281,14 @@ impl MeshControlPanel {
             .nodes
             .iter()
             .any(|n| scene.graph.try_get_of_type::<Mesh>(*n).is_some());
-        if any_mesh {
-            engine
-                .user_interfaces
-                .first_mut()
-                .send_message(WindowMessage::open_and_align(
-                    self.window,
-                    MessageDirection::ToWidget,
-                    self.scene_viewer_frame,
-                    HorizontalAlignment::Right,
-                    VerticalAlignment::Top,
-                    Thickness::top_right(5.0),
-                    false,
-                    false,
-                ));
-        } else {
-            engine
-                .user_interfaces
-                .first_mut()
-                .send_message(WindowMessage::close(
-                    self.window,
-                    MessageDirection::ToWidget,
-                ));
-        }
+        engine
+            .user_interfaces
+            .first_mut()
+            .send_message(WidgetMessage::visibility(
+                self.window,
+                MessageDirection::ToWidget,
+                any_mesh,
+            ));
     }
 }
 

--- a/editor/src/mesh.rs
+++ b/editor/src/mesh.rs
@@ -58,7 +58,7 @@ use crate::{
 };
 
 pub struct MeshControlPanel {
-    pub window: Handle<UiNode>,
+    pub root_widget: Handle<UiNode>,
     create_trimesh_collider: Handle<UiNode>,
     create_convex_collider: Handle<UiNode>,
     create_trimesh_rigid_body: Handle<UiNode>,
@@ -120,7 +120,7 @@ impl MeshControlPanel {
             rigid body.",
             ctx,
         );
-        let window = StackPanelBuilder::new(
+        let root_widget = StackPanelBuilder::new(
             WidgetBuilder::new()
                 .with_visibility(false)
                 .with_child(create_trimesh_collider)
@@ -132,13 +132,13 @@ impl MeshControlPanel {
         .build(ctx);
 
         ctx.send_message(WidgetMessage::link(
-            window,
+            root_widget,
             MessageDirection::ToWidget,
             inspector_head,
         ));
 
         Self {
-            window,
+            root_widget,
             create_trimesh_collider,
             create_convex_collider,
             create_trimesh_rigid_body,
@@ -285,7 +285,7 @@ impl MeshControlPanel {
             .user_interfaces
             .first_mut()
             .send_message(WidgetMessage::visibility(
-                self.window,
+                self.root_widget,
                 MessageDirection::ToWidget,
                 any_mesh,
             ));

--- a/editor/src/particle.rs
+++ b/editor/src/particle.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 pub struct ParticleSystemPreviewControlPanel {
-    pub window: Handle<UiNode>,
+    pub root_widget: Handle<UiNode>,
     preview: Handle<UiNode>,
     play: Handle<UiNode>,
     pause: Handle<UiNode>,
@@ -139,7 +139,7 @@ impl ParticleSystemPreviewControlPanel {
 
         let time;
         let set_time;
-        let window = GridBuilder::new(
+        let root_widget = GridBuilder::new(
             WidgetBuilder::new()
                 .with_visibility(false)
                 .with_child(grid)
@@ -195,13 +195,13 @@ impl ParticleSystemPreviewControlPanel {
         .build(ctx);
 
         ctx.send_message(WidgetMessage::link(
-            window,
+            root_widget,
             MessageDirection::ToWidget,
             inspector_head,
         ));
 
         Self {
-            window,
+            root_widget,
             play,
             pause,
             stop,
@@ -239,7 +239,7 @@ impl ParticleSystemPreviewControlPanel {
                     .user_interfaces
                     .first_mut()
                     .send_message(WidgetMessage::visibility(
-                        self.window,
+                        self.root_widget,
                         MessageDirection::ToWidget,
                         any_particle_system_selected,
                     ));

--- a/editor/src/plugins/collider/mod.rs
+++ b/editor/src/plugins/collider/mod.rs
@@ -737,7 +737,7 @@ impl EditorPlugin for ColliderPlugin {
                     let ui = editor.engine.user_interfaces.first_mut();
                     let panel = ColliderControlPanel::new(&mut ui.build_ctx());
                     ui.send_message(WidgetMessage::link(
-                        panel.window,
+                        panel.root_widget,
                         MessageDirection::ToWidget,
                         inspector.head,
                     ));

--- a/editor/src/plugins/collider/mod.rs
+++ b/editor/src/plugins/collider/mod.rs
@@ -35,6 +35,8 @@ mod segment2d;
 mod triangle;
 mod triangle2d;
 
+use fyrox::gui::widget::WidgetMessage;
+
 use crate::{
     camera::PickingOptions,
     command::SetPropertyCommand,
@@ -53,7 +55,6 @@ use crate::{
         engine::Engine,
         graph::{BaseSceneGraph, SceneGraph, SceneGraphNode},
         gui::{
-            dock::DockingManagerMessage,
             message::{MessageDirection, UiMessage},
             BuildContext, UiNode,
         },
@@ -89,6 +90,8 @@ use crate::{
     settings::Settings,
     Editor, Message,
 };
+
+use super::inspector::InspectorPlugin;
 
 fn try_get_collider_shape(collider: Handle<Node>, scene: &Scene) -> Option<ColliderShape> {
     scene
@@ -730,24 +733,18 @@ impl EditorPlugin for ColliderPlugin {
                 });
 
                 if self.panel.is_none() {
+                    let inspector = editor.plugins.get::<InspectorPlugin>();
                     let ui = editor.engine.user_interfaces.first_mut();
-                    let panel =
-                        ColliderControlPanel::new(editor.scene_viewer.frame(), &mut ui.build_ctx());
-                    ui.send_message(DockingManagerMessage::add_floating_window(
-                        editor.docking_manager,
-                        MessageDirection::ToWidget,
+                    let panel = ColliderControlPanel::new(&mut ui.build_ctx());
+                    ui.send_message(WidgetMessage::link(
                         panel.window,
+                        MessageDirection::ToWidget,
+                        inspector.head,
                     ));
-                    panel.open(ui);
                     self.panel = Some(panel);
                 }
             } else if let Some(panel) = self.panel.take() {
                 let ui = editor.engine.user_interfaces.first();
-                ui.send_message(DockingManagerMessage::remove_floating_window(
-                    editor.docking_manager,
-                    MessageDirection::ToWidget,
-                    panel.window,
-                ));
                 panel.destroy(ui);
             }
         }

--- a/editor/src/plugins/collider/panel.rs
+++ b/editor/src/plugins/collider/panel.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 
 pub struct ColliderControlPanel {
-    pub window: Handle<UiNode>,
+    pub root_widget: Handle<UiNode>,
     fit: Handle<UiNode>,
     edit: Handle<UiNode>,
 }
@@ -78,7 +78,7 @@ impl ColliderControlPanel {
 
         let fit;
         let edit;
-        let window = StackPanelBuilder::new(
+        let root_widget = StackPanelBuilder::new(
             WidgetBuilder::new()
                 .with_horizontal_alignment(HorizontalAlignment::Right)
                 .with_child({
@@ -106,12 +106,16 @@ impl ColliderControlPanel {
         )
         .with_orientation(Orientation::Horizontal)
         .build(ctx);
-        Self { window, fit, edit }
+        Self {
+            root_widget,
+            fit,
+            edit,
+        }
     }
 
     pub fn destroy(self, ui: &UserInterface) {
         ui.send_message(WidgetMessage::remove(
-            self.window,
+            self.root_widget,
             MessageDirection::ToWidget,
         ));
     }

--- a/editor/src/plugins/collider/panel.rs
+++ b/editor/src/plugins/collider/panel.rs
@@ -30,9 +30,7 @@ use crate::{
             stack_panel::StackPanelBuilder,
             utils::make_simple_tooltip,
             widget::{WidgetBuilder, WidgetMessage},
-            window::{WindowBuilder, WindowMessage, WindowTitle},
-            BuildContext, HorizontalAlignment, Orientation, Thickness, UiNode, UserInterface,
-            VerticalAlignment,
+            BuildContext, HorizontalAlignment, Orientation, UiNode, UserInterface,
         },
         scene::{
             collider::{Collider, ColliderShape},
@@ -49,7 +47,6 @@ pub struct ColliderControlPanel {
     pub window: Handle<UiNode>,
     fit: Handle<UiNode>,
     edit: Handle<UiNode>,
-    scene_frame: Handle<UiNode>,
 }
 
 fn set_property<T: Reflect>(
@@ -71,7 +68,7 @@ fn set_property<T: Reflect>(
 }
 
 impl ColliderControlPanel {
-    pub fn new(scene_frame: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
+    pub fn new(ctx: &mut BuildContext) -> Self {
         let try_fit_tooltip = "Tries to calculate the new collider shape parameters (half extents,\
         radius, etc.) using bounding boxes of descendant nodes of the parent rigid body. This \
         operation performed in world-space coordinates.";
@@ -81,65 +78,35 @@ impl ColliderControlPanel {
 
         let fit;
         let edit;
-        let window = WindowBuilder::new(
+        let window = StackPanelBuilder::new(
             WidgetBuilder::new()
-                .with_width(250.0)
-                .with_height(50.0)
-                .with_name("ColliderControlPanel"),
+                .with_horizontal_alignment(HorizontalAlignment::Right)
+                .with_child({
+                    fit = ButtonBuilder::new(
+                        WidgetBuilder::new()
+                            .with_width(80.0)
+                            .with_height(24.0)
+                            .with_tooltip(make_simple_tooltip(ctx, try_fit_tooltip)),
+                    )
+                    .with_text("Try Fit")
+                    .build(ctx);
+                    fit
+                })
+                .with_child({
+                    edit = ButtonBuilder::new(
+                        WidgetBuilder::new()
+                            .with_width(80.0)
+                            .with_height(24.0)
+                            .with_tooltip(make_simple_tooltip(ctx, edit_tooltip)),
+                    )
+                    .with_text("Edit")
+                    .build(ctx);
+                    edit
+                }),
         )
-        .open(false)
-        .with_title(WindowTitle::text("Collider Control Panel"))
-        .with_content(
-            StackPanelBuilder::new(
-                WidgetBuilder::new()
-                    .with_horizontal_alignment(HorizontalAlignment::Right)
-                    .with_child({
-                        fit = ButtonBuilder::new(
-                            WidgetBuilder::new()
-                                .with_width(80.0)
-                                .with_height(24.0)
-                                .with_tooltip(make_simple_tooltip(ctx, try_fit_tooltip)),
-                        )
-                        .with_text("Try Fit")
-                        .build(ctx);
-                        fit
-                    })
-                    .with_child({
-                        edit = ButtonBuilder::new(
-                            WidgetBuilder::new()
-                                .with_width(80.0)
-                                .with_height(24.0)
-                                .with_tooltip(make_simple_tooltip(ctx, edit_tooltip)),
-                        )
-                        .with_text("Edit")
-                        .build(ctx);
-                        edit
-                    }),
-            )
-            .with_orientation(Orientation::Horizontal)
-            .build(ctx),
-        )
+        .with_orientation(Orientation::Horizontal)
         .build(ctx);
-
-        Self {
-            window,
-            fit,
-            edit,
-            scene_frame,
-        }
-    }
-
-    pub fn open(&self, ui: &UserInterface) {
-        ui.send_message(WindowMessage::open_and_align(
-            self.window,
-            MessageDirection::ToWidget,
-            self.scene_frame,
-            HorizontalAlignment::Right,
-            VerticalAlignment::Top,
-            Thickness::uniform(1.0),
-            false,
-            false,
-        ));
+        Self { window, fit, edit }
     }
 
     pub fn destroy(self, ui: &UserInterface) {

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -55,6 +55,7 @@ use crate::{
     utils::window_content,
     Editor, Message, WidgetMessage, WrapMode, MSG_SYNC_FLAG,
 };
+use fyrox::gui::stack_panel::StackPanelBuilder;
 use fyrox::gui::style::resource::StyleResourceExt;
 use fyrox::gui::style::Style;
 use fyrox::gui::utils::make_image_button_with_tooltip;
@@ -97,6 +98,7 @@ pub struct InspectorPlugin {
     pub property_editors: Arc<PropertyEditorDefinitionContainer>,
     pub(crate) window: Handle<UiNode>,
     pub inspector: Handle<UiNode>,
+    pub head: Handle<UiNode>,
     warning_text: Handle<UiNode>,
     type_name_text: Handle<UiNode>,
     docs_button: Handle<UiNode>,
@@ -166,9 +168,14 @@ impl InspectorPlugin {
             "Multiple objects are selected, showing properties of the first object only!\
             Only common properties will be editable!";
 
+        let head = StackPanelBuilder::new(WidgetBuilder::new()).build(ctx);
+        let inspector = InspectorBuilder::new(WidgetBuilder::new()).build(ctx);
+        let content =
+            StackPanelBuilder::new(WidgetBuilder::new().with_child(head).with_child(inspector))
+                .build(ctx);
+
         let warning_text;
         let type_name_text;
-        let inspector;
         let docs_button;
         let window = WindowBuilder::new(WidgetBuilder::new().with_name("Inspector"))
             .with_title(WindowTitle::text("Inspector"))
@@ -223,11 +230,7 @@ impl InspectorPlugin {
                         )
                         .with_child(
                             ScrollViewerBuilder::new(WidgetBuilder::new().on_row(2))
-                                .with_content({
-                                    inspector =
-                                        InspectorBuilder::new(WidgetBuilder::new()).build(ctx);
-                                    inspector
-                                })
+                                .with_content(content)
                                 .build(ctx),
                         ),
                 )
@@ -242,6 +245,7 @@ impl InspectorPlugin {
         Self {
             window,
             inspector,
+            head,
             property_editors,
             warning_text,
             type_name_text,


### PR DESCRIPTION
This is an experiment to see if the editor is improved by moving some of the little control panel windows into the top of the Inspector. This has several benefits:

* It simplifies the code for this control panels, since they no longer need to manage their windows. This PR reduces the lines of code overall.
* It streamlines the Editor interface for the users, since they no longer need to manage these little windows.
* It resembles the UI of Unity, so it should be familiar to some users.

I considered doing the same with the control panels for Terrain and Tile Map, but I am less convinced this would be a good idea since these windows are larger. Instead I suggest that future work may allow a docking tile to hold multiple windows with tabs to select the currently visible window. This way these larger control panels can be docked in the same tile as the inspector and the user can tab to the control panel they want to use.