### PR TITLE
Scene Tabs Improvement

### DIFF
--- a/editor/src/scene/container.rs
+++ b/editor/src/scene/container.rs
@@ -524,17 +524,25 @@ impl SceneContainer {
     }
 
     pub fn take_scene(&mut self, id: Uuid) -> Option<EditorSceneEntry> {
+        // Remember the UUID of the current scene, because the index is about to become invalid
+        let current_id = self.current_scene_entry_ref().map(|s| s.id);
         let scene = self
             .entries
             .iter()
             .position(|e| e.id == id)
             .map(|i| self.entries.remove(i));
-        self.current_scene = if self.entries.is_empty() {
-            None
-        } else {
-            // TODO: Maybe set it to the previous one?
-            Some(0)
-        };
+        // Update the current scene index based on the UUID of the current scene.
+        if let Some(current_id) = current_id {
+            if !self.set_current_scene(current_id) {
+                // If the scene could not be set by UUID, then the current scene was taken.
+                self.current_scene = if self.entries.is_empty() {
+                    None
+                } else {
+                    // TODO: Maybe set it to the previous one?
+                    Some(0)
+                };
+            }
+        }
         scene
     }
 }

--- a/fyrox-ui/src/decorator.rs
+++ b/fyrox-ui/src/decorator.rs
@@ -201,7 +201,7 @@ impl Control for Decorator {
                 }
                 DecoratorMessage::HoverBrush(brush) => {
                     self.hover_brush.set_value_and_mark_modified(brush.clone());
-                    if self.is_mouse_directly_over {
+                    if self.has_descendant(ui.picked_node, ui) {
                         ui.send_message(WidgetMessage::background(
                             self.handle(),
                             MessageDirection::ToWidget,
@@ -211,7 +211,7 @@ impl Control for Decorator {
                 }
                 DecoratorMessage::NormalBrush(brush) => {
                     self.normal_brush.set_value_and_mark_modified(brush.clone());
-                    if !*self.is_selected && !self.is_mouse_directly_over {
+                    if !*self.is_selected && !self.has_descendant(ui.picked_node, ui) {
                         ui.send_message(WidgetMessage::background(
                             self.handle(),
                             MessageDirection::ToWidget,

--- a/fyrox-ui/src/tab_control.rs
+++ b/fyrox-ui/src/tab_control.rs
@@ -30,23 +30,24 @@ use crate::{
     brush::Brush,
     button::{ButtonBuilder, ButtonMessage},
     core::{
-        color::Color, pool::Handle, reflect::prelude::*, type_traits::prelude::*, uuid_provider,
-        visitor::prelude::*,
+        algebra::Vector2, color::Color, pool::Handle, reflect::prelude::*, type_traits::prelude::*,
+        uuid_provider, visitor::prelude::*,
     },
     decorator::{DecoratorBuilder, DecoratorMessage},
     define_constructor,
     grid::{Column, GridBuilder, Row},
-    message::{MessageDirection, MouseButton, UiMessage},
-    stack_panel::StackPanelBuilder,
+    message::{ButtonState, MessageDirection, MouseButton, UiMessage},
     utils::make_cross_primitive,
     vector_image::VectorImageBuilder,
     widget::{Widget, WidgetBuilder, WidgetMessage},
+    wrap_panel::WrapPanelBuilder,
     BuildContext, Control, HorizontalAlignment, Orientation, Thickness, UiNode, UserInterface,
     VerticalAlignment,
 };
 
 use fyrox_core::variable::InheritableVariable;
 use fyrox_graph::constructor::{ConstructorProvider, GraphNodeConstructor};
+use fyrox_graph::BaseSceneGraph;
 use std::{
     any::Any,
     cmp::Ordering,
@@ -78,7 +79,12 @@ pub enum TabControlMessage {
     /// Used to remove a particular tab by its UUID.
     RemoveTabByUuid(Uuid),
     /// Adds a new tab using its definition and activates the tab.
-    AddTab(TabDefinition),
+    AddTab {
+        /// The UUID of the newly created tab.
+        uuid: Uuid,
+        /// The specifications for the tab.
+        definition: TabDefinition,
+    },
 }
 
 impl TabControlMessage {
@@ -108,8 +114,27 @@ impl TabControlMessage {
     );
     define_constructor!(
         /// Creates [`TabControlMessage::AddTab`] message.
-        TabControlMessage:AddTab => fn add_tab(TabDefinition), layout: false
+        TabControlMessage:AddTab => fn add_tab_with_uuid(uuid: Uuid, definition: TabDefinition), layout: false
     );
+    /// Creates [`TabControlMessage::AddTab`] message with a random UUID.
+    pub fn add_tab(
+        destination: Handle<UiNode>,
+        direction: MessageDirection,
+        definition: TabDefinition,
+    ) -> UiMessage {
+        UiMessage {
+            handled: std::cell::Cell::new(false),
+            data: Box::new(Self::AddTab {
+                uuid: Uuid::new_v4(),
+                definition,
+            }),
+            destination,
+            direction,
+            routing_strategy: Default::default(),
+            perform_layout: std::cell::Cell::new(false),
+            flags: 0,
+        }
+    }
 }
 
 /// User-defined data of a tab.
@@ -256,6 +281,8 @@ pub struct Tab {
 pub struct TabControl {
     /// Base widget of the tab control.
     pub widget: Widget,
+    /// True if the user permitted to change the order of the tabs.
+    pub is_tab_drag_allowed: bool,
     /// A set of tabs used by the tab control.
     pub tabs: Vec<Tab>,
     /// Active tab of the tab control.
@@ -285,6 +312,46 @@ crate::define_widget_deref!(TabControl);
 uuid_provider!(TabControl = "d54cfac3-0afc-464b-838a-158b3a2253f5");
 
 impl TabControl {
+    fn do_drag(&mut self, position: Vector2<f32>, ui: &mut UserInterface) {
+        let mut dragged_index = None;
+        let mut target_index = None;
+        for (tab_index, tab) in self.tabs.iter().enumerate() {
+            let bounds = ui.node(tab.header_button).screen_bounds();
+            let node_x = bounds.center().x;
+            if bounds.contains(position) {
+                if node_x < position.x {
+                    target_index = Some(tab_index + 1);
+                } else {
+                    target_index = Some(tab_index);
+                }
+            }
+            if ui.is_node_child_of(ui.captured_node, tab.header_button) {
+                dragged_index = Some(tab_index);
+            }
+        }
+        if let (Some(dragged_index), Some(mut target_index)) = (dragged_index, target_index) {
+            if dragged_index < target_index {
+                target_index -= 1;
+            }
+            if target_index != dragged_index {
+                self.finalize_drag(dragged_index, target_index, ui);
+            }
+        }
+    }
+    fn finalize_drag(&mut self, from: usize, to: usize, ui: &mut UserInterface) {
+        let uuid = self.active_tab.map(|i| self.tabs[i].uuid);
+        let tab = self.tabs.remove(from);
+        self.tabs.insert(to, tab);
+        if let Some(uuid) = uuid {
+            self.active_tab = self.tabs.iter().position(|t| t.uuid == uuid);
+        }
+        let new_tab_handles = self.tabs.iter().map(|t| t.header_container).collect();
+        ui.send_message(WidgetMessage::replace_children(
+            self.headers_container,
+            MessageDirection::ToWidget,
+            new_tab_handles,
+        ));
+    }
     /// Use a tab's UUID to look up the tab.
     pub fn get_tab_by_uuid(&self, uuid: Uuid) -> Option<&Tab> {
         self.tabs.iter().find(|t| t.uuid == uuid)
@@ -414,6 +481,13 @@ impl Control for TabControl {
                     }
                 }
             }
+        } else if let Some(WidgetMessage::MouseMove { pos, state }) = message.data() {
+            if state.left == ButtonState::Pressed
+                && self.is_tab_drag_allowed
+                && ui.is_node_child_of(ui.captured_node, self.headers_container)
+            {
+                self.do_drag(*pos, ui);
+            }
         } else if let Some(msg) = message.data::<TabControlMessage>() {
             if message.destination() == self.handle()
                 && message.direction() == MessageDirection::ToWidget
@@ -460,7 +534,7 @@ impl Control for TabControl {
                             }
                         }
                     }
-                    TabControlMessage::AddTab(definition) => {
+                    TabControlMessage::AddTab { uuid, definition } => {
                         let header = Header::build(
                             definition,
                             false,
@@ -483,7 +557,7 @@ impl Control for TabControl {
                         ui.send_message(message.reverse());
 
                         self.tabs.push(Tab {
-                            uuid: Uuid::new_v4(),
+                            uuid: *uuid,
                             header_button: header.button,
                             content: definition.content,
                             close_button: header.close_button,
@@ -504,6 +578,7 @@ impl Control for TabControl {
 /// Tab control builder is used to create [`TabControl`] widget instances and add them to the user interface.
 pub struct TabControlBuilder {
     widget_builder: WidgetBuilder,
+    is_tab_drag_allowed: bool,
     tabs: Vec<TabDefinition>,
     active_tab_brush: Option<StyledProperty<Brush>>,
     initial_tab: usize,
@@ -620,10 +695,17 @@ impl TabControlBuilder {
     pub fn new(widget_builder: WidgetBuilder) -> Self {
         Self {
             tabs: Default::default(),
+            is_tab_drag_allowed: false,
             active_tab_brush: None,
             initial_tab: 0,
             widget_builder,
         }
+    }
+
+    /// Controls whether tabs may be dragged. The default is false.
+    pub fn with_tab_drag(mut self, is_tab_drag_allowed: bool) -> Self {
+        self.is_tab_drag_allowed = is_tab_drag_allowed;
+        self
     }
 
     /// Adds a new tab to the builder.
@@ -666,7 +748,7 @@ impl TabControlBuilder {
             })
             .collect::<Vec<_>>();
 
-        let headers_container = StackPanelBuilder::new(
+        let headers_container = WrapPanelBuilder::new(
             WidgetBuilder::new()
                 .with_children(tab_headers.iter().map(|h| h.button))
                 .on_row(0),
@@ -702,6 +784,7 @@ impl TabControlBuilder {
 
         let tc = TabControl {
             widget: self.widget_builder.with_child(border).build(ctx),
+            is_tab_drag_allowed: self.is_tab_drag_allowed,
             active_tab: if tab_count == 0 {
                 None
             } else {

--- a/fyrox-ui/src/wrap_panel.rs
+++ b/fyrox-ui/src/wrap_panel.rs
@@ -35,6 +35,7 @@ use crate::{
     BuildContext, Control, Orientation, UiNode, UserInterface,
 };
 
+use core::f32;
 use fyrox_core::uuid_provider;
 use fyrox_core::variable::InheritableVariable;
 use fyrox_graph::constructor::{ConstructorProvider, GraphNodeConstructor};
@@ -139,7 +140,7 @@ impl Control for WrapPanel {
         let mut line_size = Vector2::default();
         for child_handle in self.widget.children() {
             let child = ui.node(*child_handle);
-            ui.measure_node(*child_handle, available_size);
+            ui.measure_node(*child_handle, Vector2::new(f32::INFINITY, f32::INFINITY));
             let desired = child.desired_size();
             match *self.orientation {
                 Orientation::Vertical => {


### PR DESCRIPTION
Toward the greater project of allowing more than one window in a dockable tile, I have made some enhancements to TabControl and used those enhancements to improve the editor's scene tabs.

* I made a small but important change to `WrapPanel` that only affects widgets without a fixed size, like tabs. I changed how it measures its children from giving them the size of the panel to giving them infinite size. When a node of variable size is giving a finite space to measure it, it will tend to try to fill that space, and it was causing tabs to grow to the size of the whole control. Giving them infinite size causes the tabs to choose their own most-appropriate size. This does not seem to have broken anything.
* I have changed the `TabControlMessage::AddTab` so that it optionally accepts the UUID of the new tab. I made this optional by manually implementing a second function for creating this message, and generated a random UUID in that function. Allowing the UUID to be specified has eliminated the need for the `SceneViewer` so store the scene UUID as user data. It can instead simply have the tab UUID match the scene UUID, and thereby creates much simplification.
* I have made corrections to `Button`. Prior to this, moving the mouse away from a button before releasing the button would still count as clicking on the button, contrary to broad UI convention. Further, if a button was a child of another button, then clicking on the child would also click on the parent, since both parents and child were receiving the same mouse messages. This is important because a tab may be a button with a child close button. I have made it so that you must release the mouse while the cursor is within the bounds of the button to click it, and buttons ignore mouse releases that have already been handled.
* Mouse capturing creates some subtle difficulties, because capturing the mouse for a particular node prevents the mouse from picking any of the children of that node, and this includes a button's decorator if the button captures the mouse, so when a button captures the mouse the decorator ignores the mouse. At first I tried to solve this by having the decorator capture the mouse, but even this causes problems because this causes the mouse to leave the *text* of the button, which the decorator recieves as a `MouseLeave` message which again deactivates the decorator. My solution was simply to have the current picked node capture the mouse.
* I made it so that the `SceneViewer` no longer assumes that the scene that is being closed is the scene that is currently visible, so that users can seamlessly close any tab without changing the tab they are currently working on.
* I added a method to `TabControlBuilder` to optionally let the user drag the tabs to reorganize them. I considered using Fyrox's drag-and-drop feature for this, but that would have been potentially very complicated, and this solution is very simple. I simply listen `MouseMove` messages with the left button down, then check to see if one of the tabs has captured the mouse and move that tab to wherever the mouse happens to be.
 
Because the `SceneViewer` uses tabs entirely by UUID now, the order of the tabs has no effect upon the `SceneViewer`. It all seems to work quite nicely now.