### PR TITLE
Enhancement to saving and loading scenes in Fyroxed.

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -56,6 +56,7 @@ pub mod utils;
 pub mod world;
 
 pub use fyrox;
+use fyrox::core::make_relative_path;
 
 use crate::{
     asset::{item::AssetItem, AssetBrowser},
@@ -1862,6 +1863,21 @@ impl Editor {
     }
 
     fn save_scene(&mut self, id: Uuid, path: PathBuf) {
+        let path = match make_relative_path(path) {
+            Ok(path) => path,
+            Err(err) => {
+                Log::err(err.to_string());
+                return;
+            }
+        };
+
+        for entry in self.scenes.entries.iter() {
+            if entry.path.as_ref() == Some(&path) {
+                self.close_scene(entry.id);
+                break;
+            }
+        }
+
         self.try_leave_preview_mode();
 
         let engine = &mut self.engine;
@@ -1902,6 +1918,14 @@ impl Editor {
     }
 
     fn load_scene(&mut self, scene_path: PathBuf) {
+        let scene_path = match make_relative_path(scene_path) {
+            Ok(path) => path,
+            Err(err) => {
+                Log::err(err.to_string());
+                return;
+            }
+        };
+
         for entry in self.scenes.entries.iter() {
             if entry.path.as_ref() == Some(&scene_path) {
                 self.set_current_scene(entry.id);

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1863,10 +1863,13 @@ impl Editor {
     }
 
     fn save_scene(&mut self, id: Uuid, path: PathBuf) {
-        let path = match make_relative_path(path) {
+        let path = match make_relative_path(path.clone()) {
             Ok(path) => path,
             Err(err) => {
-                Log::err(err.to_string());
+                Log::err(format!(
+                    "Failed to create relative path for {}. Reason: {err}",
+                    path.display()
+                ));
                 return;
             }
         };

--- a/editor/src/menu/file.rs
+++ b/editor/src/menu/file.rs
@@ -224,6 +224,11 @@ impl FileMenu {
             MessageDirection::ToWidget,
             std::env::current_dir().unwrap(),
         ));
+        ui.send_message(FileSelectorMessage::root(
+            self.save_file_selector,
+            MessageDirection::ToWidget,
+            std::env::current_dir().ok(),
+        ));
     }
 
     pub fn handle_ui_message(

--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -274,7 +274,10 @@ impl GameScene {
         pure_scene.save("Scene", &mut visitor).unwrap();
 
         if let Err(e) = visitor.save_binary(path) {
-            Err(format!("Failed to save scene! Reason: {e}"))
+            Err(format!(
+                "Failed to save scene {}! Reason: {e}",
+                path.display()
+            ))
         } else {
             if settings.debugging.save_scene_in_text_form {
                 let text = visitor.save_text();


### PR DESCRIPTION
I discovered that saving and loading with the file menu in Fyroxed would produce scenes with absolute paths instead of relative paths, and this caused Fyroxed to become confused and allow the same scene to be open twice under different paths. To remedy this situation, I have:

* Called `make_relative_path` before saving and loading scenes.
* Modified `make_relative_path` so that can make relative paths even if the file does not exist, so long as its directory does exist. This was required in order to make saving new files possible.
* If you save a scene and give it the same name an open scene, the scene that previously had that name is automatically closed. It would be nice to warn the user that they are overwriting an existing scene, but that is an enhancement for future work. This merely prevents two scenes with the same path from being open at once.
* I set the root of the file selector when saving scenes. I suppose setting the root was simply forgotten and I have corrected that.