### PR TITLE
Improving error handling for property editors in Fyroxed

### DIFF
--- a/editor/src/plugins/inspector/editors/animation.rs
+++ b/editor/src/plugins/inspector/editors/animation.rs
@@ -80,41 +80,38 @@ where
         ctx: PropertyEditorBuildContext,
     ) -> Result<PropertyEditorInstance, InspectorError> {
         let value = ctx.property_info.cast_value::<Handle<T>>()?;
-        if let Some(environment) = EditorEnvironment::try_get_from(&ctx.environment) {
-            Ok(PropertyEditorInstance::Simple {
-                editor: DropdownListBuilder::new(WidgetBuilder::new())
-                    .with_items(
-                        environment
-                            .available_animations
-                            .iter()
-                            .map(|d| {
-                                make_dropdown_list_option_universal(
-                                    ctx.build_context,
-                                    &d.name,
-                                    22.0,
-                                    *value,
-                                )
-                            })
-                            .collect(),
-                    )
-                    .with_opt_selected(
-                        environment
-                            .available_animations
-                            .iter()
-                            .enumerate()
-                            .find_map(|(i, d)| {
-                                if *value == d.handle.into() {
-                                    Some(i)
-                                } else {
-                                    None
-                                }
-                            }),
-                    )
-                    .build(ctx.build_context),
-            })
-        } else {
-            Err(InspectorError::Custom("No environment!".to_string()))
-        }
+        let environment = EditorEnvironment::try_get_from(&ctx.environment)?;
+        Ok(PropertyEditorInstance::Simple {
+            editor: DropdownListBuilder::new(WidgetBuilder::new())
+                .with_items(
+                    environment
+                        .available_animations
+                        .iter()
+                        .map(|d| {
+                            make_dropdown_list_option_universal(
+                                ctx.build_context,
+                                &d.name,
+                                22.0,
+                                *value,
+                            )
+                        })
+                        .collect(),
+                )
+                .with_opt_selected(
+                    environment
+                        .available_animations
+                        .iter()
+                        .enumerate()
+                        .find_map(|(i, d)| {
+                            if *value == d.handle.into() {
+                                Some(i)
+                            } else {
+                                None
+                            }
+                        }),
+                )
+                .build(ctx.build_context),
+        })
     }
 
     fn create_message(
@@ -122,29 +119,26 @@ where
         ctx: PropertyEditorMessageContext,
     ) -> Result<Option<UiMessage>, InspectorError> {
         let value = ctx.property_info.cast_value::<Handle<T>>()?;
-        if let Some(environment) = EditorEnvironment::try_get_from(&ctx.environment) {
-            if let Some(index) = environment
-                .available_animations
-                .iter()
-                .position(|d| *value == d.handle.into())
-            {
-                Ok(Some(DropdownListMessage::selection(
-                    ctx.instance,
-                    MessageDirection::ToWidget,
-                    Some(index),
-                )))
-            } else {
-                Ok(None)
-            }
+        let environment = EditorEnvironment::try_get_from(&ctx.environment)?;
+        if let Some(index) = environment
+            .available_animations
+            .iter()
+            .position(|d| *value == d.handle.into())
+        {
+            Ok(Some(DropdownListMessage::selection(
+                ctx.instance,
+                MessageDirection::ToWidget,
+                Some(index),
+            )))
         } else {
-            Err(InspectorError::Custom("No environment!".to_string()))
+            Ok(None)
         }
     }
 
     fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
         if ctx.message.direction() == MessageDirection::FromWidget {
             if let Some(DropdownListMessage::SelectionChanged(Some(value))) = ctx.message.data() {
-                if let Some(environment) = EditorEnvironment::try_get_from(&ctx.environment) {
+                if let Ok(environment) = EditorEnvironment::try_get_from(&ctx.environment) {
                     if let Some(definition) = environment.available_animations.get(*value) {
                         return Some(PropertyChanged {
                             name: ctx.name.to_string(),
@@ -206,7 +200,7 @@ where
     fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
         if ctx.message.direction() == MessageDirection::FromWidget {
             if let Some(ButtonMessage::Click) = ctx.message.data() {
-                if let Some(environment) = EditorEnvironment::try_get_from(&ctx.environment) {
+                if let Ok(environment) = EditorEnvironment::try_get_from(&ctx.environment) {
                     environment.sender.send(Message::OpenAnimationEditor);
                 }
             }
@@ -262,7 +256,7 @@ where
     fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
         if ctx.message.direction() == MessageDirection::FromWidget {
             if let Some(ButtonMessage::Click) = ctx.message.data() {
-                if let Some(environment) = EditorEnvironment::try_get_from(&ctx.environment) {
+                if let Ok(environment) = EditorEnvironment::try_get_from(&ctx.environment) {
                     environment.sender.send(Message::OpenAbsmEditor);
                 }
             }

--- a/editor/src/plugins/inspector/editors/resource.rs
+++ b/editor/src/plugins/inspector/editors/resource.rs
@@ -376,20 +376,11 @@ where
         ctx: PropertyEditorBuildContext,
     ) -> Result<PropertyEditorInstance, InspectorError> {
         let value = ctx.property_info.cast_value::<Option<Resource<T>>>()?;
-
+        let environment = EditorEnvironment::try_get_from(&ctx.environment)?;
         Ok(PropertyEditorInstance::Simple {
             editor: ResourceFieldBuilder::new(WidgetBuilder::new(), self.sender.clone())
                 .with_resource(value.clone())
-                .build(
-                    ctx.build_context,
-                    ctx.environment
-                        .as_ref()
-                        .unwrap()
-                        .as_any()
-                        .downcast_ref::<EditorEnvironment>()
-                        .map(|e| e.resource_manager.clone())
-                        .unwrap(),
-                ),
+                .build(ctx.build_context, environment.resource_manager.clone()),
         })
     }
 

--- a/editor/src/plugins/inspector/editors/script.rs
+++ b/editor/src/plugins/inspector/editors/script.rs
@@ -329,23 +329,28 @@ fn selected_script(
 fn fetch_script_definitions(
     instance: Handle<UiNode>,
     ui: &mut UserInterface,
-) -> Option<Vec<Handle<UiNode>>> {
-    let instance_ref = ui
-        .node(instance)
-        .cast::<ScriptPropertyEditor>()
-        .expect("Must be ScriptPropertyEditor!");
+) -> Result<Vec<Handle<UiNode>>, InspectorError> {
+    let instance_ref =
+        ui.node(instance)
+            .cast::<ScriptPropertyEditor>()
+            .ok_or(InspectorError::Custom(
+                "Must be ScriptPropertyEditor!".into(),
+            ))?;
 
     let environment = ui
         .node(instance_ref.inspector)
         .cast::<Inspector>()
-        .expect("Must be Inspector!")
+        .ok_or(InspectorError::Custom("Must be Inspector!".into()))?
         .context()
         .environment
         .clone();
 
-    let editor_environment = EditorEnvironment::try_get_from(&environment);
+    let editor_environment = EditorEnvironment::try_get_from(&environment)?;
 
-    editor_environment.map(|e| create_items(e.serialization_context.clone(), &mut ui.build_ctx()))
+    Ok(create_items(
+        editor_environment.serialization_context.clone(),
+        &mut ui.build_ctx(),
+    ))
 }
 
 #[derive(Debug)]
@@ -361,9 +366,7 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
         ctx: PropertyEditorBuildContext,
     ) -> Result<PropertyEditorInstance, InspectorError> {
         let value = ctx.property_info.cast_value::<Option<Script>>()?;
-
-        let environment = EditorEnvironment::try_get_from(&ctx.environment)
-            .expect("Must have editor environment!");
+        let environment = EditorEnvironment::try_get_from(&ctx.environment)?;
 
         let items = create_items(environment.serialization_context.clone(), ctx.build_context);
 
@@ -432,22 +435,21 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
     ) -> Result<Option<UiMessage>, InspectorError> {
         let value = ctx.property_info.cast_value::<Option<Script>>()?;
 
-        let new_script_definitions_items = fetch_script_definitions(ctx.instance, ctx.ui);
+        let new_script_definitions_items = fetch_script_definitions(ctx.instance, ctx.ui)?;
 
         let instance_ref = ctx
             .ui
             .node(ctx.instance)
             .cast::<ScriptPropertyEditor>()
-            .expect("Must be EnumPropertyEditor!");
+            .ok_or(InspectorError::Custom("Must be EnumPropertyEditor!".into()))?;
 
-        let editor_environment =
-            EditorEnvironment::try_get_from(&ctx.environment).expect("Environment must be set!");
+        let editor_environment = EditorEnvironment::try_get_from(&ctx.environment)?;
 
         let variant_selector_ref = ctx
             .ui
             .node(instance_ref.variant_selector)
             .cast::<DropdownList>()
-            .expect("Must be a DropDownList");
+            .ok_or(InspectorError::Custom("Must be a DropDownList".into()))?;
 
         // Script list might change over time if some plugins were reloaded.
         if variant_selector_ref.items.len()
@@ -458,24 +460,22 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
                 .values()
                 .count()
         {
-            if let Some(items) = new_script_definitions_items {
-                send_sync_message(
-                    ctx.ui,
-                    DropdownListMessage::items(
-                        instance_ref.variant_selector,
-                        MessageDirection::ToWidget,
-                        items,
-                    ),
-                );
-                send_sync_message(
-                    ctx.ui,
-                    ScriptPropertyEditorMessage::value(
-                        ctx.instance,
-                        MessageDirection::ToWidget,
-                        value.as_ref().map(|s| s.id()),
-                    ),
-                );
-            }
+            send_sync_message(
+                ctx.ui,
+                DropdownListMessage::items(
+                    instance_ref.variant_selector,
+                    MessageDirection::ToWidget,
+                    new_script_definitions_items,
+                ),
+            );
+            send_sync_message(
+                ctx.ui,
+                ScriptPropertyEditorMessage::value(
+                    ctx.instance,
+                    MessageDirection::ToWidget,
+                    value.as_ref().map(|s| s.id()),
+                ),
+            );
         }
 
         if instance_ref.selected_script_uuid != value.as_ref().map(|s| s.id())
@@ -548,7 +548,7 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
             if let Some(message) = ctx.message.data::<ScriptPropertyEditorMessage>() {
                 match message {
                     ScriptPropertyEditorMessage::Value(value) => {
-                        if let Some(env) = EditorEnvironment::try_get_from(&ctx.environment) {
+                        if let Ok(env) = EditorEnvironment::try_get_from(&ctx.environment) {
                             let script = value.and_then(|uuid| {
                                 env.serialization_context
                                     .script_constructors

--- a/editor/src/plugins/inspector/editors/surface.rs
+++ b/editor/src/plugins/inspector/editors/surface.rs
@@ -217,19 +217,14 @@ impl PropertyEditorDefinition for SurfaceDataPropertyEditorDefinition {
         ctx: PropertyEditorBuildContext,
     ) -> Result<PropertyEditorInstance, InspectorError> {
         let value = ctx.property_info.cast_value::<SurfaceResource>()?;
+        let environment = EditorEnvironment::try_get_from(&ctx.environment)?;
 
         Ok(PropertyEditorInstance::Simple {
             editor: SurfaceDataPropertyEditor::build(
                 ctx.build_context,
                 value.clone(),
                 self.sender.clone(),
-                ctx.environment
-                    .as_ref()
-                    .unwrap()
-                    .as_any()
-                    .downcast_ref::<EditorEnvironment>()
-                    .map(|e| e.resource_manager.clone())
-                    .unwrap(),
+                environment.resource_manager.clone(),
             ),
         })
     }

--- a/editor/src/plugins/inspector/editors/texture.rs
+++ b/editor/src/plugins/inspector/editors/texture.rs
@@ -208,22 +208,14 @@ impl PropertyEditorDefinition for TexturePropertyEditorDefinition {
         ctx: PropertyEditorBuildContext,
     ) -> Result<PropertyEditorInstance, InspectorError> {
         let value = self.value(ctx.property_info)?;
+        let environment = EditorEnvironment::try_get_from(&ctx.environment)?;
 
         Ok(PropertyEditorInstance::Simple {
             editor: TextureEditorBuilder::new(
                 WidgetBuilder::new().with_min_size(Vector2::new(0.0, 17.0)),
             )
             .with_texture(value.clone())
-            .build(
-                ctx.build_context,
-                ctx.environment
-                    .as_ref()
-                    .unwrap()
-                    .as_any()
-                    .downcast_ref::<EditorEnvironment>()
-                    .map(|e| e.resource_manager.clone())
-                    .unwrap(),
-            ),
+            .build(ctx.build_context, environment.resource_manager.clone()),
         })
     }
 

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -59,7 +59,6 @@ use fyrox::gui::stack_panel::StackPanelBuilder;
 use fyrox::gui::style::resource::StyleResourceExt;
 use fyrox::gui::style::Style;
 use fyrox::gui::utils::make_image_button_with_tooltip;
-use std::any::TypeId;
 use std::{any::Any, sync::Arc};
 
 pub mod editors;

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -59,6 +59,7 @@ use fyrox::gui::stack_panel::StackPanelBuilder;
 use fyrox::gui::style::resource::StyleResourceExt;
 use fyrox::gui::style::Style;
 use fyrox::gui::utils::make_image_button_with_tooltip;
+use std::any::TypeId;
 use std::{any::Any, sync::Arc};
 
 pub mod editors;
@@ -83,19 +84,23 @@ impl EditorEnvironment {
     pub fn try_get_from(
         environment: &Option<Arc<dyn InspectorEnvironment>>,
     ) -> Result<&Self, InspectorError> {
-        let environment = environment.as_ref().ok_or(InspectorError::Custom(
+        let environment = &**environment.as_ref().ok_or(InspectorError::Custom(
             "Missing InspectorEnvironment".into(),
         ))?;
         environment
             .as_any()
             .downcast_ref::<Self>()
-            .ok_or(InspectorError::Custom(
-                "Expected InspectorEnvironment to be EditorEnvironment".into(),
-            ))
+            .ok_or(InspectorError::Custom(format!(
+                "Expected InspectorEnvironment to be EditorEnvironment, found: {}",
+                environment.name(),
+            )))
     }
 }
 
 impl InspectorEnvironment for EditorEnvironment {
+    fn name(&self) -> String {
+        format!("EditorEnvironment:{:?}", self.type_id())
+    }
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -80,10 +80,18 @@ pub struct EditorEnvironment {
 }
 
 impl EditorEnvironment {
-    pub fn try_get_from(environment: &Option<Arc<dyn InspectorEnvironment>>) -> Option<&Self> {
+    pub fn try_get_from(
+        environment: &Option<Arc<dyn InspectorEnvironment>>,
+    ) -> Result<&Self, InspectorError> {
+        let environment = environment.as_ref().ok_or(InspectorError::Custom(
+            "Missing InspectorEnvironment".into(),
+        ))?;
         environment
-            .as_ref()
-            .and_then(|e| e.as_any().downcast_ref::<Self>())
+            .as_any()
+            .downcast_ref::<Self>()
+            .ok_or(InspectorError::Custom(
+                "Expected InspectorEnvironment to be EditorEnvironment".into(),
+            ))
     }
 }
 

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -52,6 +52,7 @@ use crate::{
 };
 use copypasta::ClipboardProvider;
 
+use fyrox_core::log::Log;
 use fyrox_graph::{
     constructor::{ConstructorProvider, GraphNodeConstructor},
     BaseSceneGraph, SceneGraph,
@@ -393,6 +394,7 @@ impl InspectorMessage {
 /// Instead, when a property editor needs to talk to the application using the Inspector,
 /// it can attempt to cast InspectorEnvironment to whatever type it might be.
 pub trait InspectorEnvironment: Any + Send + Sync {
+    fn name(&self) -> String;
     fn as_any(&self) -> &dyn Any;
 }
 
@@ -917,20 +919,25 @@ impl InspectorContext {
 
                             container
                         }
-                        Err(e) => make_simple_property_container(
-                            create_header(ctx, info.display_name, layer_index),
-                            TextBuilder::new(WidgetBuilder::new().on_row(i).on_column(1))
-                                .with_wrap(WrapMode::Word)
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .with_text(format!(
-                                    "Unable to create property \
+                        Err(e) => {
+                            Log::err(format!(
+                                "Unable to create property editor instance: Reason {e:?}"
+                            ));
+                            make_simple_property_container(
+                                create_header(ctx, info.display_name, layer_index),
+                                TextBuilder::new(WidgetBuilder::new().on_row(i).on_column(1))
+                                    .with_wrap(WrapMode::Word)
+                                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                                    .with_text(format!(
+                                        "Unable to create property \
                                                     editor instance: Reason {e:?}"
-                                ))
-                                .build(ctx),
-                            &description,
-                            name_column_width,
-                            ctx,
-                        ),
+                                    ))
+                                    .build(ctx),
+                                &description,
+                                name_column_width,
+                                ctx,
+                            )
+                        }
                     };
 
                     editors.push(editor);


### PR DESCRIPTION
Due to a recent experience where property editors actually failed due to `EditorEnvironment` being unavailable, I discovered that the way that these editors handle that situation could be improved. When a function returns a `Result` there is no need to panic.

I improved `EditorEnvironment::try_get_from` so that it returns `Result<&Self, InspectorError>` instead of `Option<&Self>`, and this change allows `try_get_from` to more elegantly work in implementations of `PropertyEditorDefinition::create_instance`.

This improves error reporting in the event that `EditorEnvironment` ever fails again, and it also simplifies the error handling overall in editors that use `EditorEnvironment`.