### PR TITLE
Prevent clamping for infinite available size in UI layout system

### DIFF
--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -1570,8 +1570,12 @@ impl UserInterface {
 
             size = transform_size(size, &node.layout_transform);
 
-            size.x = size.x.clamp(node.min_size().x, node.max_size().x);
-            size.y = size.y.clamp(node.min_size().y, node.max_size().y);
+            if size.x.is_finite() {
+                size.x = size.x.clamp(node.min_size().x, node.max_size().x);
+            }
+            if size.y.is_finite() {
+                size.y = size.y.clamp(node.min_size().y, node.max_size().y);
+            }
 
             let mut desired_size = node.measure_override(self, size);
 


### PR DESCRIPTION
This simple change makes is to that when a widget is given a maximum size, this does not prevent the widget from being given infinite available size.

When laying out widgets, infinite size is code for asking the widget to choose its own best size. If we instead give the widget a specific size to fill, then widgets that can resize themselves will tend to fill whatever size we give them. This means that if we want to specify that a widget should choose its best size but must not choose a size bigger than some maximum, the only way to do this is by giving it infinite available size and specifying a finite `max_size`. Unfortunately that was impossible due to the available size being automatically clamped in `measure_node`.

As a result, any node which has a maximum size would tend to automatically fill that maximum size. This was especially noticeable with `DropdownList` widgets, where the dropdown list was always 200 tall regardless of content.

With this change, `available_size` remains infinite despite having a finite `max_size`, forcing `DropdownList` to choose its own best size, and only after that choice has been made is the resulting `desired_size` clamped.