### PR TITLE
Removing dependency on `fyrox-core` from `fyrox-autotile`.

### DIFF
--- a/editor/src/plugins/tilemap/autotile.rs
+++ b/editor/src/plugins/tilemap/autotile.rs
@@ -67,10 +67,25 @@ pub struct AutoTileMacro {
     autotiler: TileSetAutoTiler,
 }
 
-#[derive(Default, Debug, Clone, Visit, Reflect)]
+#[derive(Default, Debug, Clone, Reflect)]
 struct CellData {
     terrain_id: TileTerrainId,
+    #[reflect(hidden)]
     fill: ConstraintFillRules,
+}
+
+impl Visit for CellData {
+    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
+        let mut region = visitor.enter_region(name)?;
+        self.terrain_id.visit("TerrainId", &mut region)?;
+        let mut region = region.enter_region("Fill")?;
+        self.fill
+            .include_adjacent
+            .visit("IncludeAdjacent", &mut region)?;
+        self.fill
+            .include_diagonal
+            .visit("IncludeDiagonal", &mut region)
+    }
 }
 
 #[derive(Debug, Default, Clone, Visit, Reflect, TypeUuidProvider)]

--- a/fyrox-autotile/Cargo.toml
+++ b/fyrox-autotile/Cargo.toml
@@ -14,6 +14,6 @@ readme = "README.md"
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE", "/README.md"]
 
 [dependencies]
-fyrox-core = { path = "../fyrox-core", version = "0.36.0" }
+nalgebra = { version = "0.33", features = ["bytemuck"] }
 fxhash = "0.2.1"
 rand = "0.8.5"

--- a/fyrox-autotile/src/auto.rs
+++ b/fyrox-autotile/src/auto.rs
@@ -119,7 +119,7 @@ pub trait PatternSource {
 /// to fit with the new terrain of this cell. This object specifies whether that should
 /// be done. Cells that are added this way keep their current terrain, but their pattern
 /// may change.
-#[derive(Debug, Default, Clone, Copy, Visit, Reflect)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct ConstraintFillRules {
     /// True if adjacent cells should be automatically added to the autotiling constraint
     /// so that they may be modified.

--- a/fyrox-autotile/src/lib.rs
+++ b/fyrox-autotile/src/lib.rs
@@ -37,8 +37,7 @@
 use std::{collections::hash_map::Entry, fmt::Debug, hash::Hash};
 
 use fxhash::FxHashMap;
-use fyrox_core::algebra::{Vector2, Vector3};
-use fyrox_core::{reflect::prelude::*, visitor::prelude::*};
+use nalgebra::{Vector2, Vector3};
 use rand::Rng;
 
 mod auto;


### PR DESCRIPTION
Having `fyrox-autotile` depend upon `fyrox-core` was a very convenient way to get some useful libraries like `nalgebra`, but `fyrox-core` is a very large dependency that contains many things that are completely useless to `fyrox-autotile`. In order to make it simpler to use `fyrox-autotile` in non-Fyrox projects, I have removed the dependency upon `fyrox-core` and made it so that `fyrox-autotile` only includes the bare necessary dependencies.