### PR TITLE
Adjustible warning messages for autotile failures

### DIFF
--- a/editor/src/plugins/tilemap/autotile.rs
+++ b/editor/src/plugins/tilemap/autotile.rs
@@ -635,6 +635,14 @@ impl BrushMacro for AutoTileMacro {
         let tile_set = tile_set.as_deref();
         self.pattern_list.sync(pattern_id, tile_set, ui);
         self.frequency_list.sync(frequency_id, tile_set, ui);
+        send_sync_message(
+            ui,
+            DropdownListMessage::selection(
+                self.failure_log_list,
+                MessageDirection::ToWidget,
+                Some(log_kind_to_index(instance.failure_log_kind)),
+            ),
+        );
     }
 
     fn sync_cell_editors(&mut self, context: &MacroMessageContext, ui: &mut UserInterface) {

--- a/fyrox-core/src/log.rs
+++ b/fyrox-core/src/log.rs
@@ -25,6 +25,7 @@ use crate::instant::Instant;
 use crate::parking_lot::Mutex;
 #[cfg(target_arch = "wasm32")]
 use crate::wasm_bindgen::{self, prelude::*};
+use crate::{reflect::prelude::*, visitor::prelude::*};
 use fxhash::FxHashMap;
 use std::collections::hash_map::Entry;
 use std::fmt::{Debug, Display};
@@ -67,10 +68,11 @@ static LOG: LazyLock<Mutex<Log>> = LazyLock::new(|| {
 });
 
 /// A kind of message.
-#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Ord, Hash)]
+#[derive(Debug, Default, Copy, Clone, PartialOrd, PartialEq, Eq, Ord, Hash, Visit, Reflect)]
 #[repr(u32)]
 pub enum MessageKind {
     /// Some useful information.
+    #[default]
     Information = 0,
     /// A warning.
     Warning = 1,


### PR DESCRIPTION
I recently noticed a failure in the autotiler that had gone unnoticed for much testing because the difference between one tile and another can be quite subtle in autotiling. The source of the problem was in my tileset, not in the algorithm, which means that this sort of problem is bound to happen to many users as they make small errors in setting up their tile sets, which means there is value in giving error messages when the autotiler fails to find a tile for some cell, to alert the user that something is going wrong.

Despite this, it can also be that for some games the autotiler will be deliberately expected to fail because game is using an incomplete tileset and this is considered to be acceptable. In that case it would be wrong to report errors for expected behavior.

I have added a field to the autotile configuration that allows the user to choose the `MessageKind` for reporting autotile failures, ranging from `MessageKind::Error` to no message at all. This involved storing a `MessageKind` in a resource, and to make this easier I have implemented `Reflect`, `Visit`, `Default`, and `Debug` for `MessageKind`.