### PR TITLE
Kinematic Physics Support

### DIFF
--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -879,7 +879,7 @@ impl PhysicsWorld {
     ) {
         if *self.enabled {
             if let Some(native) = self.bodies.get(rigid_body.native.get()) {
-                if native.body_type() == RigidBodyType::Dynamic {
+                if native.body_type() != RigidBodyType::Fixed {
                     let local_transform: Matrix4<f32> = parent_transform
                         .try_inverse()
                         .unwrap_or_else(Matrix4::identity)
@@ -1015,6 +1015,15 @@ impl PhysicsWorld {
                                 native.apply_impulse_at_point(impulse, Point2::from(point), false)
                             }
                             ApplyAction::WakeUp => native.wake_up(true),
+                            ApplyAction::NextTranslation(position) => {
+                                native.set_next_kinematic_translation(position)
+                            }
+                            ApplyAction::NextRotation(rotation) => {
+                                native.set_next_kinematic_rotation(rotation)
+                            }
+                            ApplyAction::NextPosition(position) => {
+                                native.set_next_kinematic_position(position)
+                            }
                         }
                     }
                 }

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -1416,7 +1416,7 @@ impl PhysicsWorld {
     ) {
         if *self.enabled {
             if let Some(native) = self.bodies.get(rigid_body.native.get()) {
-                if native.body_type() == RigidBodyType::Dynamic {
+                if native.body_type() != RigidBodyType::Fixed {
                     let local_transform: Matrix4<f32> = parent_transform
                         .try_inverse()
                         .unwrap_or_else(Matrix4::identity)
@@ -1613,6 +1613,15 @@ impl PhysicsWorld {
                                 native.apply_impulse_at_point(impulse, Point3::from(point), false)
                             }
                             ApplyAction::WakeUp => native.wake_up(true),
+                            ApplyAction::NextTranslation(position) => {
+                                native.set_next_kinematic_translation(position)
+                            }
+                            ApplyAction::NextRotation(rotation) => {
+                                native.set_next_kinematic_rotation(rotation)
+                            }
+                            ApplyAction::NextPosition(position) => {
+                                native.set_next_kinematic_position(position)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I have added actions for setting the next kinematic position in both 2D and 3D.

Rapier has methods specifically for giving the user this sort of control over kinematic rigid bodies, and so I have created `ApplyAction::NextTranslation`, `ApplyAction::NextRotation`, `ApplyAction::NextPosition` to parallel the methods of rapier.

I have also changed the condition in `sync_rigid_body_node` to make it possible to sync kinematic rigid bodies.