### PR TITLE
Adding NewAge to Node to solve teleport glitch

### DIFF
--- a/fyrox-impl/src/scene/collider.rs
+++ b/fyrox-impl/src/scene/collider.rs
@@ -1112,9 +1112,10 @@ mod test {
         let collider_sensor = create_rigid_body(true);
         let collider_non_sensor = create_rigid_body(false);
 
-        // need to call two times for the physics engine to execute
-        graph.update(Vector2::new(800.0, 600.0), 1.0, Default::default());
-        graph.update(Vector2::new(800.0, 600.0), 1.0, Default::default());
+        // need to update twice so the nodes are no longer new, and two times for the physics engine to execute
+        for _ in 0..4 {
+            graph.update(Vector2::new(800.0, 600.0), 1.0, Default::default());
+        }
 
         // we don't expect contact between regular body and sensor
         assert_eq!(

--- a/fyrox-impl/src/scene/dim2/collider.rs
+++ b/fyrox-impl/src/scene/dim2/collider.rs
@@ -833,9 +833,10 @@ mod test {
         let collider_sensor = create_rigid_body(true);
         let collider_non_sensor = create_rigid_body(false);
 
-        // need to call two times for the physics engine to execute
-        graph.update(Vector2::new(800.0, 600.0), 1.0, Default::default());
-        graph.update(Vector2::new(800.0, 600.0), 1.0, Default::default());
+        // need to update twice so the nodes are no longer new, and two times for the physics engine to execute
+        for _ in 0..4 {
+            graph.update(Vector2::new(800.0, 600.0), 1.0, Default::default());
+        }
 
         // we don't expect contact between regular body and sensor
         assert_eq!(

--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -924,7 +924,7 @@ impl PhysicsWorld {
         handle: Handle<Node>,
         rigid_body_node: &scene::dim2::rigidbody::RigidBody,
     ) {
-        if !rigid_body_node.is_globally_enabled() {
+        if !rigid_body_node.is_globally_enabled() || rigid_body_node.is_new() {
             self.remove_body(rigid_body_node.native.get());
             rigid_body_node.native.set(Default::default());
             return;
@@ -1075,7 +1075,7 @@ impl PhysicsWorld {
         handle: Handle<Node>,
         collider_node: &scene::dim2::collider::Collider,
     ) {
-        if !collider_node.is_globally_enabled() {
+        if !collider_node.is_globally_enabled() || collider_node.is_new() {
             self.remove_collider(collider_node.native.get());
             collider_node.native.set(Default::default());
             return;
@@ -1202,7 +1202,7 @@ impl PhysicsWorld {
         handle: Handle<Node>,
         joint: &scene::dim2::joint::Joint,
     ) {
-        if !joint.is_globally_enabled() {
+        if !joint.is_globally_enabled() || joint.is_new() {
             self.remove_joint(joint.native.get());
             joint.native.set(ImpulseJointHandle(Default::default()));
             return;

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -1160,6 +1160,8 @@ impl Graph {
         if let Some((ticket, mut node)) = self.pool.try_take_reserve(handle) {
             let mut is_alive = node.is_alive();
 
+            node.advance_age();
+
             if node.is_globally_enabled() {
                 node.update(&mut UpdateContext {
                     frame_size,
@@ -1750,6 +1752,7 @@ impl BaseSceneGraph for Graph {
         let script_message_sender = self.script_message_sender.clone();
         let message_sender = self.message_sender.clone();
         let node = &mut self.pool[handle];
+        node.set_new(true);
         node.on_connected_to_graph(handle, message_sender, script_message_sender);
 
         self.instance_id_map.insert(node.instance_id, handle);

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -1464,7 +1464,7 @@ impl PhysicsWorld {
         handle: Handle<Node>,
         rigid_body_node: &scene::rigidbody::RigidBody,
     ) {
-        if !rigid_body_node.is_globally_enabled() {
+        if !rigid_body_node.is_globally_enabled() || rigid_body_node.is_new() {
             self.remove_body(rigid_body_node.native.get());
             rigid_body_node.native.set(Default::default());
             return;
@@ -1686,7 +1686,7 @@ impl PhysicsWorld {
         handle: Handle<Node>,
         collider_node: &scene::collider::Collider,
     ) {
-        if !collider_node.is_globally_enabled() {
+        if !collider_node.is_globally_enabled() || collider_node.is_new() {
             self.remove_collider(collider_node.native.get());
             collider_node.native.set(Default::default());
             return;
@@ -1815,7 +1815,7 @@ impl PhysicsWorld {
         handle: Handle<Node>,
         joint: &scene::joint::Joint,
     ) {
-        if !joint.is_globally_enabled() {
+        if !joint.is_globally_enabled() || joint.is_new() {
             self.remove_joint(joint.native.get());
             joint.native.set(ImpulseJointHandle(Default::default()));
             return;

--- a/fyrox-impl/src/scene/node/mod.rs
+++ b/fyrox-impl/src/scene/node/mod.rs
@@ -199,6 +199,10 @@ pub trait NodeTrait: BaseNodeTrait + Reflect + Visit + ComponentProvider {
     /// visible and (optionally) is inside some viewing frustum.
     #[inline]
     fn should_be_rendered(&self, frustum: Option<&Frustum>) -> bool {
+        if self.is_new() {
+            return false;
+        }
+
         if !self.global_visibility() {
             return false;
         }

--- a/fyrox-impl/src/scene/sound/context.rs
+++ b/fyrox-impl/src/scene/sound/context.rs
@@ -179,6 +179,7 @@ impl SoundContext {
         node_overrides: Option<&FxHashSet<Handle<Node>>>,
     ) {
         if !sound.is_globally_enabled()
+            || sound.is_new()
             || !node_overrides.is_none_or(|f| f.contains(&sound_handle))
         {
             self.remove_sound(sound.native.get(), &sound.name);


### PR DESCRIPTION
In regard to [the "teleportation" bug](https://github.com/FyroxEngine/Fyrox/issues/729#issue-2846142773), I think the underlying reason for the problem is a fundamental need for new nodes to not be rendered until the game has had a chance to prepare them, such as by moving them into their desired places and sending messages to them and so on. This means we should delay fully enabling them until *after* the node's scripts have had a chance to run their methods to do their first update and their first message handling.

This is not just about teleportation. It is about spending a frame to make sure that objects settle down into their desired shapes before they become an active part of the game world.

To this end, I have created a `NewAge` enum that keeps track of how long a node has been in the graph. It starts at `NewAge::FirstFrame`, which indicates a node that has just been added. At the end of the frame it advances to `NewAge::SecondFrame` which indicates that a new frame has started with this node already in it. This second frame gives the node a chance to run all its scripts and handle its messages. At the end of the second frame it advances to `NewAge::Old` which means the node is fully enabled so it renders and becomes part of the physics world.

This is *highly experimental.* It seems to work well in my tests, but I recommend that this should be tested in existing games to make sure it does not break anything.