### PR TITLE
Moving plugin and script handling to before node handling

### DIFF
--- a/fyrox-impl/src/engine/mod.rs
+++ b/fyrox-impl/src/engine/mod.rs
@@ -1824,6 +1824,14 @@ impl Engine {
         lag: &mut f32,
         switches: FxHashMap<Handle<Scene>, GraphUpdateSwitches>,
     ) {
+        // Run some plugin and script methods, potentially causing nodes to be added
+        // or removed. This is where most of the rules of the game happen.
+        self.update_plugins(dt, controller, lag);
+        self.handle_scripts(dt);
+
+        // Now that the plugins and scripts have made whatever changes are needed, we must respond
+        // to those changes by updating the scenes and the state of the engine.
+
         self.resource_manager.state().update(dt);
         self.handle_model_events();
 
@@ -1856,9 +1864,6 @@ impl Engine {
                 switches.get(&handle).cloned().unwrap_or_default(),
             );
         }
-
-        self.update_plugins(dt, controller, lag);
-        self.handle_scripts(dt);
     }
 
     /// Performs post update for the engine.


### PR DESCRIPTION
This attempt at fixing [the teleportation bug](https://github.com/FyroxEngine/Fyrox/issues/729#issue-2846142773) is far more elegant and simple, and seems to have no side-effects. We just move the handling of plugins and scripts to *before* the scene update instead of after the scene update.

Scripts and plugins are the part of the game that is most likely to create new nodes, and therefore running them after the update would tend to cause the new nodes to be rendered before the nodes are updated, since the update would not come until the next `AboutToWait` event. This is no longer possible because the scene is updated immediately after the scripts and plugins finish running.