### PR TITLE
Documentation and helper methods for colliders

### DIFF
--- a/fyrox-impl/src/scene/collider.rs
+++ b/fyrox-impl/src/scene/collider.rs
@@ -855,7 +855,22 @@ impl Collider {
     }
 
     /// Returns an iterator that yields contact information for the collider.
-    /// Contacts checks between two regular colliders
+    /// Contacts checks between two non-sensor colliders.
+    /// This includes only cases where two colliders are pressing against each other,
+    /// and only if [`ContactPair::has_any_active_contact`] is true.
+    /// When `has_any_active_contact` is false, the colliders may merely have overlapping
+    /// bounding boxes. See [`Collider::active_contacts`] for an interator that yields
+    /// only pairs where `has_any_active_contact` is true.
+    ///
+    /// When a collider is passing through a sensor collider, that goes into the
+    /// [`Collider::intersects`] list. Those intersections will not be produced by
+    /// this iterator.
+    ///
+    /// Each pair produced by this iterator includes the handles of two colliders,
+    /// this collider and some other collider. There is no guarantee about whether
+    /// this collider will be the first member of the pair or the second,
+    /// but [`ContactPair::other`] can be used to get the handle of the other collider
+    /// given the handle of this collider.
     pub fn contacts<'a>(
         &self,
         physics: &'a PhysicsWorld,
@@ -863,13 +878,59 @@ impl Collider {
         physics.contacts_with(self.native.get())
     }
 
+    /// Returns an iterator that yields contact information for the collider.
+    /// Contacts checks between two non-sensor colliders that are actually touching.
+    /// This includes only cases where two colliders are pressing against each other.
+    /// When a collider is passing through a sensor collider, that goes into the
+    /// [`Collider::intersects`] list.
+    ///
+    /// [`ContactPair::has_any_active_contact`] is guaranteed to be true for every pair
+    /// produced by this iterator.
+    ///
+    /// Each pair produced by this iterator includes the handles of two colliders,
+    /// this collider and some other collider. There is no guarantee about whether
+    /// this collider will be the first member of the pair or the second,
+    /// but [`ContactPair::other`] can be used to get the handle of the other collider
+    /// given the handle of this collider.
+    pub fn active_contacts<'a>(
+        &self,
+        physics: &'a PhysicsWorld,
+    ) -> impl Iterator<Item = ContactPair> + 'a {
+        self.contacts(physics)
+            .filter(|pair| pair.has_any_active_contact)
+    }
+
     /// Returns an iterator that yields intersection information for the collider.
-    /// Intersections checks between regular colliders and sensor colliders
+    /// Intersections checks for colliders passing through each other due to at least
+    /// one of the colliders being a sensor.
+    /// If [`IntersectionPair::has_any_active_contact`] is true, that means the colliders are actually touching.
+    /// When `has_any_active_contact` is false, the colliders may merely have overlapping
+    /// bounding boxes. See [`Collider::active_intersects`] for an interator that yields
+    /// only colliders that actually overlap this collider.
+    ///
+    /// Each pair produced by this iterator includes the handles of two colliders,
+    /// this collider and some other collider. There is no guarantee about whether
+    /// this collider will be the first member of the pair or the second,
+    /// but [`IntersectionPair::other`] can be used to get the handle of the other collider
+    /// given the handle of this collider.
     pub fn intersects<'a>(
         &self,
         physics: &'a PhysicsWorld,
     ) -> impl Iterator<Item = IntersectionPair> + 'a {
         physics.intersections_with(self.native.get())
+    }
+
+    /// Returns an iterator that yields intersection information for the collider.
+    /// Intersections checks for colliders passing through each other due to at least
+    /// one of the colliders being a sensor.
+    pub fn active_intersects<'a>(
+        &self,
+        physics: &'a PhysicsWorld,
+    ) -> impl Iterator<Item = Handle<Node>> + 'a {
+        let self_handle = self.handle();
+        self.intersects(physics)
+            .filter(|pair| pair.has_any_active_contact)
+            .map(move |pair| pair.other(self_handle))
     }
 
     pub(crate) fn needs_sync_model(&self) -> bool {

--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -221,10 +221,25 @@ pub struct ContactPair {
     /// All contact manifold contain themselves contact points between the colliders.
     pub manifolds: Vec<ContactManifold>,
     /// Is there any active contact in this contact pair?
+    /// When false, this pair may just mean that bounding boxes are touching.
     pub has_any_active_contact: bool,
 }
 
 impl ContactPair {
+    /// Given the handle of a collider that is expected to be part of the collision,
+    /// return the other node involved in the collision.
+    /// Often one will have a list of contact pairs for some collider, but that collider
+    /// may be the first member of some pairs and the second member of other pairs.
+    /// This method simplifies determining which objects a collider has collided with.
+    #[inline]
+    pub fn other(&self, subject: Handle<Node>) -> Handle<Node> {
+        if subject == self.collider1 {
+            self.collider2
+        } else {
+            self.collider1
+        }
+    }
+
     fn from_native(c: &rapier2d::geometry::ContactPair, physics: &PhysicsWorld) -> Option<Self> {
         Some(ContactPair {
             collider1: Handle::decode_from_u128(physics.colliders.get(c.collider1)?.user_data),
@@ -276,7 +291,24 @@ pub struct IntersectionPair {
     /// The second collider involved in the contact pair.
     pub collider2: Handle<Node>,
     /// Is there any active contact in this contact pair?
+    /// When false, this pair may just mean that bounding boxes are touching.
     pub has_any_active_contact: bool,
+}
+
+impl IntersectionPair {
+    /// Given the handle of a collider that is expected to be part of the collision,
+    /// return the other node involved in the collision.
+    /// Often one will have a list of contact pairs for some collider, but that collider
+    /// may be the first member of some pairs and the second member of other pairs.
+    /// This method simplifies determining which objects a collider has collided with.
+    #[inline]
+    pub fn other(&self, subject: Handle<Node>) -> Handle<Node> {
+        if subject == self.collider1 {
+            self.collider2
+        } else {
+            self.collider1
+        }
+    }
 }
 
 pub(super) struct Container<S, A>

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -346,6 +346,20 @@ pub struct ContactPair {
 }
 
 impl ContactPair {
+    /// Given the handle of a collider that is expected to be part of the collision,
+    /// return the other node involved in the collision.
+    /// Often one will have a list of contact pairs for some collider, but that collider
+    /// may be the first member of some pairs and the second member of other pairs.
+    /// This method simplifies determining which objects a collider has collided with.
+    #[inline]
+    pub fn other(&self, subject: Handle<Node>) -> Handle<Node> {
+        if subject == self.collider1 {
+            self.collider2
+        } else {
+            self.collider1
+        }
+    }
+
     fn from_native(c: &rapier3d::geometry::ContactPair, physics: &PhysicsWorld) -> Option<Self> {
         Some(ContactPair {
             collider1: Handle::decode_from_u128(physics.colliders.get(c.collider1)?.user_data),
@@ -397,7 +411,24 @@ pub struct IntersectionPair {
     /// The second collider involved in the contact pair.
     pub collider2: Handle<Node>,
     /// Is there any active contact in this contact pair?
+    /// When false, this pair may just mean that bounding boxes are touching.
     pub has_any_active_contact: bool,
+}
+
+impl IntersectionPair {
+    /// Given the handle of a collider that is expected to be part of the collision,
+    /// return the other node involved in the collision.
+    /// Often one will have a list of contact pairs for some collider, but that collider
+    /// may be the first member of some pairs and the second member of other pairs.
+    /// This method simplifies determining which objects a collider has collided with.
+    #[inline]
+    pub fn other(&self, subject: Handle<Node>) -> Handle<Node> {
+        if subject == self.collider1 {
+            self.collider2
+        } else {
+            self.collider1
+        }
+    }
 }
 
 pub(super) struct Container<S, A>


### PR DESCRIPTION
I have attempted to simplify and clarify the usage of colliders with the addition of more extensive documentation comments and additional helper methods. The `active_contacts` and `active_intersects` methods are similar to `contacts` and `intersects` except that they skip pairs where `has_any_active_contacts` is false. `active_intersects` has the additional simplification of just directly returning the intersecting colliders instead of returning pairs.

No change in this PR should have any effect upon existing games. It is purely the addition of more methods and documentation.