### PR TITLE
Fixing potential panic in `patch_error_message`

### DIFF
--- a/fyrox-graphics/src/gl/program.rs
+++ b/fyrox-graphics/src/gl/program.rs
@@ -101,11 +101,20 @@ impl Vendor {
     }
 }
 
+/// A version of Regex::find_at that does not panic.
+fn find_at<'a>(re: &regex::Regex, src: &'a str, offset: usize) -> Option<regex::Match<'a>> {
+    if offset > src.len() {
+        None
+    } else {
+        re.find_at(src, offset)
+    }
+}
+
 fn patch_error_message(vendor: Vendor, src: &mut String, line_offset: isize) {
     let re = vendor.regex();
     let mut offset = 0;
-    while let Some(result) = re.find_at(src, offset) {
-        offset += result.end();
+    while let Some(result) = find_at(&re, src, offset) {
+        offset = result.end().max(offset + 1);
         let range = vendor.line_number_range(result);
         let substr = &src[range];
         if let Ok(line_number) = substr.parse::<isize>() {


### PR DESCRIPTION
I discovered a bug in `patch_error_message` that caused it to use an incorrect offset, and I have attempted to make `patch_error_message` more defensive to hopefully eliminate the possibility of any other problems.

The correct offset for the next search is the end of the previous result, not the start of the previous search *plus* the end of the previous result. In principle, for some regexes, the end of the result could be the same as the current offset, if the regex matched a zero-length result, so I ensured that the offset steps ahead by at least one.