### PR TITLE
Protecting against resource deadlock

### DIFF
--- a/fyrox-impl/src/scene/mod.rs
+++ b/fyrox-impl/src/scene/mod.rs
@@ -370,11 +370,13 @@ impl SceneLoader {
             let exclusion_list = used_resources
                 .iter()
                 .filter(|res| {
+                    // Calling resource_uuid means locking the header.
+                    // To minimize the number of locks we hold at once, get the UUID first,
+                    // before we lock the resource manager and registry.
+                    let uuid = res.resource_uuid();
                     let state = self.resource_manager.state();
                     let registry = state.resource_registry.lock();
-                    res.resource_uuid()
-                        .and_then(|uuid| registry.uuid_to_path(uuid))
-                        == Some(&path)
+                    uuid.and_then(|uuid| registry.uuid_to_path(uuid)) == Some(&path)
                 })
                 .cloned()
                 .collect::<Vec<_>>();

--- a/fyrox-resource/src/manager.rs
+++ b/fyrox-resource/src/manager.rs
@@ -713,7 +713,13 @@ impl ResourceManagerState {
                     Ok(data) => {
                         let data = data.0;
 
-                        match registry.lock().path_to_uuid(&path) {
+                        // Creating this p variable causes the lock to be dropped
+                        // before the match. If we put the expression directly into the
+                        // match, then it would not be dropped until after, which would mean
+                        // holding the registry lock while we resource header, which can cause
+                        // a deadlock.
+                        let p = registry.lock().path_to_uuid(&path);
+                        match p {
                             Some(resource_uuid) => {
                                 let mut mutex_guard = resource.0.lock();
 


### PR DESCRIPTION
I used the [tracing-mutex](https://crates.io/crates/tracing-mutex) crate to temporarily tool the mutexes and discover potential sources of deadlock. I have not included tracing-mutex in this PR since tracing-mutex has performance costs, but I have included the modifications that I made in order to stop tracing-mutex from detecting any problems. Hopefully this will eliminate the deadlocking issue.