### PR TITLE
Fixing cut-off text in tooltips

### DIFF
--- a/fyrox-ui/src/utils.rs
+++ b/fyrox-ui/src/utils.rs
@@ -152,7 +152,7 @@ pub fn make_simple_tooltip(ctx: &mut BuildContext, text: &str) -> RcUiNodeHandle
             .with_hit_test_visibility(false)
             .with_foreground(ctx.style.property(Style::BRUSH_DARKEST))
             .with_background(Brush::Solid(Color::opaque(230, 230, 230)).into())
-            .with_max_size(Vector2::new(300.0, f32::INFINITY))
+            .with_width(300.0)
             .with_child(
                 TextBuilder::new(
                     WidgetBuilder::new()


### PR DESCRIPTION
A fundamental limitation in the way that widgets are measured is that very limited information may be passed in through `available_size`, and this does not capture all the nuances of what we may want from a widget. A widget has no way of knowing its maximum size, its minimum size, whether it should try to fill a given space or whether it should decide its own best size, because all this information cannot be conveyed in a `f32`

Setting the max size of the width of a tool tip currently does not pass any measurement information to the widgets that are being constrained, which means that the widgets are left to choose their own sizes and only afterward are the widgets forced to be within max size. This means that a `Text` widget that is given a max width will not wrap its content, but will instead choose a width to fit its text without wrapping and then the unwrapped text will be cut-off when its width is constrained to be within the max size.

The only way to force text to wrap is to constrain the width of the widget to an exact number such as with `with_width`.

Obviously the ideal situation would be for the `Text` widget to wrap if the text exceeds 300 in width, but otherwise for the widget to shrink itself to just the width that is necessary to contain the unwrapped text. Unfortunately there is no way to tell the widget to do that using the limited parameters of the `override_measure` method. The best we can do is have the widget be fixed to a width of 300 regardless of the text.