### PR TITLE
Using a `BitMask` to control which nodes are visible to each camera

### DIFF
--- a/editor/src/highlight.rs
+++ b/editor/src/highlight.rs
@@ -140,6 +140,7 @@ impl SceneRenderPass for HighlightRenderPass {
 
             let frustum = ctx.camera.frustum();
             let mut render_context = RenderContext {
+                render_mask: *ctx.camera.render_mask,
                 elapsed_time: ctx.elapsed_time,
                 observer_info: &observer_info,
                 frustum: Some(&frustum),

--- a/editor/src/plugins/inspector/editors/mod.rs
+++ b/editor/src/plugins/inspector/editors/mod.rs
@@ -459,6 +459,7 @@ pub fn make_property_editors_container(
     container.insert(ScriptPropertyEditorDefinition {});
 
     container.insert(BitFieldPropertyEditorDefinition::<BitMask>::new());
+    container.insert(InheritablePropertyEditorDefinition::<BitMask>::new());
 
     container.register_inheritable_inspectable::<BallShape>();
     container.register_inheritable_inspectable::<dim2::collider::BallShape>();

--- a/fyrox-impl/src/renderer/light.rs
+++ b/fyrox-impl/src/renderer/light.rs
@@ -634,6 +634,7 @@ impl DeferredLightRenderer {
                         pass_stats += self.spot_shadow_map_renderer.render(
                             server,
                             &scene.graph,
+                            *camera.render_mask,
                             elapsed_time,
                             light.position,
                             light_view_matrix,
@@ -655,6 +656,7 @@ impl DeferredLightRenderer {
                         pass_stats +=
                             self.point_shadow_map_renderer
                                 .render(PointShadowMapRenderContext {
+                                    render_mask: *camera.render_mask,
                                     elapsed_time,
                                     state: server,
                                     graph: &scene.graph,

--- a/fyrox-impl/src/renderer/mod.rs
+++ b/fyrox-impl/src/renderer/mod.rs
@@ -1476,6 +1476,7 @@ impl Renderer {
 
             let bundle_storage = RenderDataBundleStorage::from_graph(
                 graph,
+                *camera.render_mask,
                 elapsed_time,
                 ObserverInfo {
                     observer_position: camera.global_position(),

--- a/fyrox-impl/src/renderer/shadow/csm.rs
+++ b/fyrox-impl/src/renderer/shadow/csm.rs
@@ -252,6 +252,7 @@ impl CsmRenderer {
 
             let bundle_storage = RenderDataBundleStorage::from_graph(
                 graph,
+                *camera.render_mask,
                 elapsed_time,
                 ObserverInfo {
                     observer_position,

--- a/fyrox-impl/src/renderer/shadow/point.rs
+++ b/fyrox-impl/src/renderer/shadow/point.rs
@@ -32,16 +32,17 @@ use crate::{
         cache::{shader::ShaderCache, texture::TextureCache, uniform::UniformMemoryAllocator},
         framework::{
             error::FrameworkError,
-            framebuffer::{Attachment, AttachmentKind},
-            gpu_texture::{CubeMapFace, GpuTextureDescriptor, GpuTextureKind, PixelKind},
+            framebuffer::{Attachment, AttachmentKind, GpuFrameBuffer},
+            gpu_texture::{
+                CubeMapFace, GpuTexture, GpuTextureDescriptor, GpuTextureKind, PixelKind,
+            },
             server::GraphicsServer,
         },
-        framework::{framebuffer::GpuFrameBuffer, gpu_texture::GpuTexture},
         shadow::cascade_size,
         DynamicSurfaceCache, FallbackResources, GeometryCache, RenderPassStatistics,
         ShadowMapPrecision, POINT_SHADOW_PASS_NAME,
     },
-    scene::graph::Graph,
+    scene::{collider::BitMask, graph::Graph},
 };
 
 pub struct PointShadowMapRenderer {
@@ -58,6 +59,7 @@ struct PointShadowCubeMapFace {
 }
 
 pub(crate) struct PointShadowMapRenderContext<'a> {
+    pub render_mask: BitMask,
     pub elapsed_time: f32,
     pub state: &'a dyn GraphicsServer,
     pub graph: &'a Graph,
@@ -178,6 +180,7 @@ impl PointShadowMapRenderer {
             elapsed_time,
             state,
             graph,
+            render_mask,
             light_pos,
             light_radius,
             geom_cache,
@@ -212,6 +215,7 @@ impl PointShadowMapRenderer {
 
             let bundle_storage = RenderDataBundleStorage::from_graph(
                 graph,
+                render_mask,
                 elapsed_time,
                 ObserverInfo {
                     observer_position: light_pos,

--- a/fyrox-impl/src/renderer/shadow/spot.rs
+++ b/fyrox-impl/src/renderer/shadow/spot.rs
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 use crate::renderer::DynamicSurfaceCache;
+use crate::scene::collider::BitMask;
 use crate::{
     core::{
         algebra::{Matrix4, Vector3},
@@ -117,6 +118,7 @@ impl SpotShadowMapRenderer {
         &mut self,
         server: &dyn GraphicsServer,
         graph: &Graph,
+        render_mask: BitMask,
         elapsed_time: f32,
         light_position: Vector3<f32>,
         light_view_matrix: Matrix4<f32>,
@@ -142,6 +144,7 @@ impl SpotShadowMapRenderer {
 
         let bundle_storage = RenderDataBundleStorage::from_graph(
             graph,
+            render_mask,
             elapsed_time,
             ObserverInfo {
                 observer_position: light_position,

--- a/fyrox-impl/src/scene/base.rs
+++ b/fyrox-impl/src/scene/base.rs
@@ -51,6 +51,8 @@ use std::{
 };
 use strum_macros::{AsRefStr, EnumString, VariantNames};
 
+use super::collider::BitMask;
+
 /// Level of detail is a collection of objects for given normalized distance range.
 /// Objects will be rendered **only** if they're in specified range.
 /// Normalized distance is a distance in (0; 1) range where 0 - closest to camera,
@@ -462,6 +464,14 @@ pub struct Base {
 
     #[reflect(deref)]
     enabled: TrackedProperty<InheritableVariable<bool>>,
+
+    /// Control whether this node should be rendered. A node should be rendered only if its render mask shares
+    /// some set bits in common with the render mask of the camera.
+    #[reflect(
+        description = "Control whether this node should be rendered. A node should be rendered only if its render mask shares\
+        some set bits in common with the render mask of the camera."
+    )]
+    pub render_mask: InheritableVariable<BitMask>,
 
     #[reflect(
         description = "Maximum amount of Some(time) that node will \"live\" or None if the node has unlimited lifetime."
@@ -1207,6 +1217,7 @@ impl Visit for Base {
         let _ = self.cast_shadows.visit("CastShadows", &mut region);
         let _ = self.instance_id.visit("InstanceId", &mut region);
         let _ = self.enabled.visit("Enabled", &mut region);
+        let _ = self.render_mask.visit("RenderMask", &mut region);
 
         // Script visiting may fail for various reasons:
         //
@@ -1406,6 +1417,7 @@ impl BaseBuilder {
                 self.enabled.into(),
                 NodeMessageKind::EnabledFlagChanged,
             ),
+            render_mask: BitMask::all().into(),
             global_visibility: Cell::new(true),
             parent: Handle::NONE,
             global_transform: Cell::new(Matrix4::identity()),

--- a/fyrox-impl/src/scene/dim2/rectangle.rs
+++ b/fyrox-impl/src/scene/dim2/rectangle.rs
@@ -23,7 +23,6 @@
 //!
 //! See [`Rectangle`] docs for more info.
 
-use crate::scene::collider::BitMask;
 use crate::scene::node::constructor::NodeConstructor;
 use crate::{
     core::{
@@ -307,11 +306,7 @@ impl NodeTrait for Rectangle {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
-        if *self.render_mask & ctx.render_mask == BitMask::none() {
-            return RdcControlFlow::Continue;
-        }
-
-        if !self.should_be_rendered(ctx.frustum) {
+        if !self.should_be_rendered(ctx.frustum, ctx.render_mask) {
             return RdcControlFlow::Continue;
         }
 

--- a/fyrox-impl/src/scene/dim2/rectangle.rs
+++ b/fyrox-impl/src/scene/dim2/rectangle.rs
@@ -23,6 +23,7 @@
 //!
 //! See [`Rectangle`] docs for more info.
 
+use crate::scene::collider::BitMask;
 use crate::scene::node::constructor::NodeConstructor;
 use crate::{
     core::{
@@ -306,6 +307,10 @@ impl NodeTrait for Rectangle {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
+        if *self.render_mask & ctx.render_mask == BitMask::none() {
+            return RdcControlFlow::Continue;
+        }
+
         if !self.should_be_rendered(ctx.frustum) {
             return RdcControlFlow::Continue;
         }

--- a/fyrox-impl/src/scene/mesh/mod.rs
+++ b/fyrox-impl/src/scene/mesh/mod.rs
@@ -72,6 +72,8 @@ use std::{
 };
 use strum_macros::{AsRefStr, EnumString, VariantNames};
 
+use super::collider::BitMask;
+
 pub mod buffer;
 pub mod surface;
 pub mod vertex;
@@ -178,6 +180,7 @@ impl BatchContainer {
             }
 
             descendant.collect_render_data(&mut RenderContext {
+                render_mask: ctx.render_mask,
                 elapsed_time: ctx.elapsed_time,
                 observer_info: ctx.observer_info,
                 frustum: None,
@@ -664,6 +667,10 @@ impl NodeTrait for Mesh {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
+        if *self.render_mask & ctx.render_mask == BitMask::none() {
+            return RdcControlFlow::Continue;
+        }
+
         if !self.should_be_rendered(ctx.frustum) {
             return RdcControlFlow::Continue;
         }

--- a/fyrox-impl/src/scene/mesh/mod.rs
+++ b/fyrox-impl/src/scene/mesh/mod.rs
@@ -72,8 +72,6 @@ use std::{
 };
 use strum_macros::{AsRefStr, EnumString, VariantNames};
 
-use super::collider::BitMask;
-
 pub mod buffer;
 pub mod surface;
 pub mod vertex;
@@ -667,11 +665,7 @@ impl NodeTrait for Mesh {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
-        if *self.render_mask & ctx.render_mask == BitMask::none() {
-            return RdcControlFlow::Continue;
-        }
-
-        if !self.should_be_rendered(ctx.frustum) {
+        if !self.should_be_rendered(ctx.frustum, ctx.render_mask) {
             return RdcControlFlow::Continue;
         }
 

--- a/fyrox-impl/src/scene/node/mod.rs
+++ b/fyrox-impl/src/scene/node/mod.rs
@@ -68,6 +68,8 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use super::collider::BitMask;
+
 pub mod constructor;
 pub mod container;
 
@@ -198,7 +200,11 @@ pub trait NodeTrait: BaseNodeTrait + Reflect + Visit + ComponentProvider {
     /// Checks if the node should be rendered or not. A node should be rendered if it is enabled,
     /// visible and (optionally) is inside some viewing frustum.
     #[inline]
-    fn should_be_rendered(&self, frustum: Option<&Frustum>) -> bool {
+    fn should_be_rendered(&self, frustum: Option<&Frustum>, render_mask: BitMask) -> bool {
+        if *self.render_mask & render_mask == BitMask::none() {
+            return false;
+        }
+
         if !self.global_visibility() {
             return false;
         }

--- a/fyrox-impl/src/scene/particle_system/mod.rs
+++ b/fyrox-impl/src/scene/particle_system/mod.rs
@@ -62,8 +62,6 @@ use std::{
 };
 use strum_macros::{AsRefStr, EnumString, VariantNames};
 
-use super::collider::BitMask;
-
 pub(crate) mod draw;
 pub mod emitter;
 pub mod particle;
@@ -589,11 +587,7 @@ impl NodeTrait for ParticleSystem {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
-        if *self.render_mask & ctx.render_mask == BitMask::none() {
-            return RdcControlFlow::Continue;
-        }
-
-        if !self.should_be_rendered(ctx.frustum)
+        if !self.should_be_rendered(ctx.frustum, ctx.render_mask)
             || self.is_distance_clipped(&ctx.observer_info.observer_position)
         {
             return RdcControlFlow::Continue;

--- a/fyrox-impl/src/scene/particle_system/mod.rs
+++ b/fyrox-impl/src/scene/particle_system/mod.rs
@@ -62,6 +62,8 @@ use std::{
 };
 use strum_macros::{AsRefStr, EnumString, VariantNames};
 
+use super::collider::BitMask;
+
 pub(crate) mod draw;
 pub mod emitter;
 pub mod particle;
@@ -587,6 +589,10 @@ impl NodeTrait for ParticleSystem {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
+        if *self.render_mask & ctx.render_mask == BitMask::none() {
+            return RdcControlFlow::Continue;
+        }
+
         if !self.should_be_rendered(ctx.frustum)
             || self.is_distance_clipped(&ctx.observer_info.observer_position)
         {

--- a/fyrox-impl/src/scene/sprite.rs
+++ b/fyrox-impl/src/scene/sprite.rs
@@ -22,7 +22,6 @@
 //!
 //! For more info see [`Sprite`].
 
-use crate::scene::collider::BitMask;
 use crate::scene::node::constructor::NodeConstructor;
 use crate::scene::node::RdcControlFlow;
 use crate::{
@@ -320,11 +319,7 @@ impl NodeTrait for Sprite {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
-        if *self.render_mask & ctx.render_mask == BitMask::none() {
-            return RdcControlFlow::Continue;
-        }
-
-        if !self.should_be_rendered(ctx.frustum) {
+        if !self.should_be_rendered(ctx.frustum, ctx.render_mask) {
             return RdcControlFlow::Continue;
         }
 

--- a/fyrox-impl/src/scene/sprite.rs
+++ b/fyrox-impl/src/scene/sprite.rs
@@ -22,6 +22,7 @@
 //!
 //! For more info see [`Sprite`].
 
+use crate::scene::collider::BitMask;
 use crate::scene::node::constructor::NodeConstructor;
 use crate::scene::node::RdcControlFlow;
 use crate::{
@@ -233,7 +234,7 @@ impl TypeUuidProvider for Sprite {
 
 impl Sprite {
     /// Sets new size of sprite. Since sprite is always square, size defines half of width or height, so actual size
-    /// will be doubled. Default value is 0.2.    
+    /// will be doubled. Default value is 0.2.
     ///
     /// Negative values could be used to "inverse" the image on the sprite.
     pub fn set_size(&mut self, size: f32) -> f32 {
@@ -319,6 +320,10 @@ impl NodeTrait for Sprite {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
+        if *self.render_mask & ctx.render_mask == BitMask::none() {
+            return RdcControlFlow::Continue;
+        }
+
         if !self.should_be_rendered(ctx.frustum) {
             return RdcControlFlow::Continue;
         }

--- a/fyrox-impl/src/scene/terrain/mod.rs
+++ b/fyrox-impl/src/scene/terrain/mod.rs
@@ -81,6 +81,8 @@ pub use brushstroke::*;
 use fyrox_core::visitor::pod::PodVecView;
 use fyrox_graph::constructor::ConstructorProvider;
 
+use super::collider::BitMask;
+
 /// Current implementation version marker.
 pub const VERSION: u8 = 2;
 
@@ -2618,6 +2620,10 @@ impl NodeTrait for Terrain {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
+        if *self.render_mask & ctx.render_mask == BitMask::none() {
+            return RdcControlFlow::Continue;
+        }
+
         if !self.global_visibility()
             || !self.is_globally_enabled()
             || (self.frustum_culling()

--- a/fyrox-impl/src/scene/tilemap/mod.rs
+++ b/fyrox-impl/src/scene/tilemap/mod.rs
@@ -50,9 +50,7 @@ use tileset::*;
 pub use transform::*;
 pub use update::*;
 
-use super::{
-    collider::BitMask, dim2::rectangle::RectangleVertex, node::constructor::NodeConstructor,
-};
+use super::{dim2::rectangle::RectangleVertex, node::constructor::NodeConstructor};
 use crate::lazy_static::*;
 use crate::{
     asset::{untyped::ResourceKind, ResourceDataRef},
@@ -1408,11 +1406,7 @@ impl NodeTrait for TileMap {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
-        if *self.render_mask & ctx.render_mask == BitMask::none() {
-            return RdcControlFlow::Continue;
-        }
-
-        if !self.should_be_rendered(ctx.frustum) {
+        if !self.should_be_rendered(ctx.frustum, ctx.render_mask) {
             return RdcControlFlow::Continue;
         }
 

--- a/fyrox-impl/src/scene/tilemap/mod.rs
+++ b/fyrox-impl/src/scene/tilemap/mod.rs
@@ -50,7 +50,9 @@ use tileset::*;
 pub use transform::*;
 pub use update::*;
 
-use super::{dim2::rectangle::RectangleVertex, node::constructor::NodeConstructor};
+use super::{
+    collider::BitMask, dim2::rectangle::RectangleVertex, node::constructor::NodeConstructor,
+};
 use crate::lazy_static::*;
 use crate::{
     asset::{untyped::ResourceKind, ResourceDataRef},
@@ -1406,6 +1408,10 @@ impl NodeTrait for TileMap {
     }
 
     fn collect_render_data(&self, ctx: &mut RenderContext) -> RdcControlFlow {
+        if *self.render_mask & ctx.render_mask == BitMask::none() {
+            return RdcControlFlow::Continue;
+        }
+
         if !self.should_be_rendered(ctx.frustum) {
             return RdcControlFlow::Continue;
         }


### PR DESCRIPTION
By giving each node a `BitMask` called `render_mask` we can provide fine control over whether a camera renders a particular node by doing a bitwise-and on the `render_mask` of the node and the camera. If the two masks have any set bits in common, then the camera will render the node as normal, but if the bitwise-and results in zero, then the node is treated as invisible.

`BitMask` is part of the collision system, since it is defined in `collider.rs`, but it can be useful for purposes like this beyond just collision. I have added some helper methods to make `BitMask` easier to use.

I have only tested this in 2D since the game that I am working on is a 2D game, but whether a game is 2D or 3D should make no difference to how `render_mask` works. So long as `render_mask` has all bits set, which is the default, this change should have no effect at all upon existing games.