### PR TITLE
Project manager Open IDE settings improvements

### DIFF
--- a/project-manager/src/settings.rs
+++ b/project-manager/src/settings.rs
@@ -51,6 +51,7 @@ use std::{
 };
 
 pub const MANIFEST_PATH_VAR: &str = "%MANIFEST_PATH%";
+pub const MANIFEST_DIR_VAR: &str = "%MANIFEST_DIR%";
 
 pub static PROJECT_DIRS: LazyLock<Option<ProjectDirs>> =
     LazyLock::new(|| ProjectDirs::from("", "Fyrox", "Fyrox Project Manager"));
@@ -94,7 +95,7 @@ pub struct SettingsData {
     #[serde(default = "default_open_ide_command")]
     #[reflect(
         description = "Defines a command to run an IDE in a project folder. This command \
-    should use %MANIFEST_PATH% built-in variable to provide the selected project path to the \
+    should use either %MANIFEST_PATH% or %MANIFEST_DIR% built-in variable to provide the selected project path to the \
     chosen IDE."
     )]
     pub open_ide_command: CommandDescriptor,


### PR DESCRIPTION
For some IDEs (like VSCode-based editors), it is better to open the project's folder rather than just the manifest file. With these changes, I allow the usage of `%MANIFEST_DIR%` for that.

Additionally, I've improved code that replaces argument variables so that it replaces them even if the argument includes extra text besides the variable name. i.e.: if there is an argument with value "test-%MANIFEST_PATH%" currently the `%MANIFEST_PATH%` wouldn't be replaced because it requires the whole string to be equal to the variable's name, but with my changes it would actually be replaced, thus making the variables work in a more generic way.