### PR TITLE
Fixed crash when CSM near and far values are superimposed

### DIFF
--- a/fyrox-impl/Cargo.toml
+++ b/fyrox-impl/Cargo.toml
@@ -48,6 +48,7 @@ lightmap = "0.2"
 libloading = "0.8.1"
 gltf = { version = "1.4.0", default-features = false, features = ["names", "utils", "extras"] }
 bytemuck = { version = "1.16.1", features = ["derive"] }
+approx = "0.5.1"
 
 # These dependencies aren't used by the engine, but it is necessary to prevent cargo from rebuilding
 # the engine lib on different packages. This is especially important for hot reloading feature.

--- a/fyrox-impl/src/renderer/shadow/csm.rs
+++ b/fyrox-impl/src/renderer/shadow/csm.rs
@@ -48,6 +48,7 @@ use crate::{
         light::directional::{FrustumSplitOptions, CSM_NUM_CASCADES},
     },
 };
+use approx::relative_eq;
 use fyrox_graphics::framebuffer::GpuFrameBuffer;
 use fyrox_graphics::gpu_texture::GpuTexture;
 
@@ -194,8 +195,11 @@ impl CsmRenderer {
             let z_near = z_values[i];
             let mut z_far = z_values[i + 1];
 
-            if z_far.eq(&z_near) {
-                z_far += 10.0 * f32::EPSILON;
+            // Prevents z_near and z_far from being relatively equal, which would result in an invalid perspective matrix.
+            if relative_eq!(z_far, z_near) {
+                // Needs to be at least greater than f32::EPSILON to break the relative equality.
+                const MIN_DEPTH_DELTA: f32 = f32::EPSILON * 2.0;
+                z_far += MIN_DEPTH_DELTA * z_near;
             }
 
             let projection_matrix = camera


### PR DESCRIPTION
## Description
Fixed a crash when CSM near and far values are superimposed.
This happened because the `z_far` value sanitation was using absolute instead of relative equality check. This PR changes the equality to be relative, and also changes the way `z_far` is adjusted from absolute to relative (based on `z_near` value).

Also added a dependency to `approx` in `fyrox-impl`, enabling the use of `approx::relative_eq`.

## Review Guidance
Tested on Windows 11 (no project):
```bash
cargo run --package=fyroxed
```

## Screenshots
![image](https://github.com/user-attachments/assets/bf2c0984-f712-4c18-b179-759a6d535dce)
_The CSM far planes values can now be anything you want them to be!_

## Related Issues
Fixes #788 