### PR TITLE
Fixed crash when an empty string is used in the asset browser search

### DIFF
--- a/editor/src/asset/mod.rs
+++ b/editor/src/asset/mod.rs
@@ -1134,7 +1134,14 @@ impl AssetBrowser {
                 && message.direction() == MessageDirection::FromWidget
             {
                 if search_text.is_empty() {
-                    let path = self.selected_item_path.parent().unwrap().to_path_buf();
+                    let path = if self.selected_item_path != PathBuf::default() {
+                        self.selected_item_path
+                            .parent()
+                            .map(|p| p.to_path_buf())
+                            .unwrap_or_else(|| PathBuf::from("./"))
+                    } else {
+                        PathBuf::from("./")
+                    };
                     self.item_to_select = Some(self.selected_item_path.clone());
                     self.set_path(&path, ui, &engine.resource_manager, &sender);
                 } else {


### PR DESCRIPTION
## Description
Fixed a crash when the asset browser uses an empty string as a search query.

## Review Guidance
The issue was that when `self.selected_item_path` was empty (`== PathBuf::default()`), calling `parent()` would fail.

Tested on Windows 11 (no project):
```bash
cargo run --package=fyroxed
```

## Related Issues
Fixes #790 

## Screenshots
https://github.com/user-attachments/assets/67580912-04fb-4731-a619-09a42225eb88

