### PR TITLE
Fixed crash when an invalid asset is drag-dropped onto a surface field

### DIFF
--- a/editor/src/plugins/inspector/editors/surface.rs
+++ b/editor/src/plugins/inspector/editors/surface.rs
@@ -108,14 +108,16 @@ impl Control for SurfaceDataPropertyEditor {
                     };
 
                     if let Ok(path) = path {
-                        if let Ok(value) =
-                            block_on(self.resource_manager.request::<SurfaceData>(path))
+                        if let Some(request) =
+                            self.resource_manager.try_request::<SurfaceData>(path)
                         {
-                            ui.send_message(SurfaceDataPropertyEditorMessage::value(
-                                self.handle(),
-                                MessageDirection::ToWidget,
-                                value,
-                            ));
+                            if let Ok(value) = block_on(request) {
+                                ui.send_message(SurfaceDataPropertyEditorMessage::value(
+                                    self.handle(),
+                                    MessageDirection::ToWidget,
+                                    value,
+                                ));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Fixed crash when an invalid asset is drag and dropped onto a a field expecting a path to a `SurfaceData` resource.

Changed:
```rust
self.resource_manager.request::<SurfaceData>(path)
```
to
```rust
self.resource_manager.try_request::<SurfaceData>(path)
```

## Review Guidance
Tested on Windows 11 (fyrox_test project):

## Related Issues
Fixes #792 

## Screenshots
https://github.com/user-attachments/assets/2e909be3-1f34-4d2b-afb5-a60680b5933f
_No more crash 🥳_



