### PR TITLE
Improved focus distance to be less close to the object

### DIFF
--- a/editor/src/camera/mod.rs
+++ b/editor/src/camera/mod.rs
@@ -241,7 +241,7 @@ impl CameraController {
         world_space_position
     }
 
-    pub fn fit_object(&mut self, scene: &mut Scene, handle: Handle<Node>) {
+    pub fn fit_object(&mut self, scene: &mut Scene, handle: Handle<Node>, scale: Option<f32>) {
         // Combine AABBs from the descendants.
         let mut aabb = AxisAlignedBoundingBox::default();
         for (_, descendant) in scene.graph.traverse_iter(handle) {
@@ -254,6 +254,10 @@ impl CameraController {
         if aabb.is_invalid_or_degenerate() {
             // To prevent the camera from flying away into abyss.
             aabb = AxisAlignedBoundingBox::from_point(scene.graph[handle].global_position());
+        }
+
+        if scale.is_some() {
+            aabb = aabb.transform(&Matrix4::identity().scale(scale.unwrap()));
         }
 
         let fit_parameters = scene.graph[self.camera].as_camera().fit(

--- a/editor/src/camera/mod.rs
+++ b/editor/src/camera/mod.rs
@@ -256,8 +256,8 @@ impl CameraController {
             aabb = AxisAlignedBoundingBox::from_point(scene.graph[handle].global_position());
         }
 
-        if scale.is_some() {
-            aabb = aabb.transform(&Matrix4::identity().scale(scale.unwrap()));
+        if let Some(scale) = scale {
+            aabb = aabb.transform(&Matrix4::identity().scale(scale));
         }
 
         let fit_parameters = scene.graph[self.camera].as_camera().fit(

--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -990,7 +990,7 @@ impl SceneController for GameScene {
             }
             Message::FocusObject(handle) => {
                 let scene = &mut engine.scenes[self.scene];
-                self.camera_controller.fit_object(scene, *handle);
+                self.camera_controller.fit_object(scene, *handle, Some(2.0));
                 false
             }
             Message::SyncNodeHandleName { view, handle } => {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Improved editor camera focus distance to be less close to the object, effectively allowing the user to view the object they chose to focus.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
_N/A_

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
This is what focusing looks like before and after the change
| Before Change | After Change |
| - | - |
| ![image](https://github.com/user-attachments/assets/4c46f18b-45a5-4aaa-a85e-765a4ffba405) | ![image](https://github.com/user-attachments/assets/fbbd6ac7-b5e5-4fb0-a348-1ecf5bc60111) |
| Way too close to the object to see anything (even closer than z_near) | Slightly further away |

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
