### PR TITLE
Prevented the camera frustum in debug draw from being scaled

### DIFF
--- a/fyrox-impl/src/scene/camera.rs
+++ b/fyrox-impl/src/scene/camera.rs
@@ -770,7 +770,7 @@ impl NodeTrait for Camera {
     }
 
     fn debug_draw(&self, ctx: &mut SceneDrawingContext) {
-        let transform = self.global_transform.get();
+        let transform = self.global_transform_without_scaling();
         ctx.draw_pyramid(
             self.frustum().center(),
             self.frustum().right_top_front_corner(),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Updated `Camera.debug_draw` to ignore the node's scale when drawing its frustum, as scaling a camera node shouldn't affect the frustum.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
_N/A_

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
_N/A_

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
