### PR TITLE
Improved gizmo and exposed scale in editor settings

### DIFF
--- a/editor/src/interaction/gizmo/move_gizmo.rs
+++ b/editor/src/interaction/gizmo/move_gizmo.rs
@@ -87,6 +87,9 @@ fn make_move_axis(
     color: Color,
     name_prefix: &str,
 ) -> (Handle<Node>, Handle<Node>) {
+    const ARROW_LENGTH: f32 = 0.5;
+    const ARROW_THICKNESS: f32 = 0.015;
+
     let arrow;
     let axis = MeshBuilder::new(
         BaseBuilder::new()
@@ -98,7 +101,7 @@ fn make_move_axis(
                         .with_name(name_prefix.to_owned() + "Arrow")
                         .with_local_transform(
                             TransformBuilder::new()
-                                .with_local_position(Vector3::new(0.0, 1.0, 0.0))
+                                .with_local_position(Vector3::new(0.0, ARROW_LENGTH, 0.0))
                                 .build(),
                         ),
                 )
@@ -120,7 +123,13 @@ fn make_move_axis(
     )
     .with_render_path(RenderPath::Forward)
     .with_surfaces(vec![SurfaceBuilder::new(SurfaceResource::new_embedded(
-        SurfaceData::make_cylinder(10, 0.015, 1.0, true, &Matrix4::identity()),
+        SurfaceData::make_cylinder(
+            10,
+            ARROW_THICKNESS,
+            ARROW_LENGTH,
+            true,
+            &Matrix4::identity(),
+        ),
     ))
     .with_material(make_color_material(color))
     .build()])

--- a/editor/src/interaction/gizmo/rotate_gizmo.rs
+++ b/editor/src/interaction/gizmo/rotate_gizmo.rs
@@ -63,6 +63,8 @@ fn make_rotation_ribbon(
     color: Color,
     name: &str,
 ) -> Handle<Node> {
+    const RIBBON_THICKNESS: f32 = 0.015;
+
     MeshBuilder::new(
         BaseBuilder::new()
             .with_cast_shadows(false)
@@ -75,7 +77,7 @@ fn make_rotation_ribbon(
     )
     .with_render_path(RenderPath::Forward)
     .with_surfaces(vec![SurfaceBuilder::new(SurfaceResource::new_embedded(
-        SurfaceData::make_torus(0.5, 0.025, 16, 32, &Matrix4::identity()),
+        SurfaceData::make_torus(0.5, RIBBON_THICKNESS, 16, 32, &Matrix4::identity()),
     ))
     .with_material(make_color_material(color))
     .build()])

--- a/editor/src/interaction/gizmo/scale_gizmo.rs
+++ b/editor/src/interaction/gizmo/scale_gizmo.rs
@@ -67,6 +67,9 @@ fn make_scale_axis(
     color: Color,
     name_prefix: &str,
 ) -> (Handle<Node>, Handle<Node>) {
+    const ARROW_LENGTH: f32 = 0.5;
+    const ARROW_THICKNESS: f32 = 0.015;
+
     let arrow;
     let axis = MeshBuilder::new(
         BaseBuilder::new()
@@ -78,7 +81,7 @@ fn make_scale_axis(
                         .with_name(name_prefix.to_owned() + "Arrow")
                         .with_local_transform(
                             TransformBuilder::new()
-                                .with_local_position(Vector3::new(0.0, 1.0, 0.0))
+                                .with_local_position(Vector3::new(0.0, ARROW_LENGTH, 0.0))
                                 .build(),
                         ),
                 )
@@ -102,7 +105,13 @@ fn make_scale_axis(
     )
     .with_render_path(RenderPath::Forward)
     .with_surfaces(vec![SurfaceBuilder::new(SurfaceResource::new_embedded(
-        SurfaceData::make_cylinder(10, 0.015, 1.0, true, &Matrix4::identity()),
+        SurfaceData::make_cylinder(
+            10,
+            ARROW_THICKNESS,
+            ARROW_LENGTH,
+            true,
+            &Matrix4::identity(),
+        ),
     ))
     .with_material(make_color_material(color))
     .build()])

--- a/editor/src/interaction/move_mode.rs
+++ b/editor/src/interaction/move_mode.rs
@@ -498,7 +498,7 @@ impl InteractionMode for MoveInteractionMode {
                 graph,
                 game_scene.camera_controller.camera,
                 self.move_gizmo.origin,
-            );
+            ) * _settings.graphics.gizmo_scale;
             self.move_gizmo.set_visible(graph, true);
             self.move_gizmo
                 .sync_transform(scene, editor_selection, scale);

--- a/editor/src/interaction/rotate_mode.rs
+++ b/editor/src/interaction/rotate_mode.rs
@@ -281,7 +281,7 @@ impl InteractionMode for RotateInteractionMode {
                     graph,
                     game_scene.camera_controller.camera,
                     self.rotation_gizmo.origin,
-                );
+                ) * _settings.graphics.gizmo_scale;
                 self.rotation_gizmo.sync_transform(graph, selection, scale);
                 self.rotation_gizmo.set_visible(graph, true);
             }

--- a/editor/src/interaction/scale_mode.rs
+++ b/editor/src/interaction/scale_mode.rs
@@ -258,7 +258,7 @@ impl InteractionMode for ScaleInteractionMode {
                     graph,
                     game_scene.camera_controller.camera,
                     self.scale_gizmo.origin,
-                );
+                ) * _settings.graphics.gizmo_scale;
                 self.scale_gizmo.sync_transform(graph, selection, scale);
                 self.scale_gizmo.set_visible(graph, true);
             }

--- a/editor/src/settings/graphics.rs
+++ b/editor/src/settings/graphics.rs
@@ -28,6 +28,7 @@ pub struct GraphicsSettings {
     pub z_far: f32,
     #[serde(default = "default_draw_grid")]
     pub draw_grid: bool,
+    pub gizmo_scale: f32,
 }
 
 fn default_draw_grid() -> bool {
@@ -41,6 +42,7 @@ impl Default for GraphicsSettings {
             z_near: 0.025,
             z_far: 128.0,
             draw_grid: default_draw_grid(),
+            gizmo_scale: 1.0,
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Improved gizmos by tweaking:
- Arrow length (for move and scale)
- Arrow thickness (for move and scale)
- Ribbon thickness (for rotate)

Thickness has been made consistent across the board (move, rotate, and scale now use the same thickness).

Exposed gizmo scale to the editor settings (under graphics)

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Moved magic numbers (arrow length, thickness, and ribbon thickness) to proper `const` values to document them naturally by naming them.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
| Action | Before | After |
| - | - | - |
| Move | ![image](https://github.com/user-attachments/assets/5c1c4623-a293-4391-949c-fb7f5b788d1c) | ![image](https://github.com/user-attachments/assets/521e87a6-429e-4437-b123-0732f2869285) |
| Rotate | ![image](https://github.com/user-attachments/assets/3fd77cde-d686-4e66-9e58-0411eeb60e3f) | ![image](https://github.com/user-attachments/assets/33e9bc90-17b0-4786-839a-a0d93f3abb19) |
| Scale | ![image](https://github.com/user-attachments/assets/946636c7-f14c-455e-8f11-814f01dabd78) | ![image](https://github.com/user-attachments/assets/de3aa1bb-f61e-4613-bf68-5709b46ff5e7) |

**Gizmo Scale:**

https://github.com/user-attachments/assets/938a99a6-7582-4932-b445-b074a8db20f3



## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
