### PR TITLE
Fixed disfunctional node focus following its latest improvement

### DIFF
--- a/editor/src/camera/mod.rs
+++ b/editor/src/camera/mod.rs
@@ -257,7 +257,7 @@ impl CameraController {
         }
 
         if let Some(scale) = scale {
-            aabb = aabb.transform(&Matrix4::identity().scale(scale));
+            aabb.scale(scale);
         }
 
         let fit_parameters = scene.graph[self.camera].as_camera().fit(

--- a/fyrox-math/src/aabb.rs
+++ b/fyrox-math/src/aabb.rs
@@ -112,6 +112,13 @@ impl AxisAlignedBoundingBox {
     }
 
     #[inline]
+    pub fn scale(&mut self, scale: f32) {
+        let center = self.center();
+        self.min = (self.min - center) * scale + center;
+        self.max = (self.max - center) * scale + center;
+    }
+
+    #[inline]
     pub fn add_box(&mut self, other: Self) {
         self.add_point(other.min);
         self.add_point(other.max);


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Following https://github.com/FyroxEngine/Fyrox/pull/795, focusing an object is broken when the object isn't positioned at origin. This is because applying a scale matrix to an AABB not position at the world origin `(0, 0, 0)` changes the center of the `AABB`. 

To avoid that, a proper `scale` function has been added to `AxisAlignedBoundingBox`, to effectively scale the AABB **around** its center, instead of scaling it around the world origin.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
_N/A_

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/22ab46e8-2878-4943-af45-99d69444231f



## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
