### PR TITLE
Small test fix for calculate_sorting_index

### DIFF
--- a/fyrox-impl/src/renderer/bundle.rs
+++ b/fyrox-impl/src/renderer/bundle.rs
@@ -1234,17 +1234,17 @@ mod test {
 
         assert_eq!(
             render_context.calculate_sorting_index(Vector3::new(0.0, 0.0, 1.0)),
-            center - 1000
+            center + 1000
         );
 
         assert_eq!(
             render_context.calculate_sorting_index(Vector3::new(0.0, 0.0, 2.0)),
-            center - 2000
+            center + 2000
         );
 
         assert_eq!(
             render_context.calculate_sorting_index(Vector3::new(0.0, 0.0, -3.0)),
-            center + 3000
+            center - 3000
         );
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
This simply fixes an incorrect expectation in the tests. Here is the example of the tests failing: https://github.com/FyroxEngine/Fyrox/actions/runs/14782543715/job/41504440447

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [ ] My code follows the project's code style guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes don't generate new warnings or errors
- [ ] No unsafe code introduced (or if introduced, thoroughly justified and documented)
