### PR TITLE
Fixed interaction mode order in the toolbar to follow indices: 1..6

### DIFF
--- a/editor/src/scene/container.rs
+++ b/editor/src/scene/container.rs
@@ -92,12 +92,12 @@ impl EditorSceneEntry {
             engine,
             message_sender.clone(),
         ));
-        interaction_modes.add(ScaleInteractionMode::new(
+        interaction_modes.add(RotateInteractionMode::new(
             &game_scene,
             engine,
             message_sender.clone(),
         ));
-        interaction_modes.add(RotateInteractionMode::new(
+        interaction_modes.add(ScaleInteractionMode::new(
             &game_scene,
             engine,
             message_sender.clone(),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Interaction modes in the toolbar were displayed in this order:
  * Select [1]
  * Move [2]
  * Scale [4]
  * Rotate [3]
  * Edit Navmesh [5]
  * Edit Terrain [6]
* "Rotate" (Key `[3]`) and "Scale" (Key `[4]`) interaction modes are now ordered properly.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
![image](https://github.com/user-attachments/assets/d1afe221-e17c-448c-8187-82f3cf0eeee7)
_New order_

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
