### PR TITLE
Fixed terrain holes incorrect command name

### DIFF
--- a/editor/src/scene/commands/terrain.rs
+++ b/editor/src/scene/commands/terrain.rs
@@ -189,7 +189,7 @@ impl ModifyTerrainHolesCommand {
 
 impl CommandTrait for ModifyTerrainHolesCommand {
     fn name(&mut self, _context: &dyn CommandContext) -> String {
-        "Modify Terrain Height".to_owned()
+        "Modify Terrain Holes".to_owned()
     }
 
     fn execute(&mut self, context: &mut dyn CommandContext) {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
`ModifyTerrainHolesCommand::name()` was set to return `Modify Terrain Height` instead of `Modify Terrain Holes`. This PR fixes that incorrect name.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
![image](https://github.com/user-attachments/assets/d4ad8143-9770-44af-b681-c6b6ef8b8ee2)

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
