### PR TITLE
Added missing interaction modes shortcuts for terrain and navmesh

### DIFF
--- a/editor/src/interaction/navmesh/mod.rs
+++ b/editor/src/interaction/navmesh/mod.rs
@@ -680,7 +680,7 @@ impl InteractionMode for EditNavmeshMode {
 
     fn make_button(&mut self, ctx: &mut BuildContext, selected: bool) -> Handle<UiNode> {
         let navmesh_mode_tooltip =
-            "Edit Navmesh\n\nNavmesh edit mode allows you to modify selected \
+            "Edit Navmesh - Shortcut: [5]\n\nNavmesh edit mode allows you to modify selected \
         navigational mesh.";
 
         make_interaction_mode_button(

--- a/editor/src/interaction/terrain.rs
+++ b/editor/src/interaction/terrain.rs
@@ -543,7 +543,7 @@ impl InteractionMode for TerrainInteractionMode {
 
     fn make_button(&mut self, ctx: &mut BuildContext, selected: bool) -> Handle<UiNode> {
         let terrain_mode_tooltip =
-            "Edit Terrain\n\nTerrain edit mode allows you to modify selected \
+            "Edit Terrain - Shortcut: [6]\n\nTerrain edit mode allows you to modify selected \
         terrain.";
 
         make_interaction_mode_button(


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
The interaction modes to edit terrain and navmesh didn't display any shortcut info. This PR adds shortcut info for these 2 interaction modes.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

![image](https://github.com/user-attachments/assets/b51fb7f2-1b44-4b5d-894a-c640606a142b)

![image](https://github.com/user-attachments/assets/96930d06-de23-4ae4-8379-14deb596dd49)


## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
