### PR TITLE
Introducing runs to FormattedText

### DIFF
--- a/fyrox-ui/src/formatted_text/run.rs
+++ b/fyrox-ui/src/formatted_text/run.rs
@@ -1,0 +1,253 @@
+// Copyright (c) 2019-present Dmitry Stepanov and Fyrox Engine contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use std::ops::{Deref, DerefMut};
+
+use crate::font::FontHeight;
+
+use super::*;
+
+#[derive(Clone, PartialEq, Debug, Default, Reflect)]
+pub struct RunSet(Vec<Run>);
+
+impl From<&[Run]> for RunSet {
+    fn from(value: &[Run]) -> Self {
+        Self(value.to_vec())
+    }
+}
+
+impl From<Vec<Run>> for RunSet {
+    fn from(value: Vec<Run>) -> Self {
+        Self(value)
+    }
+}
+
+impl Visit for RunSet {
+    fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
+        self.0.visit(name, visitor)
+    }
+}
+
+impl Deref for RunSet {
+    type Target = Vec<Run>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for RunSet {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl RunSet {
+    pub fn font_at(&self, index: usize) -> Option<FontResource> {
+        for run in self.0.iter().rev() {
+            if run.range.contains(&(index as u32)) && run.font().is_some() {
+                return Some(run.font().unwrap().clone());
+            }
+        }
+        None
+    }
+    pub fn font_size_at(&self, index: usize) -> Option<f32> {
+        for run in self.0.iter().rev() {
+            if run.range.contains(&(index as u32)) && run.font_size().is_some() {
+                return Some(run.font_size().unwrap());
+            }
+        }
+        None
+    }
+    pub fn brush_at(&self, index: usize) -> Option<Brush> {
+        for run in self.0.iter().rev() {
+            if run.range.contains(&(index as u32)) && run.brush().is_some() {
+                return Some(run.brush().unwrap().clone());
+            }
+        }
+        None
+    }
+    pub fn shadow_at(&self, index: usize) -> Option<bool> {
+        for run in self.0.iter().rev() {
+            if run.range.contains(&(index as u32)) && run.shadow().is_some() {
+                return Some(run.shadow().unwrap());
+            }
+        }
+        None
+    }
+    pub fn shadow_brush_at(&self, index: usize) -> Option<Brush> {
+        for run in self.0.iter().rev() {
+            if run.range.contains(&(index as u32)) && run.shadow_brush().is_some() {
+                return Some(run.shadow_brush().unwrap().clone());
+            }
+        }
+        None
+    }
+    pub fn shadow_dilation_at(&self, index: usize) -> Option<f32> {
+        for run in self.0.iter().rev() {
+            if run.range.contains(&(index as u32)) && run.shadow_dilation().is_some() {
+                return Some(run.shadow_dilation().unwrap());
+            }
+        }
+        None
+    }
+    pub fn shadow_offset_at(&self, index: usize) -> Option<Vector2<f32>> {
+        for run in self.0.iter().rev() {
+            if run.range.contains(&(index as u32)) && run.shadow_offset().is_some() {
+                return Some(run.shadow_offset().unwrap());
+            }
+        }
+        None
+    }
+}
+
+/// The style of a partion of text within a range.
+#[derive(Clone, PartialEq, Debug, Default, Visit, Reflect)]
+pub struct Run {
+    /// The range of characters that this run applies to within the text.
+    pub range: Range<u32>,
+    font: Option<FontResource>,
+    brush: Option<Brush>,
+    font_size: Option<f32>,
+    shadow: Option<bool>,
+    shadow_brush: Option<Brush>,
+    shadow_dilation: Option<f32>,
+    shadow_offset: Option<Vector2<f32>>,
+}
+
+impl Run {
+    /// The font of the characters in this run, or None if the font is unmodified.
+    pub fn font(&self) -> Option<&FontResource> {
+        self.font.as_ref()
+    }
+    /// The brush of the characters in this run, or None if the brush is unmodified.
+    pub fn brush(&self) -> Option<&Brush> {
+        self.brush.as_ref()
+    }
+    /// The size of the characters in this run, or None if the size is unmodified.
+    pub fn font_size(&self) -> Option<f32> {
+        self.font_size
+    }
+    /// True if the characters in this run should have a shadow. None if this run does not change
+    /// whether the characters are shadowed.
+    pub fn shadow(&self) -> Option<bool> {
+        self.shadow
+    }
+    /// The brush for the shadow of the characters in this run, or None if the brush is unmodified.
+    pub fn shadow_brush(&self) -> Option<&Brush> {
+        self.shadow_brush.as_ref()
+    }
+    /// The dilation for the shadow in this run, or None if the dilation is unmodified.
+    pub fn shadow_dilation(&self) -> Option<f32> {
+        self.shadow_dilation
+    }
+    /// The offset for the shadow in this run, or None if the offset is unmodified.
+    pub fn shadow_offset(&self) -> Option<Vector2<f32>> {
+        self.shadow_offset
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub enum DrawValueLayer {
+    Main,
+    Shadow,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct GlyphDrawValues {
+    pub atlas_page_index: usize,
+    pub font: FontResource,
+    pub brush: Brush,
+    /// Font size scaled by super sampling scaling to pick correct atlas page.
+    pub height: FontHeight,
+}
+
+pub struct RunBuilder {
+    range: Range<u32>,
+    font: Option<FontResource>,
+    brush: Option<Brush>,
+    font_size: Option<f32>,
+    shadow: Option<bool>,
+    shadow_brush: Option<Brush>,
+    shadow_dilation: Option<f32>,
+    shadow_offset: Option<Vector2<f32>>,
+}
+
+impl RunBuilder {
+    pub fn new(range: Range<u32>) -> Self {
+        Self {
+            range,
+            font: None,
+            brush: None,
+            font_size: None,
+            shadow: None,
+            shadow_brush: None,
+            shadow_dilation: None,
+            shadow_offset: None,
+        }
+    }
+    pub fn build(self) -> Run {
+        Run {
+            range: self.range,
+            font: self.font,
+            brush: self.brush,
+            font_size: self.font_size,
+            shadow: self.shadow,
+            shadow_brush: self.shadow_brush,
+            shadow_dilation: self.shadow_dilation,
+            shadow_offset: self.shadow_offset,
+        }
+    }
+    /// Set this run to modify the font of the text within the range.
+    pub fn with_font(mut self, font: FontResource) -> Self {
+        self.font = Some(font);
+        self
+    }
+    /// Set this run to modify the brush of the text within the range.
+    pub fn with_brush(mut self, brush: Brush) -> Self {
+        self.brush = Some(brush);
+        self
+    }
+    /// Set this run to modify the size of the text within the range.
+    pub fn with_size(mut self, size: f32) -> Self {
+        self.font_size = Some(size);
+        self
+    }
+    /// Set this run to enable or disable the shadow of the text within the range.
+    pub fn with_shadow(mut self, shadow: bool) -> Self {
+        self.shadow = Some(shadow);
+        self
+    }
+    /// Set this run to modify the brush of the shadow within the range.
+    pub fn with_shadow_brush(mut self, brush: Brush) -> Self {
+        self.shadow_brush = Some(brush);
+        self
+    }
+    /// Set this run to modify the dilation of the shadow within the range.
+    pub fn with_shadow_dilation(mut self, size: f32) -> Self {
+        self.shadow_dilation = Some(size);
+        self
+    }
+    /// Set this run to modify the offset of the shadow within the range.
+    pub fn with_shadow_offset(mut self, offset: Vector2<f32>) -> Self {
+        self.shadow_offset = Some(offset);
+        self
+    }
+}

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -23,6 +23,7 @@
 
 #![warn(missing_docs)]
 
+use crate::formatted_text::Run;
 use crate::style::StyledProperty;
 use crate::{
     brush::Brush,
@@ -502,6 +503,7 @@ pub struct TextBuilder {
     shadow_dilation: f32,
     shadow_offset: Vector2<f32>,
     font_size: Option<StyledProperty<f32>>,
+    runs: Vec<Run>,
 }
 
 impl TextBuilder {
@@ -519,6 +521,7 @@ impl TextBuilder {
             shadow_dilation: 1.0,
             shadow_offset: Vector2::new(1.0, 1.0),
             font_size: None,
+            runs: Vec::default(),
         }
     }
 
@@ -589,6 +592,22 @@ impl TextBuilder {
         self
     }
 
+    /// Adds the given run to the text to set the style for a portion of the text.
+    /// Later runs potentially overriding earlier runs if the ranges of the runs overlap and the later run
+    /// sets a property that conflicts with an earlier run.
+    pub fn with_run(mut self, run: Run) -> Self {
+        self.runs.push(run);
+        self
+    }
+
+    /// Adds multiple runs to the text to set the style of portions of the text.
+    /// Later runs potentially overriding earlier runs if the ranges of the runs overlap and the later run
+    /// sets a property that conflicts with an earlier run.
+    pub fn with_runs<I: IntoIterator<Item = Run>>(mut self, runs: I) -> Self {
+        self.runs.extend(runs);
+        self
+    }
+
     /// Finishes text widget creation and registers it in the user interface, returning its handle to you.
     pub fn build(mut self, ctx: &mut BuildContext) -> Handle<UiNode> {
         let font = if let Some(font) = self.font {
@@ -617,6 +636,7 @@ impl TextBuilder {
                         self.font_size
                             .unwrap_or_else(|| ctx.style.property(Style::FONT_SIZE)),
                     )
+                    .with_runs(self.runs)
                     .build(),
             ),
         };


### PR DESCRIPTION
## Description
A `formatted_text::Run` struct and `RunBuilder` have been added into `fyrox-ui` that represents a style modification to a range of chars within some formatted text. Each run may optionally modify:
* Font
* Brush
* Size
* Shadow enabled/disabled
* Shadow brush
* Shadow offset
* Shadow dilation

Each `FormattedText` now contains a `RunSet` which is a vector of runs. Later runs in the vector are given priority over earlier runs, if two runs conflict.

Added methods: `FormattedTextBuilder::with_run`, `FormattedTextBuilder::with_runs`, `TextBuilder::with_run`, `TextBuilder::with_runs`. The `with_run` method takes a single run and adds it to the end of the list. The `with_runs` method extends the list with runs from the given iterator.

### Not yet implemented:
* A markup parser to automatically generate runs.
* Messages to modify runs in already constructed text.

## Related Issue(s)
Progress is made toward issue #138. All that remains should be creating a markup parser and integrating it into `Text`.

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
