### PR TITLE
(breaking change) blanket impl for ScriptMessagePayload replaced with derive macro

### DIFF
--- a/fyrox-core-derive/src/lib.rs
+++ b/fyrox-core-derive/src/lib.rs
@@ -22,6 +22,7 @@
 
 mod component;
 mod reflect;
+mod script_message_payload;
 mod uuid;
 mod visit;
 
@@ -189,4 +190,13 @@ pub fn type_uuid(input: TokenStream) -> TokenStream {
 pub fn component(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     TokenStream::from(component::impl_type_uuid_provider(ast))
+}
+
+/// Implements `ScriptMessagePayload` trait
+///
+/// User has to import `ScriptMessagePayload` trait to use this macro.
+#[proc_macro_derive(ScriptMessagePayload)]
+pub fn script_message_payload(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(script_message_payload::impl_script_message_payload(ast))
 }

--- a/fyrox-core-derive/src/script_message_payload.rs
+++ b/fyrox-core-derive/src/script_message_payload.rs
@@ -1,0 +1,18 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::DeriveInput;
+
+pub(crate) fn impl_script_message_payload(ast: DeriveInput) -> TokenStream2 {
+    let ident = &ast.ident;
+    quote! {
+        impl ScriptMessagePayload for #ident {
+            fn as_any_ref(&self) -> &dyn std::any::Any {
+                self
+            }
+
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+                self
+            }
+        }
+    }
+}

--- a/fyrox-impl/src/engine/mod.rs
+++ b/fyrox-impl/src/engine/mod.rs
@@ -3050,7 +3050,7 @@ mod test {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, ScriptMessagePayload)]
     enum MyMessage {
         Foo(usize),
         Bar(String),

--- a/fyrox-impl/src/script/mod.rs
+++ b/fyrox-impl/src/script/mod.rs
@@ -48,6 +48,8 @@ use std::{
     sync::mpsc::Sender,
 };
 
+pub use fyrox_core_derive::ScriptMessagePayload;
+
 pub mod constructor;
 
 pub(crate) trait UniversalScriptContext {
@@ -60,6 +62,14 @@ pub(crate) trait UniversalScriptContext {
 pub type DynamicTypeId = i64;
 
 /// A script message's payload.
+/// Use `#[derive(ScriptMessagePayload)]` to implement this trait:
+///
+/// ```rust
+///     use fyrox::script::ScriptMessagePayload;
+///     #[derive(Debug, ScriptMessagePayload)]
+///     struct MyStruct {
+///     }
+/// ```
 pub trait ScriptMessagePayload: Any + Send + Debug {
     /// Returns `self` as `&dyn Any`
     fn as_any_ref(&self) -> &dyn Any;
@@ -88,19 +98,6 @@ impl dyn ScriptMessagePayload {
     /// Tries to cast the payload to a particular type.
     pub fn downcast_mut<T: 'static>(&mut self) -> Option<&mut T> {
         self.as_any_mut().downcast_mut::<T>()
-    }
-}
-
-impl<T> ScriptMessagePayload for T
-where
-    T: 'static + Send + Debug,
-{
-    fn as_any_ref(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
     }
 }
 


### PR DESCRIPTION
(breaking change) blanket impl for ScriptMessagePayload replaced with derive macro

- allowing user to override get_dynamic_type(&self) -> DynamicTypeId { None }, which I've added recently to this trait (I forgot about orphan rules, making my change useless),
- also, it will help user to catch error early if he due to coding mistake passed wrong variable to send method. such early error detection is what people like in rust, and probably will like in rust-based engine, accepting additional macro for types as reasonable price