### PR TITLE
fix: use calculated local instead of screen position when setting new desired position after toggling off a view

### DIFF
--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -1913,7 +1913,7 @@ impl UserInterface {
                                 self.unlink_node(message.destination());
 
                                 let node = &self.nodes[message.destination()];
-                                let new_position = node.screen_position();
+                                let new_position = self.screen_to_root_canvas_space(node.screen_position());
                                 self.send_message(WidgetMessage::desired_position(
                                     message.destination(),
                                     MessageDirection::ToWidget,


### PR DESCRIPTION
## Description
Unlink did set the desired position based on the screen position, which can be outside the window when the screen resolution is higher then the one of the editor. But `set_desired_local_position()` of `Widget` does expect a local position (based on the resolution of the editor. Hence one has to calculate the local position first before setting the desired position.

## Related Issue(s)
Fixes #743 

## Review Guidance
I am struggling to write a good test for the fix. If you want to have a test for the fix then I would need a hint on how to setup a window that simulates being on a screen with a different resolution.

## Screenshots/GIFs
Before:

https://github.com/user-attachments/assets/4dc7e1ee-f982-403c-8fae-90b984860cea

After:

https://github.com/user-attachments/assets/e4894e6c-4c73-457c-a454-aee8a7d8b804



## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
