### PR TITLE
Improving FormattedText

### DIFF
--- a/editor/src/plugins/tilemap/panel_preview.rs
+++ b/editor/src/plugins/tilemap/panel_preview.rs
@@ -230,9 +230,22 @@ impl Control for PanelPreview {
         }
 
         ctx.transform_stack.pop();
+        let position = bounds.right_bottom_corner() - self.handle_text_size;
+        let rect = Rect {
+            position,
+            size: self.handle_text_size,
+        };
+        ctx.push_rect_filled(&rect, None);
+        ctx.commit(
+            self.clip_bounds(),
+            Brush::Solid(Color::from_rgba(0, 0, 0, 200)),
+            CommandTexture::None,
+            &self.material,
+            None,
+        );
         ctx.draw_text(
             self.clip_bounds(),
-            bounds.right_bottom_corner() - self.handle_text_size,
+            position,
             &self.material,
             &self.handle_text,
         );
@@ -270,6 +283,7 @@ impl PanelPreviewBuilder {
             tile_size: Vector2::repeat(32.0),
             transform: Matrix3::identity(),
             handle_text: FormattedTextBuilder::new(ctx.inner().default_font.clone())
+                .with_constraint(Vector2::new(f32::INFINITY, f32::INFINITY))
                 .with_brush(Brush::Solid(Color::WHITE))
                 .build(),
             handle_text_size: Vector2::default(),

--- a/fyrox-ui/src/formatted_text/run.rs
+++ b/fyrox-ui/src/formatted_text/run.rs
@@ -24,6 +24,9 @@ use crate::font::FontHeight;
 
 use super::*;
 
+#[deprecated]
+pub type RunBuilder = Run;
+
 #[derive(Clone, PartialEq, Debug, Default, Reflect)]
 pub struct RunSet(Vec<Run>);
 
@@ -133,6 +136,18 @@ pub struct Run {
 }
 
 impl Run {
+    pub fn new(range: Range<u32>) -> Self {
+        Self {
+            range,
+            font: None,
+            brush: None,
+            font_size: None,
+            shadow: None,
+            shadow_brush: None,
+            shadow_dilation: None,
+            shadow_offset: None,
+        }
+    }
     /// The font of the characters in this run, or None if the font is unmodified.
     pub fn font(&self) -> Option<&FontResource> {
         self.font.as_ref()
@@ -162,58 +177,9 @@ impl Run {
     pub fn shadow_offset(&self) -> Option<Vector2<f32>> {
         self.shadow_offset
     }
-}
-
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub enum DrawValueLayer {
-    Main,
-    Shadow,
-}
-
-#[derive(Clone, PartialEq, Debug)]
-pub struct GlyphDrawValues {
-    pub atlas_page_index: usize,
-    pub font: FontResource,
-    pub brush: Brush,
-    /// Font size scaled by super sampling scaling to pick correct atlas page.
-    pub height: FontHeight,
-}
-
-pub struct RunBuilder {
-    range: Range<u32>,
-    font: Option<FontResource>,
-    brush: Option<Brush>,
-    font_size: Option<f32>,
-    shadow: Option<bool>,
-    shadow_brush: Option<Brush>,
-    shadow_dilation: Option<f32>,
-    shadow_offset: Option<Vector2<f32>>,
-}
-
-impl RunBuilder {
-    pub fn new(range: Range<u32>) -> Self {
-        Self {
-            range,
-            font: None,
-            brush: None,
-            font_size: None,
-            shadow: None,
-            shadow_brush: None,
-            shadow_dilation: None,
-            shadow_offset: None,
-        }
-    }
-    pub fn build(self) -> Run {
-        Run {
-            range: self.range,
-            font: self.font,
-            brush: self.brush,
-            font_size: self.font_size,
-            shadow: self.shadow,
-            shadow_brush: self.shadow_brush,
-            shadow_dilation: self.shadow_dilation,
-            shadow_offset: self.shadow_offset,
-        }
+    #[deprecated]
+    pub fn build(self) -> Self {
+        self
     }
     /// Set this run to modify the font of the text within the range.
     pub fn with_font(mut self, font: FontResource) -> Self {
@@ -250,4 +216,19 @@ impl RunBuilder {
         self.shadow_offset = Some(offset);
         self
     }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub enum DrawValueLayer {
+    Main,
+    Shadow,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct GlyphDrawValues {
+    pub atlas_page_index: usize,
+    pub font: FontResource,
+    pub brush: Brush,
+    /// Font size scaled by super sampling scaling to pick correct atlas page.
+    pub height: FontHeight,
 }


### PR DESCRIPTION
## Description
This PR adds features to `FormattedText` to make it a more powerful tool for various uses and to make it easier to use.
* The space between lines can be controlled.
* The first line of multi-line text can have its indent controlled independently of the following lines.
* The `text_rect` method returns a rectangle containing a given span of text on a given line, since that is commonly useful.
* The `get_char_width` method is akin to `get_range_width` but simply allows access to the width of a single char without needing an iterator.
* The text can now be optionally supplied in the form of a `Vec<char>`, for cases when a `Vec<char>` is available to avoid having to construct a `String` just to turn it back into a `Vec<char>`.
* `Run` and `RunBuilder` were effectively identical, so combine them into a single type, turn `RunBuilder` into an alias for `Run`, and deprecate `RunBuilder` and the `build` method.
* A glitch is corrected in how the tilemap tile preview panel was using its `FormattedText`.

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
