### PR TITLE
Fix typos on fyrox_ui

### DIFF
--- a/fyrox-ui/src/curve/mod.rs
+++ b/fyrox-ui/src/curve/mod.rs
@@ -344,7 +344,7 @@ pub struct StepIterator {
 }
 
 impl StepIterator {
-    /// Construct an interator that starts at or before `start` and ends at or after `end`.
+    /// Construct an iterator that starts at or before `start` and ends at or after `end`.
     /// The intention is to cover the whole range of `start` to `end` at least.
     pub fn new(step: f32, start: f32, end: f32) -> Self {
         Self {

--- a/fyrox-ui/src/grid.rs
+++ b/fyrox-ui/src/grid.rs
@@ -619,7 +619,7 @@ impl Control for Grid {
             let space_y = calc_avg_size_for_stretch_dim(&self.rows, available_size.y).unwrap();
             // Now that we finally have the vertical stretch amount, we can properly measure group 1 (auto width, stretch height).
             // This is the only time we measure a node twice. The first time was just to discover the width.
-            // This measurement is just for height, now that we can give the node the true available veritical size.
+            // This measurement is just for height, now that we can give the node the true available vertical size.
             self.measure_group_height(&groups[1], ui, Vector2::new(available_size.x, space_y));
             self.measure_group(&groups[3], ui, Vector2::new(space_x, space_y));
         }

--- a/fyrox-ui/src/inspector/editors/mod.rs
+++ b/fyrox-ui/src/inspector/editors/mod.rs
@@ -210,7 +210,7 @@ pub struct PropertyEditorMessageContext<'a, 'b, 'c> {
     /// The layer_index indicates the nesting level of the widget that will receive the created message.
     pub layer_index: usize,
     /// Optional untyped information about the broader application in which
-    /// this proprety is being translated. This allows the created message to
+    /// this property is being translated. This allows the created message to
     /// adapt to the situation if we can successfully cast the given
     /// [InspectorEnvironment] into a specific type.
     pub environment: Option<Arc<dyn InspectorEnvironment>>,
@@ -230,7 +230,7 @@ pub struct PropertyEditorMessageContext<'a, 'b, 'c> {
 /// can use to update the inspected property based on the messages from the editor.
 pub struct PropertyEditorTranslationContext<'b, 'c> {
     /// Optional untyped information about the broader application in which
-    /// this proprety is being translated. This allows the translation to
+    /// this property is being translated. This allows the translation to
     /// adapt to the situation if we can successfully cast the given
     /// [InspectorEnvironment] into a specific type.
     ///

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -685,7 +685,7 @@ impl Inspector {
     }
 }
 
-/// Default margines for editor containers.
+/// Default margins for editor containers.
 pub const HEADER_MARGIN: Thickness = Thickness {
     left: 2.0,
     top: 1.0,
@@ -1224,7 +1224,7 @@ impl InspectorContext {
         }
     }
 
-    /// Update the widgest to reflect the value of the given object.
+    /// Update the widgets to reflect the value of the given object.
     /// We will iterate through the fields and find the appropriate [PropertyEditorDefinition](editors::PropertyEditorDefinition)
     /// for each field. We call [create_message](editors::PropertyEditorDefinition::create_message) to get each property editor
     /// definition to generate the appropriate message to get the editor widget to update itself, and we set the [flags](UiMessage::flags)

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -135,9 +135,9 @@
 //!
 //! ### Controls
 //!
-//! Control widgets primary purpose is to provide users with intractable UI elements to control some aspect of the program.
+//! Control widgets primary purpose is to provide users with interactable UI elements to control some aspect of the program.
 //!
-//! * [`crate::border::Border`]: The Button provides a press-able control that can contain other UI elements, for example a Text
+//! * [`crate::button::Button`]: The Button provides a press-able control that can contain other UI elements, for example a Text
 //! or Image Widget.
 //! * [`crate::check_box::CheckBox`]: The Check Box is a toggle-able control that can contain other UI elements, for example a Text
 //! or Image Widget.

--- a/fyrox-ui/src/messagebox.rs
+++ b/fyrox-ui/src/messagebox.rs
@@ -328,7 +328,7 @@ pub struct MessageBoxBuilder<'b> {
 }
 
 impl<'b> MessageBoxBuilder<'b> {
-    /// Creates new builder instace. `window_builder` could be used to customize the look of you message box.
+    /// Creates new builder instance. `window_builder` could be used to customize the look of you message box.
     pub fn new(window_builder: WindowBuilder) -> Self {
         Self {
             window_builder,

--- a/fyrox-ui/src/scroll_bar.rs
+++ b/fyrox-ui/src/scroll_bar.rs
@@ -180,7 +180,7 @@ pub struct ScrollBar {
     pub indicator_canvas: InheritableVariable<Handle<UiNode>>,
     /// A handle of the [`crate::text::Text`] widget that is used to show the current value of the scroll bar.
     pub value_text: InheritableVariable<Handle<UiNode>>,
-    /// Current value precison in decimal places.
+    /// Current value precision in decimal places.
     pub value_precision: InheritableVariable<usize>,
 }
 

--- a/fyrox-ui/src/thickness.rs
+++ b/fyrox-ui/src/thickness.rs
@@ -93,7 +93,7 @@ impl Thickness {
         }
     }
 
-    /// Thickness for the rigth side of a rectangle.
+    /// Thickness for the right side of a rectangle.
     pub fn right(v: f32) -> Self {
         Self {
             left: 0.0,


### PR DESCRIPTION
Hi :wave: 

I'm new to Fyrox, I mainly use the ui crate, and I've noticed a few typos in the documentation.

So this PR fixes multiple typos into the fyrox-ui documentation.\
No functional or behavioral changes were introduced. This PR only updates doc comments.

Would you be interested in adding a tool such as [typos](https://github.com/crate-ci/typos) ? (in the CI or other)

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
