### PR TITLE
fyrox-material has no license in Cargo.toml

### DIFF
--- a/fyrox-material/Cargo.toml
+++ b/fyrox-material/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "fyrox-material"
 version = "1.0.0-rc.1"
+authors = ["Dmitry Stepanov <d1maxa@yandex.ru>"]
 edition = "2021"
+license = "MIT"
 description = "Material and shader utilities for Fyrox Engine"
 keywords = ["graphics"]
 categories = ["game-development"]


### PR DESCRIPTION
## Description
Adds the missing license and authors fields to the `Cargo.toml` of `fyrox-material`.

## Review Guidance
Our `cargo-deny` setup is complaining that this crate doesn't have a license.

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
