### PR TITLE
Added the joint motor functionality from the Rapier library

### DIFF
--- a/fyrox-impl/src/scene/dim2/joint.rs
+++ b/fyrox-impl/src/scene/dim2/joint.rs
@@ -102,6 +102,21 @@ impl Default for PrismaticJoint {
     }
 }
 
+/// Parameters that define how the joint motor will behave.
+#[derive(Default, Clone, Debug, PartialEq, Visit, Reflect)]
+pub struct JointMotorParams {
+    /// The target velocity of the motor.
+    pub target_vel: f32,
+    /// The target position of the motor.
+    pub target_pos: f32,
+    /// The stiffness coefficient of the motor’s spring-like equation.
+    pub stiffness: f32,
+    /// The damping coefficient of the motor’s spring-like equation.
+    pub damping: f32,
+    /// The maximum force this motor can deliver.
+    pub max_force: f32,
+}
+
 /// The exact kind of the joint.
 #[derive(Clone, Debug, PartialEq, Visit, Reflect, AsRefStr, EnumString, VariantNames)]
 pub enum JointParams {
@@ -161,6 +176,9 @@ pub struct Joint {
     #[reflect(setter = "set_params")]
     pub(crate) params: InheritableVariable<JointParams>,
 
+    #[reflect(setter = "set_motor_params")]
+    pub(crate) motor_params: InheritableVariable<JointMotorParams>,
+
     #[reflect(setter = "set_body1")]
     pub(crate) body1: InheritableVariable<Handle<RigidBody>>,
 
@@ -185,6 +203,7 @@ impl Default for Joint {
         Self {
             base: Default::default(),
             params: Default::default(),
+            motor_params: Default::default(),
             body1: Default::default(),
             body2: Default::default(),
             local_frames: Default::default(),
@@ -214,6 +233,7 @@ impl Clone for Joint {
         Self {
             base: self.base.clone(),
             params: self.params.clone(),
+            motor_params: self.motor_params.clone(),
             body1: self.body1.clone(),
             body2: self.body2.clone(),
             local_frames: self.local_frames.clone(),
@@ -246,6 +266,39 @@ impl Joint {
         self.params.get_value_mut_and_mark_modified()
     }
 
+    /// Returns a shared reference to the current joint motor parameters.
+    pub fn motor_params(&self) -> &JointMotorParams {
+        &self.motor_params
+    }
+
+    /// Returns a mutable reference to the current joint motor parameters. Obtaining the mutable reference
+    ///
+    /// Recommend calling [`Self::set_motor_force_as_prismatic`] or [`Self::set_motor_torque_as_ball`] for prismatic or ball joints.
+    ///
+    /// Currently we do not support motor forces on more than one axis.
+    ///
+    /// If you have more complex needs, you may try to chain different joints together.
+    /// # Notice
+    /// If the joint is not BallJoint or PrismaticJoint, modifying the motor parameters directly may lead to unexpected behavior.
+    pub fn motor_params_mut(&mut self) -> &mut JointMotorParams {
+        self.motor_params.get_value_mut_and_mark_modified()
+    }
+
+    /// Sets new joint motor parameters.
+    ///
+    /// Recommend calling [`Self::set_motor_force_as_prismatic`] or [`Self::set_motor_torque_as_ball`] for prismatic or ball joints.
+    ///
+    /// Currently we do not support motor forces on more than one axis.
+    ///
+    /// If you have more complex needs, you may try to chain different joints together.
+    /// # Notice
+    /// If the joint is not BallJoint or PrismaticJoint, modifying the motor parameters directly may lead to unexpected behavior.
+    pub fn set_motor_params(&mut self, motor_params: JointMotorParams) -> JointMotorParams {
+        // to see how setting these params affect the rapier3d physics engine,
+        // go to sync_native function in this file.
+        self.motor_params.set_value_and_mark_modified(motor_params)
+    }
+
     /// Sets the first body of the joint. The handle should point to the RigidBody node, otherwise
     /// the joint will have no effect!
     pub fn set_body1(&mut self, handle: Handle<RigidBody>) -> Handle<RigidBody> {
@@ -268,7 +321,7 @@ impl Joint {
         *self.body2
     }
 
-    /// Sets whether the connected bodies should ignore collisions with each other or not.  
+    /// Sets whether the connected bodies should ignore collisions with each other or not.
     pub fn set_contacts_enabled(&mut self, enabled: bool) -> bool {
         self.contacts_enabled.set_value_and_mark_modified(enabled)
     }
@@ -276,6 +329,174 @@ impl Joint {
     /// Returns true if contacts between connected bodies is enabled, false - otherwise.
     pub fn is_contacts_enabled(&self) -> bool {
         *self.contacts_enabled
+    }
+
+    /// Sets the motor force of the joint assuming it is a [`PrismaticJoint`].
+    ///
+    /// Call [`Self::disable_motor`] to properly stop the motor and set the joint free.
+    /// # Arguments
+    /// * `force` - The maximum force this motor can deliver.
+    /// * `max_vel` - The target velocity of the motor.
+    /// * `damping` - Controls how smoothly the motor will reach the target velocity. A higher damping value will result in a smoother transition to the target velocity.
+    /// # Errors
+    /// If the joint is not a [`PrismaticJoint`], this function will do nothing and return an Err.
+    /// # Notice
+    /// The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    ///
+    /// To avoid this behavior, call this function periodically or call [`RigidBody::set_can_sleep`] on the rigid bodies with "false".
+    pub fn set_motor_force_as_prismatic(
+        &mut self,
+        force: f32,
+        max_vel: f32,
+        damping: f32,
+    ) -> Result<(), String> {
+        let JointParams::PrismaticJoint(_) = self.params() else {
+            return Err("Joint is not a PrismaticJoint".to_string());
+        };
+        let motor_params = JointMotorParams {
+            target_vel: max_vel,
+            target_pos: 0.0,
+            stiffness: 0.0,
+            damping,
+            max_force: force,
+        };
+        // retrieving the mutable reference to the joint params will cause the engine to do additional calculations to reflect changes to the physics engine.
+        self.set_motor_params(motor_params);
+        Ok(())
+    }
+
+    /// Sets the motor torque of the joint assuming it is a [`BallJoint`].
+    ///
+    /// Call [`Self::disable_motor`] to properly stop the motor and set the joint free.
+    /// # Arguments
+    /// * `torque` - The maximum torque this motor can deliver.
+    /// * `max_angular_vel` - The target angular velocity of the motor.
+    /// * `damping` - Controls how smoothly the motor will reach the target angular velocity. A higher damping value will result in a smoother transition to the target angular velocity.
+    /// # Errors
+    /// If the joint is not a [`BallJoint`], this function will do nothing and return an Err.
+    /// # Notice
+    /// The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    ///
+    /// To avoid this behavior, call this function periodically or call [`RigidBody::set_can_sleep`] on the rigid bodies with "false".
+    pub fn set_motor_torque_as_ball(
+        &mut self,
+        torque: f32,
+        max_angular_vel: f32,
+        damping: f32,
+    ) -> Result<(), String> {
+        let JointParams::BallJoint(_) = self.params() else {
+            return Err("Joint is not a BallJoint".to_string());
+        };
+        let motor_params = JointMotorParams {
+            target_vel: max_angular_vel,
+            target_pos: 0.0,
+            stiffness: 0.0,
+            damping,
+            max_force: torque,
+        };
+        // retrieving the mutable reference to the joint params will cause the engine to do additional calculations to reflect changes to the physics engine.
+        self.set_motor_params(motor_params);
+        Ok(())
+    }
+
+    /// Sets the motor target position of the joint assuming it is a [`PrismaticJoint`].
+    ///
+    /// After the joint reaches the target position, the joint will act as a spring with the specified stiffness and damping values.
+    ///
+    /// Call [`Self::disable_motor`] to stop the motor and remove the spring effect.
+    /// # Arguments
+    /// * `target_position` - The target position that the joint will try to reach, can be negative.
+    /// * `stiffness` - Controls how fast the joint will try to reach the target position.
+    /// * `max_force` - The maximum force this motor can deliver.
+    /// * `damping` - Controls how much the joint will resist motion when it is moving towards the target position.
+    /// # Errors
+    /// If the joint is not a [`PrismaticJoint`], the function will do nothing and return an Err.
+    /// # Notice
+    /// The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    ///
+    /// To avoid this behavior, call this function periodically or call [`RigidBody::set_can_sleep`] on the rigid bodies with "false".
+    pub fn set_motor_target_position_as_prismatic(
+        &mut self,
+        target_position: f32,
+        stiffness: f32,
+        max_force: f32,
+        damping: f32,
+    ) -> Result<(), String> {
+        let JointParams::PrismaticJoint(_) = self.params() else {
+            return Err("Joint is not a PrismaticJoint".to_string());
+        };
+        let motor_params = JointMotorParams {
+            target_vel: 0.0,
+            target_pos: target_position,
+            stiffness,
+            damping,
+            max_force,
+        };
+        // retrieving the mutable reference to the joint params will cause the engine to do additional calculations to reflect changes to the physics engine.
+        self.set_motor_params(motor_params);
+        Ok(())
+    }
+
+    /// Sets the motor target angle of the joint assuming it is a [`BallJoint`].
+    ///
+    /// After the joint reaches the target angle, the joint will act as a spring with the specified stiffness and damping values.
+    ///
+    /// Call [`Self::disable_motor`] to stop the motor and remove the spring effect.
+    /// # Arguments
+    /// * `target_angle` - The target angle **in radians** that the joint will try to reach, can be negative. If the value is greater than 2π or less than -2π, the joint will turn multiple times to reach the target angle.
+    /// * `stiffness` - Controls how fast the joint will try to reach the target angle.
+    /// * `max_torque` - The maximum torque this motor can deliver.
+    /// * `damping` - Controls how much the joint will resist motion when it is moving towards the target angle.
+    /// # Errors
+    /// If the joint is not a [`BallJoint`], the function will do nothing and return an Err.
+    /// # Notice
+    /// The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    ///
+    /// To avoid this behavior, call this function periodically or call [`RigidBody::set_can_sleep`] on the rigid bodies with "false".
+    pub fn set_motor_target_angle_as_ball(
+        &mut self,
+        target_angle: f32,
+        stiffness: f32,
+        max_torque: f32,
+        damping: f32,
+    ) -> Result<(), String> {
+        let JointParams::BallJoint(_) = self.params() else {
+            return Err("Joint is not a BallJoint".to_string());
+        };
+        let motor_params = JointMotorParams {
+            target_vel: 0.0,
+            target_pos: target_angle,
+            stiffness,
+            damping,
+            max_force: max_torque,
+        };
+        // retrieving the mutable reference to the joint params will cause the engine to do additional calculations to reflect changes to the physics engine.
+        self.set_motor_params(motor_params);
+        Ok(())
+    }
+
+    /// Disables the motor of the joint assuming it is a [`BallJoint`] or [`PrismaticJoint`].
+    ///
+    /// After this call, the joint will no longer apply any motor force or torque to the connected bodies.
+    /// # Errors
+    /// If the joint is not a [`BallJoint`] or [`PrismaticJoint`], the function will do nothing and return an Err.
+    pub fn disable_motor(&mut self) -> Result<(), String> {
+        if !matches!(
+            self.params(),
+            JointParams::BallJoint(_) | JointParams::PrismaticJoint(_)
+        ) {
+            return Err("Joint is not a BallJoint or PrismaticJoint".to_string());
+        }
+        let motor_params = JointMotorParams {
+            target_vel: 0.0,
+            target_pos: 0.0,
+            stiffness: 0.0,
+            damping: 0.0,
+            max_force: 0.0,
+        };
+        // retrieving the mutable reference to the joint params will cause the engine to do additional calculations to reflect changes to the physics engine.
+        self.set_motor_params(motor_params);
+        Ok(())
     }
 }
 
@@ -364,6 +585,7 @@ impl NodeTrait for Joint {
 pub struct JointBuilder {
     base_builder: BaseBuilder,
     params: JointParams,
+    motor_params: JointMotorParams,
     body1: Handle<RigidBody>,
     body2: Handle<RigidBody>,
     contacts_enabled: bool,
@@ -375,6 +597,7 @@ impl JointBuilder {
         Self {
             base_builder,
             params: Default::default(),
+            motor_params: Default::default(),
             body1: Default::default(),
             body2: Default::default(),
             contacts_enabled: true,
@@ -384,6 +607,12 @@ impl JointBuilder {
     /// Sets desired joint parameters which defines exact type of the joint.
     pub fn with_params(mut self, params: JointParams) -> Self {
         self.params = params;
+        self
+    }
+
+    /// Set desired motor parameters which defines how the joint motor will behave.
+    pub fn with_motor_params(mut self, motor_params: JointMotorParams) -> Self {
+        self.motor_params = motor_params;
         self
     }
 
@@ -401,7 +630,7 @@ impl JointBuilder {
         self
     }
 
-    /// Sets whether the connected bodies should ignore collisions with each other or not.  
+    /// Sets whether the connected bodies should ignore collisions with each other or not.
     pub fn with_contacts_enabled(mut self, enabled: bool) -> Self {
         self.contacts_enabled = enabled;
         self
@@ -412,6 +641,7 @@ impl JointBuilder {
         Joint {
             base: self.base_builder.build_base(),
             params: self.params.into(),
+            motor_params: self.motor_params.into(),
             body1: self.body1.into(),
             body2: self.body2.into(),
             local_frames: Default::default(),

--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -44,8 +44,10 @@ use crate::{
         collider::{self},
         debug::SceneDrawingContext,
         dim2::{
-            self, collider::ColliderShape, collider::TileMapShape, joint::JointLocalFrames,
-            joint::JointParams, rigidbody::ApplyAction,
+            self,
+            collider::{ColliderShape, TileMapShape},
+            joint::{JointLocalFrames, JointMotorParams, JointParams},
+            rigidbody::ApplyAction,
         },
         graph::{
             isometric_global_transform,
@@ -1239,6 +1241,40 @@ impl PhysicsWorld {
                 native.data =
                     // Preserve local frames.
                     convert_joint_params(v, native.data.local_frame1, native.data.local_frame2)
+            });
+            joint.motor_params.try_sync_model(|v|{
+                // The free axis is defined to be the x axis for both prismatic and ball joints in fyrox.
+                // If you want the joint to translate / rotate along a different axis, you can rotate the joint itself.
+                let joint_axis = match joint.params.get_value_ref(){
+                    JointParams::PrismaticJoint(_) => JointAxis::LinX,
+                    JointParams::BallJoint(_) => JointAxis::AngX,
+                    _ => {
+                        Log::warn("Try to modify motor parameters for unsupported joint type, this operation will be ignored.");
+                        return;
+                    }
+                };
+                // Force based motor model is better in the Fyrox's context
+                native.data.set_motor_model(joint_axis, rapier2d::prelude::MotorModel::ForceBased);
+                let JointMotorParams {
+                    target_vel,
+                    target_pos,
+                    stiffness,
+                    damping,
+                    max_force
+                } = v;
+                native.data.set_motor(joint_axis, target_pos, target_vel, stiffness, damping);
+                native.data.set_motor_max_force(joint_axis, max_force);
+                // wake up the bodies connected to the joint to ensure they respond to the motor changes immediately
+                // however, the rigid bodies may fall asleep any time later unless Joint::set_motor_* functions are called periodically,
+                // or the rigid bodies are set to cannot sleep
+                let Some(body1) = self.bodies.get_mut(native.body1) else {
+                    return;
+                };
+                body1.wake_up(true);
+                let Some(body2) = self.bodies.get_mut(native.body2) else {
+                    return;
+                };
+                body2.wake_up(true);
             });
             joint.contacts_enabled.try_sync_model(|v| {
                 native.data.set_contacts_enabled(v);

--- a/fyrox-impl/src/scene/joint.rs
+++ b/fyrox-impl/src/scene/joint.rs
@@ -325,19 +325,27 @@ impl Joint {
     }
 
     /// Returns a mutable reference to the current joint motor parameters. Obtaining the mutable reference
+    ///
     /// Recommend calling [`Self::set_motor_force_as_prismatic`] or [`Self::set_motor_torque_as_revolute`] for prismatic or revolute joints.
+    ///
     /// Currently we do not support motor forces on more than one axis.
+    ///
     /// If you have more complex needs, you may try to chain different joints together.
-    /// Warning: if the joint is not RevoluteJoint or PrismaticJoint, modifying the motor parameters directly may lead to unexpected behavior.
+    /// # Notice
+    /// If the joint is not RevoluteJoint or PrismaticJoint, modifying the motor parameters directly may lead to unexpected behavior.
     pub fn motor_params_mut(&mut self) -> &mut JointMotorParams {
         self.motor_params.get_value_mut_and_mark_modified()
     }
 
     /// Sets new joint motor parameters.
+    ///
     /// Recommend calling [`Self::set_motor_force_as_prismatic`] or [`Self::set_motor_torque_as_revolute`] for prismatic or revolute joints.
+    ///
     /// Currently we do not support motor forces on more than one axis.
+    ///
     /// If you have more complex needs, you may try to chain different joints together.
-    /// Warning: if the joint is not RevoluteJoint or PrismaticJoint, modifying the motor parameters directly may lead to unexpected behavior.
+    /// # Notice
+    /// If the joint is not RevoluteJoint or PrismaticJoint, modifying the motor parameters directly may lead to unexpected behavior.
     pub fn set_motor_params(&mut self, motor_params: JointMotorParams) -> JointMotorParams {
         // to see how setting these params affect the rapier3d physics engine,
         // go to sync_native function in this file.
@@ -387,10 +395,18 @@ impl Joint {
         *self.auto_rebind
     }
 
-    /// Sets the motor force of the joint assuming it is a PrismaticJoint.
-    /// If the joint is not a PrismaticJoint, this function will do nothing and return an Err.
+    /// Sets the motor force of the joint assuming it is a [`PrismaticJoint`].
+    ///
     /// Call [`Self::disable_motor`] to properly stop the motor and set the joint free.
-    /// Hint: The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    /// # Arguments
+    /// * `force` - The maximum force this motor can deliver.
+    /// * `max_vel` - The target velocity of the motor.
+    /// * `damping` - Controls how smoothly the motor will reach the target velocity. A higher damping value will result in a smoother transition to the target velocity.
+    /// # Errors
+    /// If the joint is not a [`PrismaticJoint`], this function will do nothing and return an Err.
+    /// # Notice
+    /// The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    ///
     /// To avoid this behavior, call this function periodically or call [`RigidBody::set_can_sleep`] on the rigid bodies with "false".
     pub fn set_motor_force_as_prismatic(
         &mut self,
@@ -413,10 +429,18 @@ impl Joint {
         Ok(())
     }
 
-    /// Sets the motor torque of the joint assuming it is a RevoluteJoint.
-    /// If the joint is not a RevoluteJoint, this function will do nothing and return an Err.
+    /// Sets the motor torque of the joint assuming it is a [`RevoluteJoint`].
+    ///
     /// Call [`Self::disable_motor`] to properly stop the motor and set the joint free.
-    /// Hint: The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    /// # Arguments
+    /// * `torque` - The maximum torque this motor can deliver.
+    /// * `max_angular_vel` - The target angular velocity of the motor.
+    /// * `damping` - Controls how smoothly the motor will reach the target angular velocity. A higher damping value will result in a smoother transition to the target angular velocity.
+    /// # Errors
+    /// If the joint is not a [`RevoluteJoint`], this function will do nothing and return an Err.
+    /// # Notice
+    /// The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    ///
     /// To avoid this behavior, call this function periodically or call [`RigidBody::set_can_sleep`] on the rigid bodies with "false".
     pub fn set_motor_torque_as_revolute(
         &mut self,
@@ -439,11 +463,21 @@ impl Joint {
         Ok(())
     }
 
-    /// Sets the motor target position of the joint assuming it is a PrismaticJoint.
-    /// If the joint is not a PrismaticJoint, the function will do nothing and return an Err.
+    /// Sets the motor target position of the joint assuming it is a [`PrismaticJoint`].
+    ///
     /// After the joint reaches the target position, the joint will act as a spring with the specified stiffness and damping values.
+    ///
     /// Call [`Self::disable_motor`] to stop the motor and remove the spring effect.
-    /// Hint: The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    /// # Arguments
+    /// * `target_position` - The target position that the joint will try to reach, can be negative.
+    /// * `stiffness` - Controls how fast the joint will try to reach the target position.
+    /// * `max_force` - The maximum force this motor can deliver.
+    /// * `damping` - Controls how much the joint will resist motion when it is moving towards the target position.
+    /// # Errors
+    /// If the joint is not a [`PrismaticJoint`], the function will do nothing and return an Err.
+    /// # Notice
+    /// The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    ///
     /// To avoid this behavior, call this function periodically or call [`RigidBody::set_can_sleep`] on the rigid bodies with "false".
     pub fn set_motor_target_position_as_prismatic(
         &mut self,
@@ -467,11 +501,21 @@ impl Joint {
         Ok(())
     }
 
-    /// Sets the motor target angle of the joint assuming it is a RevoluteJoint.
-    /// If the joint is not a RevoluteJoint, the function will do nothing and return an Err.
+    /// Sets the motor target angle of the joint assuming it is a [`RevoluteJoint`].
+    ///
     /// After the joint reaches the target angle, the joint will act as a spring with the specified stiffness and damping values.
+    ///
     /// Call [`Self::disable_motor`] to stop the motor and remove the spring effect.
-    /// Hint: The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    /// # Arguments
+    /// * `target_angle` - The target angle **in radians** that the joint will try to reach, can be negative. If the value is greater than 2π or less than -2π, the joint will turn multiple times to reach the target angle.
+    /// * `stiffness` - Controls how fast the joint will try to reach the target angle.
+    /// * `max_torque` - The maximum torque this motor can deliver.
+    /// * `damping` - Controls how much the joint will resist motion when it is moving towards the target angle.
+    /// # Errors
+    /// If the joint is not a [`RevoluteJoint`], the function will do nothing and return an Err.
+    /// # Notice
+    /// The rigid bodies attached to the joint may fall asleep anytime regardless whether the motor is enabled or not.
+    ///
     /// To avoid this behavior, call this function periodically or call [`RigidBody::set_can_sleep`] on the rigid bodies with "false".
     pub fn set_motor_target_angle_as_revolute(
         &mut self,
@@ -495,9 +539,11 @@ impl Joint {
         Ok(())
     }
 
-    /// Disables the motor of the joint assuming it is a revolute or prismatic joint.
-    /// If the joint is not of these types, the function will do nothing and return an Err.
-    /// After this call, the joint will no longer apply any motor forces or torques to the connected bodies.
+    /// Disables the motor of the joint assuming it is a [`RevoluteJoint`] or [`PrismaticJoint`].
+    ///
+    /// After this call, the joint will no longer apply any motor force or torque to the connected bodies.
+    /// # Errors
+    /// If the joint is not a [`RevoluteJoint`] or [`PrismaticJoint`], the function will do nothing and return an Err.
     pub fn disable_motor(&mut self) -> Result<(), String> {
         if !matches!(
             self.params(),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Added the joint motor functionality from the Rapier library for both 2D and 3D.
The motor functionality is designed for revolute joints and prismatic joints.
Use cases may be motored wheels, roulette wheels, pistons, suspensions, springs, etc.
Specifically, opened up the following interfaces:
Joint::set_motor_force_as_prismatic(...)
Joint::set_motor_torque_as_revolute(...) (2D version: Joint::set_motor_torque_as_ball(...))
Joint::set_motor_target_position_as_prismatic(...)
Joint::set_motor_target_angle_as_revolute(...) (2D version: Joint::set_motor_target_angle_as_ball(...))
Joint::disable_motor(...)

To accomplish these interfaces, a new struct "JointMotorParams" is added to the Joint's fields.
The underlying working principle is in the sync_native -> sync_to_joint_node call, a modified motor_params field of the Joint will trigger a closure that writes the params to the native joint data through native.data.set_motor_model, native.data.set_motor and native.data.set_motor_max_force. After that, the connecting rigidbodies are waked up through native function calls.

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
These functionalities are fully tested with unit tests.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
A sample test result that tests the 2d prismatic joint motor:

![executor_ZQR2dQQk8q](https://github.com/user-attachments/assets/5f882997-ecbf-4020-ac51-6a7ea526f16d)

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
