### PR TITLE
Replaced the BorrowAs trait with ObjectOrVariant trait.

### DIFF
--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -74,23 +74,60 @@ where
     free_stack: Vec<u32>,
 }
 
-pub trait BorrowAs<Object, Container: PayloadContainer<Element = Object>> {
-    type Target;
-    fn borrow_as_ref(self, pool: &Pool<Object, Container>) -> Option<&Self::Target>;
-    fn borrow_as_mut(self, pool: &mut Pool<Object, Container>) -> Option<&mut Self::Target>;
+/// This trait unifies pool objects and their variants.
+///
+/// If T is the pool object type, [`convert_to_dest_type`] returns the pool object itself.
+///
+/// If T is a variant of the pool object type, [`convert_to_dest_type`] returns the variant of the pool object.
+///
+/// The [`Pool`] struct uses this trait to unify the logic of retrieving both pool objects and their variants.
+pub trait ObjectOrVariant<T> {
+    fn convert_to_dest_type(object: &T) -> Option<&Self>;
+    fn convert_to_dest_type_mut(object: &mut T) -> Option<&mut Self>;
 }
 
-impl<Object, Container: PayloadContainer<Element = Object> + 'static> BorrowAs<Object, Container>
-    for Handle<Object>
-{
-    type Target = Object;
+/// This trait is a helper trait for implementing [`ObjectOrVariant`] indirectly in child crates.
+///
+/// To implement [`ObjectOrVariant`] for type `U` in a child crate, you need to implement [`ObjectOrVariantHelper`] for [`PhantomData<U>`].
+///
+/// This is necessary because Rust does not support `impl<T> ForeignTrait<LocalType> for T`
+///
+/// But Rust does support `impl<T> ForeignTrait<LocalType> for ForeignType<T>`
+///
+/// Details can be found in https://rust-lang.github.io/rfcs/2451-re-rebalancing-coherence.html#concrete-orphan-rules
+///
+/// Therefore, we cannot implement [`ObjectOrVariant`] directly using `impl<U: TraitBound> ObjectOrVariant<LocalType> for U`
+///
+/// but we can do `impl<U: TraitBound> ObjectOrVariantHelper<LocalType, U> for PhantomData<U>`
+///
+/// There is an indirection to get rid of [`PhantomData<U>`] because we want to have a clean API for pool methods
+/// where you can pass in `U` directly instead of [`PhantomData<U>`].
+pub trait ObjectOrVariantHelper<T, U> {
+    fn convert_to_dest_type_helper(object: &T) -> Option<&U>;
+    fn convert_to_dest_type_helper_mut(object: &mut T) -> Option<&mut U>;
+}
 
-    fn borrow_as_ref(self, pool: &Pool<Object, Container>) -> Option<&Object> {
-        pool.try_borrow(self)
+// This is the default implementation for pool object types.
+// For pool object variant types, they need to be implemented case by case, since Rust does not support multiple blanket implementations.
+impl<T> ObjectOrVariantHelper<T, T> for PhantomData<T> {
+    fn convert_to_dest_type_helper(object: &T) -> Option<&T> {
+        Some(object)
     }
+    fn convert_to_dest_type_helper_mut(object: &mut T) -> Option<&mut T> {
+        Some(object)
+    }
+}
 
-    fn borrow_as_mut(self, pool: &mut Pool<Object, Container>) -> Option<&mut Object> {
-        pool.try_borrow_mut(self)
+// This blanket implementation wraps types that implement ObjectOrVariantHelper with the ObjectOrVariant trait.
+impl<T, U> ObjectOrVariant<T> for U
+where
+    PhantomData<U>: ObjectOrVariantHelper<T, U>,
+{
+    fn convert_to_dest_type(object: &T) -> Option<&Self> {
+        PhantomData::<U>::convert_to_dest_type_helper(object)
+    }
+    fn convert_to_dest_type_mut(object: &mut T) -> Option<&mut Self> {
+        PhantomData::<U>::convert_to_dest_type_helper_mut(object)
     }
 }
 
@@ -414,16 +451,15 @@ where
     }
 
     #[inline]
-    pub fn typed_ref<Ref>(&self, handle: impl BorrowAs<T, P, Target = Ref>) -> Option<&Ref> {
-        handle.borrow_as_ref(self)
+    pub fn typed_ref<U: ObjectOrVariant<T>>(&self, handle: Handle<U>) -> Option<&U> {
+        let pool_object = self.try_borrow(handle.transmute())?;
+        U::convert_to_dest_type(pool_object)
     }
 
     #[inline]
-    pub fn typed_mut<Ref>(
-        &mut self,
-        handle: impl BorrowAs<T, P, Target = Ref>,
-    ) -> Option<&mut Ref> {
-        handle.borrow_as_mut(self)
+    pub fn typed_mut<U: ObjectOrVariant<T>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
+        let pool_object = self.try_borrow_mut(handle.transmute())?;
+        U::convert_to_dest_type_mut(pool_object)
     }
 
     #[inline]
@@ -1367,28 +1403,27 @@ where
     }
 }
 
-impl<Object, Container, Borrow, Ref> Index<Borrow> for Pool<Object, Container>
+impl<T, U, Container> Index<Handle<U>> for Pool<T, Container>
 where
-    Object: 'static,
-    Container: PayloadContainer<Element = Object> + 'static,
-    Borrow: BorrowAs<Object, Container, Target = Ref>,
+    T: 'static,
+    U: ObjectOrVariant<T>,
+    Container: PayloadContainer<Element = T> + 'static,
 {
-    type Output = Ref;
-
+    type Output = U;
     #[inline]
-    fn index(&self, index: Borrow) -> &Self::Output {
+    fn index(&self, index: Handle<U>) -> &Self::Output {
         self.typed_ref(index).expect("The handle must be valid!")
     }
 }
 
-impl<Object, Container, Borrow, Ref> IndexMut<Borrow> for Pool<Object, Container>
+impl<T, U, Container> IndexMut<Handle<U>> for Pool<T, Container>
 where
-    Object: 'static,
-    Container: PayloadContainer<Element = Object> + 'static,
-    Borrow: BorrowAs<Object, Container, Target = Ref>,
+    T: 'static,
+    U: ObjectOrVariant<T>,
+    Container: PayloadContainer<Element = T> + 'static,
 {
     #[inline]
-    fn index_mut(&mut self, index: Borrow) -> &mut Self::Output {
+    fn index_mut(&mut self, index: Handle<U>) -> &mut Self::Output {
         self.typed_mut(index).expect("The handle must be valid!")
     }
 }

--- a/fyrox-impl/src/scene/node/mod.rs
+++ b/fyrox-impl/src/scene/node/mod.rs
@@ -61,10 +61,11 @@ use crate::{
         Scene,
     },
 };
-use fyrox_core::define_as_any_trait;
+use fyrox_core::{define_as_any_trait, pool::ObjectOrVariantHelper};
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
+    marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
@@ -232,6 +233,17 @@ pub trait NodeTrait: BaseNodeTrait + Reflect + Visit + ComponentProvider {
     /// provide centralized diagnostics for scene graph.
     fn validate(&self, #[allow(unused_variables)] scene: &Scene) -> Result<(), String> {
         Ok(())
+    }
+}
+
+// Essentially implements ObjectOrVariant for NodeTrait types.
+// See ObjectOrVariantHelper for the cause of the indirection.
+impl<T: NodeTrait> ObjectOrVariantHelper<Node, T> for PhantomData<T> {
+    fn convert_to_dest_type_helper(node: &Node) -> Option<&T> {
+        NodeAsAny::as_any(node.0.deref()).downcast_ref()
+    }
+    fn convert_to_dest_type_helper_mut(node: &mut Node) -> Option<&mut T> {
+        NodeAsAny::as_any_mut(node.0.deref_mut()).downcast_mut()
     }
 }
 

--- a/fyrox-ui/src/control.rs
+++ b/fyrox-ui/src/control.rs
@@ -26,11 +26,12 @@ use crate::{
     widget::Widget,
     UiNode, UserInterface,
 };
-use fyrox_core::define_as_any_trait;
+use fyrox_core::{define_as_any_trait, pool::ObjectOrVariant};
 
 use fyrox_core::algebra::Matrix3;
 use std::{
     any::Any,
+    marker::PhantomData,
     ops::{Deref, DerefMut},
     sync::mpsc::Sender,
 };
@@ -354,5 +355,16 @@ pub trait Control:
         #[allow(unused_variables)] ui: &UserInterface,
     ) -> bool {
         *self.allow_drop
+    }
+}
+
+// Essentially implements ObjectOrVariant for NodeTrait types.
+// See ObjectOrVariantHelper for the cause of the indirection.
+impl<T: Control> ObjectOrVariant<UiNode> for PhantomData<T> {
+    fn convert_to_dest_type(node: &UiNode) -> Option<&Self> {
+        ControlAsAny::as_any(node.0.deref()).downcast_ref()
+    }
+    fn convert_to_dest_type_mut(node: &mut UiNode) -> Option<&mut Self> {
+        ControlAsAny::as_any_mut(node.0.deref_mut()).downcast_mut()
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Previously pools and graphs utilized the BorrowAs trait to realize the unification of retrieving both pool objects and their variants. For example, typed_ref method of the graph retrieves a reference &T from Handle<T> no matter whether T is a pool object (like a Node) or a pool object variant (like RigidBody). This is an elegant solution that exposes a unified API, but the implementation is hard to read since it involves a reverse of control between the pool and the handle. It can easily confuse users who would like to inspect the working principle of the pool system.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
There is no perfect solution for realizing two different behaviors for the same trait because Rust does not allow blanket implementing a trait more than once, and there are strict rules regarding how a blanket implementation can be conducted.

I found the major contradiction is that we cannot do `impl<T> ForeignTrait<LocalType> for T` when attempting to implement a trait from the fyrox_core crate (foreign crate) for all pool object variants that implement a local trait. However, we can do `impl<T> ForeignTrait<LocalType> for ForeignType<T>`. This might be the motivation of implementing traits for `Handle<T>` instead of `T` in the current code.

However, I find that we can bypass the restriction by simply implementing the essential trait (`ObjectOrVariantHelper`) for a dummy type like `PhantomData<T>`, and then wrap the essential trait (`ObjectOrVariantHelper`) with a nominal trait (`ObjectOrVariant`) using a universal blanket implementation. This still introduces some boilerplate code, but the implementation logic is not affected and no reverse of control is needed.

All the related automatic tests are passed.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
