### PR TITLE
Correcting InheritableVariable::visit and physics integration parameters `dt`

### DIFF
--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -211,10 +211,6 @@ impl GameScene {
             scene_content_root,
         );
 
-        // Freeze physics simulation in while editing scene by setting time step to zero.
-        scene.graph.physics.integration_parameters.dt = Some(0.0);
-        scene.graph.physics2d.integration_parameters.dt = Some(0.0);
-
         GameScene {
             editor_objects_root,
             scene_content_root,
@@ -224,6 +220,8 @@ impl GameScene {
             clipboard: Default::default(),
             preview_camera: Default::default(),
             graph_switches: GraphUpdateSwitches {
+                // Freeze physics simulation while editing scene by setting time step to zero.
+                physics_dt: false,
                 physics2d: true,
                 physics: true,
                 // Prevent engine to update lifetime of the nodes and to delete "dead" nodes. Otherwise

--- a/fyrox-core/src/variable.rs
+++ b/fyrox-core/src/variable.rs
@@ -337,8 +337,15 @@ where
         if visitor.is_reading() {
             // Try to visit inner value first, this is very useful if user decides to make their
             // variable inheritable, but still keep backward compatibility.
-            visited = self.value.visit(name, visitor).is_ok();
-            self.flags.get_mut().insert(VariableFlags::MODIFIED);
+            let has_flags = if let Ok(mut region) = visitor.enter_region(name) {
+                self.flags.get_mut().0.visit("Flags", &mut region).is_ok()
+            } else {
+                false
+            };
+            if !has_flags {
+                visited = self.value.visit(name, visitor).is_ok();
+                self.flags.get_mut().insert(VariableFlags::MODIFIED);
+            }
         }
 
         if !visited {

--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -618,12 +618,33 @@ impl PhysicsWorld {
         }
     }
 
-    pub(crate) fn update(&mut self, dt: f32) {
+    /// Update the physics pipeline with a timestep of the given length.
+    ///
+    /// * `dt`: The amount of time that has passed since the previous update.
+    ///   This may be overriden by [`PhysicsWorld::integration_parameters`] if
+    ///   `integration_parameters.dt` is `Some`, in which case that value is used
+    ///   instead of this argument.
+    /// * `dt_enabled`: If this is true then `dt` is used as usual, but if this is false
+    ///   then both the `dt` argument and `integration_parameters.dt` are ignored and
+    ///   a `dt` of zero is used instead, freezing all physics. This corresponds to the
+    ///   [`GraphUpdateSwitches::physics_dt`](crate::scene::graph::GraphUpdateSwitches::physics_dt).
+    pub(crate) fn update(&mut self, dt: f32, dt_enabled: bool) {
         let time = instant::Instant::now();
+        let parameter_dt = self.integration_parameters.dt;
+        let parameter_dt = if parameter_dt == Some(0.0) {
+            None
+        } else {
+            parameter_dt
+        };
+        let dt = if dt_enabled {
+            parameter_dt.unwrap_or(dt)
+        } else {
+            0.0
+        };
 
         if *self.enabled {
             let integration_parameters = rapier2d::dynamics::IntegrationParameters {
-                dt: self.integration_parameters.dt.unwrap_or(dt),
+                dt,
                 min_ccd_dt: self.integration_parameters.min_ccd_dt,
                 contact_damping_ratio: self.integration_parameters.contact_damping_ratio,
                 contact_natural_frequency: self.integration_parameters.contact_natural_frequency,

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -284,6 +284,8 @@ fn clear_links(mut node: Node) -> Node {
 /// A set of switches that allows you to disable a particular step of graph update pipeline.
 #[derive(Clone, PartialEq, Eq)]
 pub struct GraphUpdateSwitches {
+    /// Enables the physics update to have a non-zero `dt`.
+    pub physics_dt: bool,
     /// Enables or disables update of the 2D physics.
     pub physics2d: bool,
     /// Enables or disables update of the 3D physics.
@@ -301,6 +303,7 @@ pub struct GraphUpdateSwitches {
 impl Default for GraphUpdateSwitches {
     fn default() -> Self {
         Self {
+            physics_dt: true,
             physics2d: true,
             physics: true,
             node_overrides: Default::default(),
@@ -1214,13 +1217,13 @@ impl Graph {
 
         if switches.physics {
             self.physics.performance_statistics.reset();
-            self.physics.update(dt);
+            self.physics.update(dt, switches.physics_dt);
             self.performance_statistics.physics = self.physics.performance_statistics.clone();
         }
 
         if switches.physics2d {
             self.physics2d.performance_statistics.reset();
-            self.physics2d.update(dt);
+            self.physics2d.update(dt, switches.physics_dt);
             self.performance_statistics.physics2d = self.physics2d.performance_statistics.clone();
         }
 

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -1101,12 +1101,33 @@ impl PhysicsWorld {
         }
     }
 
-    pub(super) fn update(&mut self, dt: f32) {
+    /// Update the physics pipeline with a timestep of the given length.
+    ///
+    /// * `dt`: The amount of time that has passed since the previous update.
+    ///   This may be overriden by [`PhysicsWorld::integration_parameters`] if
+    ///   `integration_parameters.dt` is `Some`, in which case that value is used
+    ///   instead of this argument.
+    /// * `dt_enabled`: If this is true then `dt` is used as usual, but if this is false
+    ///   then both the `dt` argument and `integration_parameters.dt` are ignored and
+    ///   a `dt` of zero is used instead, freezing all physics. This corresponds to the
+    ///   [`GraphUpdateSwitches::physics_dt`](crate::scene::graph::GraphUpdateSwitches::physics_dt).
+    pub(super) fn update(&mut self, dt: f32, dt_enabled: bool) {
         let time = instant::Instant::now();
+        let parameter_dt = self.integration_parameters.dt;
+        let parameter_dt = if parameter_dt == Some(0.0) {
+            None
+        } else {
+            parameter_dt
+        };
+        let dt = if dt_enabled {
+            parameter_dt.unwrap_or(dt)
+        } else {
+            0.0
+        };
 
         if *self.enabled {
             let integration_parameters = rapier3d::dynamics::IntegrationParameters {
-                dt: self.integration_parameters.dt.unwrap_or(dt),
+                dt,
                 min_ccd_dt: self.integration_parameters.min_ccd_dt,
                 contact_damping_ratio: self.integration_parameters.contact_damping_ratio,
                 contact_natural_frequency: self.integration_parameters.contact_natural_frequency,


### PR DESCRIPTION
## Description
Prior to this PR, there was a bug in `InheritableVariable::visit` that would often result in some values not being read. When `InheritableVariable` writes to a visitor, it puts its value into "Value" and puts its flags into "Flags". When it reads, it can try both to read the value directly from the current node or read the value from "Value". This allows an `InheritableVariable` to be read from a visitor that was created using the inner value.

The bug was that `visit` would first try to visit the inner value directly and if that returned `Ok` then it assumed this was successful and never tried visiting "Value". This is a problem for any type that would produce `Ok` when visiting an `InheritableVariable` node, and `fyrox_impl::scene::graph::physics::IntegrationParameters` is such a type because it is annotated with `#[visit(optional)]` which means that visiting would never fail regardless of what node it visits. So even if the intended `IntegrationParameters` was stored in "Value" that node would never be read and instead we would end up with the default values for `IntegrationParameters`. Those default values are sufficient for most cases, allowing this bug to go unnoticed, but the reality was that the `IntegrationParameters` were not being loaded.

The fact that `IntegrationParameters` were not being loaded allowed another bug to go unnoticed, because the editor was modifying `IntegrationParameters::dt` to make it `Some(0.0)` and thereby freeze physics in the editor. This `dt` was never loaded, thereby preventing the physics freeze from being an issue in the executor, but this bug must now be dealt with since games will be loading their `IntegrationParameters`.

I have removed the lines of the editor that were setting `IntegrationParameters::dt` to `Some(0.0)`, and I have changed both 2D and 3D versions of `PhysicsWorld::update` so that a `dt` of `Some(0.0)` is treated as equivalent to `None` for the sake of backwards compatibility.

I have created a new switch to `fyrox_impl::scene::graph::GraphUpdateSwitches` which controls whether the physics `dt` is zero or whether it is taken from the usual source. `GraphUpdateSwitches::physics_dt` must be true, or else `dt` will be 0.0, and that switch is set to `false` in the editor, there by replicating the effect of setting `IntegrationParameters::dt` to `Some(0.0)` in the editor without actually changing the scene's `IntegrationParameters`.

## Checklist
- [X] My code follows the project's code style guidelines
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
- [X] My changes don't generate new warnings or errors
- [X] No unsafe code introduced (or if introduced, thoroughly justified and documented)
