### PR TITLE
Renamed pool method typed_ref to try_get

### DIFF
--- a/editor/src/asset/mod.rs
+++ b/editor/src/asset/mod.rs
@@ -837,7 +837,7 @@ impl AssetBrowser {
                 if let Some(item) = engine
                     .user_interfaces
                     .first_mut()
-                    .try_get(self.context_menu.placement_target)
+                    .try_get_node(self.context_menu.placement_target)
                     .and_then(|n| n.cast::<AssetItem>())
                 {
                     if let Ok(resource) =

--- a/editor/src/camera/mod.rs
+++ b/editor/src/camera/mod.rs
@@ -248,7 +248,7 @@ impl CameraController {
                 .try_normalize(f32::EPSILON)
                 .unwrap_or_default()
                 .scale(5.0);
-        if let Some(relative_to) = graph.try_get(relative_to) {
+        if let Some(relative_to) = graph.try_get_node(relative_to) {
             return relative_to
                 .global_transform()
                 .try_inverse()

--- a/editor/src/camera/panel.rs
+++ b/editor/src/camera/panel.rs
@@ -42,6 +42,7 @@ use crate::{
 use fyrox::core::algebra::Vector2;
 use fyrox::gui::widget::WidgetMessage;
 use fyrox::scene::collider::BitMask;
+use fyrox::graph::BaseSceneGraph;
 
 pub struct CameraPreviewControlPanel {
     pub window: Handle<UiNode>,
@@ -204,7 +205,7 @@ impl CameraPreviewControlPanel {
         let node_overrides = game_scene.graph_switches.node_overrides.as_mut().unwrap();
 
         if let Some((camera_handle, original)) = self.camera_state.take() {
-            if let Some(camera) = scene.graph.try_get_mut(camera_handle) {
+            if let Some(camera) = scene.graph.try_get_node_mut(camera_handle) {
                 *camera = original
             }
 

--- a/editor/src/camera/panel.rs
+++ b/editor/src/camera/panel.rs
@@ -40,9 +40,9 @@ use crate::{
     send_sync_message, send_sync_messages, Message,
 };
 use fyrox::core::algebra::Vector2;
+use fyrox::graph::BaseSceneGraph;
 use fyrox::gui::widget::WidgetMessage;
 use fyrox::scene::collider::BitMask;
-use fyrox::graph::BaseSceneGraph;
 
 pub struct CameraPreviewControlPanel {
     pub window: Handle<UiNode>,

--- a/editor/src/interaction/navmesh/selection.rs
+++ b/editor/src/interaction/navmesh/selection.rs
@@ -65,7 +65,7 @@ impl SelectionContainer for NavmeshSelection {
     ) {
         let game_scene = some_or_return!(controller.downcast_ref::<GameScene>());
         let scene = &scenes[game_scene.scene];
-        let node = scene.graph.try_get(self.navmesh_node).unwrap();
+        let node = scene.graph.try_get_node(self.navmesh_node).unwrap();
         (callback)(node as &dyn Reflect, node.has_inheritance_parent());
     }
 

--- a/editor/src/interaction/navmesh/selection.rs
+++ b/editor/src/interaction/navmesh/selection.rs
@@ -98,7 +98,7 @@ impl SelectionContainer for NavmeshSelection {
                     ctx.get_mut::<GameSceneContext>()
                         .scene
                         .graph
-                        .try_get_mut(navmesh_node)
+                        .try_get_node_mut(navmesh_node)
                         .map(|n| n as &mut dyn Reflect)
                 },
             ))

--- a/editor/src/plugins/absm/canvas.rs
+++ b/editor/src/plugins/absm/canvas.rs
@@ -212,7 +212,7 @@ impl AbsmCanvas {
         T: 'static,
     {
         if ui
-            .try_get(node_handle)
+            .try_get_node(node_handle)
             .is_some_and(|n| n.has_component::<T>())
         {
             return node_handle;
@@ -290,8 +290,8 @@ impl AbsmCanvas {
                 {
                     if transition_handle == transition.handle() {
                         if let (Some(source_state), Some(dest_state)) = (
-                            ui.try_get(transition.segment.source),
-                            ui.try_get(transition.segment.dest),
+                            ui.try_get_node(transition.segment.source),
+                            ui.try_get_node(transition.segment.dest),
                         ) {
                             let source_pos = source_state.center();
                             let dest_pos = dest_state.center();

--- a/editor/src/plugins/absm/mod.rs
+++ b/editor/src/plugins/absm/mod.rs
@@ -130,7 +130,7 @@ where
     N: SceneGraphNode<SceneGraph = G>,
 {
     graph
-        .try_get_mut(handle)
+        .try_get_node_mut(handle)
         .and_then(|n| n.component_mut::<InheritableVariable<Machine<Handle<N>>>>())
         .map(|v| v.get_value_mut_silent())
 }
@@ -144,12 +144,12 @@ where
     N: SceneGraphNode<SceneGraph = G>,
 {
     let animation_player_handle = *graph
-        .try_get(handle)
+        .try_get_node(handle)
         .and_then(|n| n.component_ref::<InheritableVariable<Handle<N>>>())
         .cloned()?;
 
     graph
-        .try_get_mut(animation_player_handle)
+        .try_get_node_mut(animation_player_handle)
         .and_then(|n| n.component_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>())
         .map(|ac| (animation_player_handle, ac.get_value_mut_silent()))
 }
@@ -160,7 +160,7 @@ where
     N: SceneGraphNode<SceneGraph = G>,
 {
     graph
-        .try_get(handle)
+        .try_get_node(handle)
         .and_then(|n| n.component_ref::<InheritableVariable<Machine<Handle<N>>>>())
         .map(|v| v.get_value_ref())
 }
@@ -174,11 +174,11 @@ where
     N: SceneGraphNode<SceneGraph = G>,
 {
     graph
-        .try_get(handle)
+        .try_get_node(handle)
         .and_then(|n| n.component_ref::<InheritableVariable<Handle<N>>>())
         .and_then(|ap| {
             graph
-                .try_get(**ap)
+                .try_get_node(**ap)
                 .and_then(|n| {
                     n.component_ref::<InheritableVariable<AnimationContainer<Handle<N>>>>()
                 })

--- a/editor/src/plugins/absm/toolbar.rs
+++ b/editor/src/plugins/absm/toolbar.rs
@@ -272,7 +272,7 @@ impl Toolbar {
                         .cloned()
                         .filter(|n| {
                             graph
-                                .try_get(*n)
+                                .try_get_node(*n)
                                 .is_some_and(|n| !unique_nodes.contains(&n.parent()))
                         })
                         .collect::<Vec<_>>();

--- a/editor/src/plugins/animation/mod.rs
+++ b/editor/src/plugins/animation/mod.rs
@@ -178,7 +178,7 @@ where
     N: SceneGraphNode<SceneGraph = G>,
 {
     graph
-        .try_get_mut(handle)
+        .try_get_node_mut(handle)
         .and_then(|n| n.component_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>())
         .map(|v| v.get_value_mut_silent())
 }
@@ -192,7 +192,7 @@ where
     N: SceneGraphNode<SceneGraph = G>,
 {
     graph
-        .try_get(handle)
+        .try_get_node(handle)
         .and_then(|n| {
             n.query_component_ref(TypeId::of::<
                 InheritableVariable<AnimationContainer<Handle<N>>>,
@@ -454,7 +454,7 @@ impl AnimationEditor {
                     assert!(node_overrides.insert(selection.animation_player));
 
                     let animation_player_node =
-                        graph.try_get_mut(selection.animation_player).unwrap();
+                        graph.try_get_node_mut(selection.animation_player).unwrap();
 
                     // HACK. This is unreliable to just use `bool` here. It should be wrapped into
                     // newtype or something.

--- a/editor/src/plugins/animation/toolbar.rs
+++ b/editor/src/plugins/animation/toolbar.rs
@@ -391,7 +391,7 @@ impl RootMotionDropdownArea {
                         .content,
                     MessageDirection::ToWidget,
                     graph
-                        .try_get(settings.node)
+                        .try_get_node(settings.node)
                         .map(|n| n.name().to_owned())
                         .unwrap_or_else(|| String::from("<Unassigned>")),
                 ),

--- a/editor/src/plugins/animation/track.rs
+++ b/editor/src/plugins/animation/track.rs
@@ -936,7 +936,7 @@ impl TrackList {
             if message.destination() == self.property_selector
                 && message.direction() == MessageDirection::FromWidget
             {
-                if let Some(node) = graph.try_get(self.selected_node.into()) {
+                if let Some(node) = graph.try_get_node(self.selected_node.into()) {
                     for property_path in selected_properties {
                         node.resolve_path(&property_path.path, &mut |result| match result {
                             Ok(property) => {
@@ -1117,7 +1117,7 @@ impl TrackList {
         N: SceneGraphNode,
     {
         let mut descriptors = Vec::new();
-        if let Some(node) = graph.try_get(node) {
+        if let Some(node) = graph.try_get_node(node) {
             node.as_reflect(&mut |node| {
                 descriptors = object_to_property_tree("", node, &mut |field: &FieldRef| {
                     let type_id = field.value.field_value_as_reflect().type_id();
@@ -1237,7 +1237,7 @@ impl TrackList {
             return;
         };
 
-        let Some(node) = graph.try_get(binding.target()) else {
+        let Some(node) = graph.try_get_node(binding.target()) else {
             Log::err("Invalid node handle!");
             return;
         };
@@ -1390,7 +1390,7 @@ impl TrackList {
                                             .with_text(format!(
                                                 "{} ({}:{})",
                                                 graph
-                                                    .try_get(model_track_binding.target())
+                                                    .try_get_node(model_track_binding.target())
                                                     .map(|n| n.name())
                                                     .unwrap_or_default(),
                                                 model_track_binding.target().index(),
@@ -1581,7 +1581,7 @@ impl TrackList {
                 }
 
                 let mut validation_result = Ok(());
-                if let Some(target) = graph.try_get(model_track_binding.target()) {
+                if let Some(target) = graph.try_get_node(model_track_binding.target()) {
                     if let Some(parent_group) =
                         self.group_views.get(&model_track_binding.target().into())
                     {

--- a/editor/src/plugins/collider/mod.rs
+++ b/editor/src/plugins/collider/mod.rs
@@ -496,7 +496,7 @@ impl InteractionMode for ColliderShapeInteractionMode {
                 ctx.get_mut::<GameSceneContext>()
                     .scene
                     .graph
-                    .try_get_mut(collider)
+                    .try_get_node_mut(collider)
                     .map(|n| n as &mut dyn Reflect)
             });
             self.message_sender.do_command(command);

--- a/editor/src/plugins/collider/panel.rs
+++ b/editor/src/plugins/collider/panel.rs
@@ -199,7 +199,7 @@ impl ColliderControlPanel {
                     ColliderShape::Capsule(_) => {
                         let local_center = scene
                             .graph
-                            .try_get(collider_ref.parent())
+                            .try_get_node(collider_ref.parent())
                             .map(|p| p.global_transform())
                             .unwrap_or_default()
                             .try_inverse()

--- a/editor/src/plugins/collider/panel.rs
+++ b/editor/src/plugins/collider/panel.rs
@@ -62,7 +62,7 @@ fn set_property<T: Reflect>(
             ctx.get_mut::<GameSceneContext>()
                 .scene
                 .graph
-                .try_get_mut(selected_collider)
+                .try_get_node_mut(selected_collider)
                 .map(|n| n as &mut dyn Reflect)
         },
     )));

--- a/editor/src/plugins/inspector/handlers/node/mod.rs
+++ b/editor/src/plugins/inspector/handlers/node/mod.rs
@@ -30,6 +30,7 @@ use crate::{
     scene::commands::terrain::{AddTerrainLayerCommand, DeleteTerrainLayerCommand},
     Command,
 };
+use fyrox::graph::BaseSceneGraph;
 
 pub struct SceneNodePropertyChangedHandler;
 
@@ -83,7 +84,7 @@ impl SceneNodePropertyChangedHandler {
                     ctx.get_mut::<GameSceneContext>()
                         .scene
                         .graph
-                        .try_get_mut(handle)
+                        .try_get_node_mut(handle)
                         .map(|n| n as &mut dyn Reflect)
                 })
             }

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -178,7 +178,7 @@ fn current_widget_style(
         if let Some(ui_selection) = selection.as_ui() {
             return ui_scene
                 .ui
-                .try_get(ui_selection.widgets[0])
+                .try_get_node(ui_selection.widgets[0])
                 .and_then(|n| n.style.clone());
         }
     }

--- a/editor/src/plugins/probe.rs
+++ b/editor/src/plugins/probe.rs
@@ -30,7 +30,7 @@ use crate::{
             Uuid,
         },
         engine::Engine,
-        graph::SceneGraph,
+        graph::{SceneGraph, BaseSceneGraph},
         gui::{
             button::{ButtonBuilder, ButtonMessage},
             grid::{Column, GridBuilder, Row},
@@ -218,7 +218,7 @@ impl InteractionMode for ReflectionProbeInteractionMode {
                 ctx.get_mut::<GameSceneContext>()
                     .scene
                     .graph
-                    .try_get_mut(probe.transmute())
+                    .try_get_node_mut(probe.transmute())
                     .map(|n| n as &mut dyn Reflect)
             },
         );

--- a/editor/src/plugins/probe.rs
+++ b/editor/src/plugins/probe.rs
@@ -30,7 +30,7 @@ use crate::{
             Uuid,
         },
         engine::Engine,
-        graph::{SceneGraph, BaseSceneGraph},
+        graph::{BaseSceneGraph, SceneGraph},
         gui::{
             button::{ButtonBuilder, ButtonMessage},
             grid::{Column, GridBuilder, Row},

--- a/editor/src/plugins/ragdoll.rs
+++ b/editor/src/plugins/ragdoll.rs
@@ -306,7 +306,7 @@ impl RagdollPreset {
         apply_offset: bool,
         graph: &mut Graph,
     ) -> Handle<Node> {
-        if let Some(from_ref) = graph.try_get(from) {
+        if let Some(from_ref) = graph.try_get_node(from) {
             let offset = if apply_offset {
                 from_ref
                     .up_vector()
@@ -364,7 +364,7 @@ impl RagdollPreset {
         ragdoll: Handle<Node>,
         graph: &mut Graph,
     ) -> Handle<Node> {
-        if let (Some(from_ref), Some(to_ref)) = (graph.try_get(from), graph.try_get(to)) {
+        if let (Some(from_ref), Some(to_ref)) = (graph.try_get_node(from), graph.try_get_node(to)) {
             let pos_from = from_ref.global_position();
             let pos_to = to_ref.global_position();
 
@@ -418,7 +418,7 @@ impl RagdollPreset {
         ragdoll: Handle<Node>,
         graph: &mut Graph,
     ) -> Handle<Node> {
-        if let Some(from_ref) = graph.try_get(from) {
+        if let Some(from_ref) = graph.try_get_node(from) {
             let cuboid = RigidBodyBuilder::new(
                 BaseBuilder::new()
                     .with_name(name)
@@ -458,7 +458,8 @@ impl RagdollPreset {
             (self.left_fore_arm, self.left_hand),
             (self.left_fore_arm, self.right_hand),
         ] {
-            if let (Some(upper_ref), Some(lower_ref)) = (graph.try_get(upper), graph.try_get(lower))
+            if let (Some(upper_ref), Some(lower_ref)) =
+                (graph.try_get_node(upper), graph.try_get_node(lower))
             {
                 base_size = (upper_ref.global_position() - lower_ref.global_position()).norm();
                 break;

--- a/editor/src/plugins/settings.rs
+++ b/editor/src/plugins/settings.rs
@@ -372,7 +372,7 @@ impl SettingsWindow {
                 self.sync_to_model(ui, settings, sender, engine.resource_manager.clone());
             }
 
-            if let Some(node) = ui.try_get(message.destination()) {
+            if let Some(node) = ui.try_get_node(message.destination()) {
                 if let Some(user_data) = node.user_data_cloned::<GroupName>() {
                     let inspector = ui.try_get_of_type::<Inspector>(self.inspector).unwrap();
 

--- a/editor/src/plugins/tilemap/mod.rs
+++ b/editor/src/plugins/tilemap/mod.rs
@@ -725,7 +725,7 @@ impl EditorPlugin for TileMapEditorPlugin {
 
         let palette = self.state.lock().selection_palette();
         if let Some(palette) = ui
-            .try_get_mut(palette)
+            .try_get_node_mut(palette)
             .and_then(|p| p.cast_mut::<PaletteWidget>())
         {
             palette.sync_selection_to_model();

--- a/editor/src/plugins/tilemap/mod.rs
+++ b/editor/src/plugins/tilemap/mod.rs
@@ -581,7 +581,7 @@ impl TileMapEditorPlugin {
         let entry = editor.scenes.current_scene_entry_mut()?;
         let game_scene = entry.controller.downcast_mut::<GameScene>()?;
         let scene = &mut editor.engine.scenes[game_scene.scene];
-        let node = scene.graph.try_get_mut(self.tile_map)?;
+        let node = scene.graph.try_get_node_mut(self.tile_map)?;
         node.component_mut::<TileMap>()
     }
     fn open_panel_for_tile_set(
@@ -873,7 +873,7 @@ impl EditorPlugin for TileMapEditorPlugin {
             // Remove the editor data from the currently selected tile map, so it will render as normal.
             if let Some(tile_map) = scene
                 .graph
-                .try_get_mut(self.tile_map)
+                .try_get_node_mut(self.tile_map)
                 .and_then(|n| n.component_mut::<TileMap>())
             {
                 tile_map.before_effects.clear();

--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -302,7 +302,7 @@ impl GameScene {
 
         if let Some(selection) = editor_selection.as_graph() {
             for &node in selection.nodes() {
-                if let Some(node) = scene.graph.try_get(node) {
+                if let Some(node) = scene.graph.try_get_node(node) {
                     scene.drawing_context.draw_oob(
                         &node.local_bounding_box(),
                         node.global_transform(),
@@ -1049,7 +1049,7 @@ impl SceneController for GameScene {
                     UiMessage::with_data(HandlePropertyEditorNameMessage(
                         scene
                             .graph
-                            .try_get((*handle).into())
+                            .try_get_node((*handle).into())
                             .map(|n| n.name_owned()),
                     ))
                     .with_destination(*view)

--- a/editor/src/ui_scene/interaction/move_mode.rs
+++ b/editor/src/ui_scene/interaction/move_mode.rs
@@ -83,7 +83,7 @@ impl InteractionMode for MoveWidgetsInteractionMode {
                 .widgets
                 .iter()
                 .filter_map(|w| {
-                    if let Some(widget_ref) = ui_scene.ui.try_get(*w) {
+                    if let Some(widget_ref) = ui_scene.ui.try_get_node(*w) {
                         if !in_bounds && widget_ref.screen_bounds().contains(mouse_position) {
                             in_bounds = true;
                         }
@@ -179,7 +179,7 @@ impl InteractionMode for MoveWidgetsInteractionMode {
                 let new_screen_space_position = mouse_position - entry.delta;
                 let parent_inv_transform = ui_scene
                     .ui
-                    .try_get(ui_scene.ui.node(entry.widget).parent)
+                    .try_get_node(ui_scene.ui.node(entry.widget).parent)
                     .and_then(|w| w.visual_transform().try_inverse())
                     .unwrap_or_default();
                 let new_local_position = parent_inv_transform.transform_point(&Point2::new(

--- a/editor/src/ui_scene/menu.rs
+++ b/editor/src/ui_scene/menu.rs
@@ -71,7 +71,7 @@ fn resource_path_of_first_selected_node(
 ) -> Option<PathBuf> {
     if let Some(ui_selection) = editor_selection.as_ui() {
         if let Some(first) = ui_selection.widgets.first() {
-            if let Some(resource) = ui_scene.ui.try_get(*first).and_then(|n| n.resource()) {
+            if let Some(resource) = ui_scene.ui.try_get_node(*first).and_then(|n| n.resource()) {
                 return resource_manager.resource_path(resource.as_ref());
             }
         }

--- a/editor/src/ui_scene/mod.rs
+++ b/editor/src/ui_scene/mod.rs
@@ -100,7 +100,7 @@ impl UiScene {
     }
 
     fn select_object(&mut self, handle: ErasedHandle) {
-        if self.ui.try_get(handle.into()).is_some() {
+        if self.ui.try_get_node(handle.into()).is_some() {
             self.message_sender
                 .do_command(ChangeSelectionCommand::new(Selection::new(
                     UiSelection::single_or_empty(handle.into()),
@@ -358,7 +358,7 @@ impl SceneController for UiScene {
         // Draw selection on top.
         if let Some(selection) = editor_selection.as_ui() {
             for node in selection.widgets.iter() {
-                if let Some(node) = self.ui.try_get(*node) {
+                if let Some(node) = self.ui.try_get_node(*node) {
                     let bounds = node.screen_bounds();
                     let clip_bounds = node.clip_bounds();
                     let drawing_context = &mut self.ui.drawing_context;
@@ -458,7 +458,7 @@ impl SceneController for UiScene {
                 engine.user_interfaces.first_mut().send_message(
                     UiMessage::with_data(HandlePropertyEditorNameMessage(
                         self.ui
-                            .try_get((*handle).into())
+                            .try_get_node((*handle).into())
                             .map(|n| n.name().to_owned()),
                     ))
                     .with_destination(*view)

--- a/editor/src/ui_scene/selection.rs
+++ b/editor/src/ui_scene/selection.rs
@@ -56,7 +56,7 @@ impl SelectionContainer for UiSelection {
     ) {
         let ui_scene = some_or_return!(controller.downcast_ref::<UiScene>());
         if let Some(first) = self.widgets.first() {
-            if let Some(node) = ui_scene.ui.try_get(*first) {
+            if let Some(node) = ui_scene.ui.try_get_node(*first) {
                 (callback)(node as &dyn Reflect, node.has_inheritance_parent())
             }
         }
@@ -74,7 +74,7 @@ impl SelectionContainer for UiSelection {
             .widgets
             .iter()
             .filter_map(|&node_handle| {
-                let node = ui_scene.ui.try_get(node_handle)?;
+                let node = ui_scene.ui.try_get_node(node_handle)?;
                 if args.is_inheritable() {
                     // Prevent reverting property value if there's no parent resource.
                     if node.resource().is_some() {
@@ -89,7 +89,7 @@ impl SelectionContainer for UiSelection {
                     make_command(args, move |ctx| {
                         ctx.get_mut::<UiSceneContext>()
                             .ui
-                            .try_get_mut(node_handle)
+                            .try_get_node_mut(node_handle)
                             .map(|n| n as &mut dyn Reflect)
                     })
                 }
@@ -111,7 +111,7 @@ impl SelectionContainer for UiSelection {
                         move |ctx| {
                             ctx.get_mut::<UiSceneContext>()
                                 .ui
-                                .try_get_mut(node_handle)
+                                .try_get_node_mut(node_handle)
                                 .map(|n| n as &mut dyn Reflect)
                         },
                     ))
@@ -126,7 +126,7 @@ impl SelectionContainer for UiSelection {
         let ui_scene = controller.downcast_ref::<UiScene>()?;
         self.widgets
             .first()
-            .and_then(|h| ui_scene.ui.try_get(*h).map(|n| n.doc().to_string()))
+            .and_then(|h| ui_scene.ui.try_get_node(*h).map(|n| n.doc().to_string()))
     }
 }
 

--- a/editor/src/ui_scene/utils.rs
+++ b/editor/src/ui_scene/utils.rs
@@ -67,14 +67,14 @@ impl WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'_> {
 
     fn children_of(&self, node: ErasedHandle) -> Vec<ErasedHandle> {
         self.ui
-            .try_get(node.into())
+            .try_get_node(node.into())
             .map(|n| n.children.iter().map(|c| (*c).into()).collect::<Vec<_>>())
             .unwrap_or_default()
     }
 
     fn child_count_of(&self, node: ErasedHandle) -> usize {
         self.ui
-            .try_get(node.into())
+            .try_get_node(node.into())
             .map(|n| n.children.len())
             .unwrap_or_default()
     }
@@ -91,19 +91,19 @@ impl WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'_> {
 
     fn is_node_has_child(&self, node: ErasedHandle, child: ErasedHandle) -> bool {
         self.ui
-            .try_get(node.into())
+            .try_get_node(node.into())
             .is_some_and(|n| n.children().iter().any(|c| *c == child.into()))
     }
 
     fn parent_of(&self, node: ErasedHandle) -> ErasedHandle {
         self.ui
-            .try_get(node.into())
+            .try_get_node(node.into())
             .map(|n| n.parent().into())
             .unwrap_or_default()
     }
 
     fn name_of(&self, node: ErasedHandle) -> Option<Cow<str>> {
-        self.ui.try_get(node.into()).map(|n| {
+        self.ui.try_get_node(node.into()).map(|n| {
             Cow::Owned(format!(
                 "{} [{}]",
                 n.name(),
@@ -113,11 +113,11 @@ impl WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'_> {
     }
 
     fn is_valid_handle(&self, node: ErasedHandle) -> bool {
-        self.ui.try_get(node.into()).is_some()
+        self.ui.try_get_node(node.into()).is_some()
     }
 
     fn icon_of(&self, node: ErasedHandle) -> Option<TextureResource> {
-        let node: &UiNode = self.ui.try_get(node.into()).unwrap();
+        let node: &UiNode = self.ui.try_get_node(node.into()).unwrap();
 
         // all icons are able to be used freely
         // todo: add more icons
@@ -166,7 +166,7 @@ impl WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'_> {
 
     fn is_instance(&self, node: ErasedHandle) -> bool {
         self.ui
-            .try_get(node.into())
+            .try_get_node(node.into())
             .is_some_and(|n| n.resource().is_some())
     }
 
@@ -211,7 +211,7 @@ impl WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'_> {
                             if let Some((parents_parent, position)) =
                                 self.ui.relative_position(parent, index_offset)
                             {
-                                if let Some(node) = self.ui.try_get(widget_handle) {
+                                if let Some(node) = self.ui.try_get_node(widget_handle) {
                                     if node.parent() != parents_parent {
                                         commands.push(LinkWidgetsCommand::new(
                                             widget_handle,

--- a/editor/src/utils/mod.rs
+++ b/editor/src/utils/mod.rs
@@ -132,7 +132,7 @@ pub fn fetch_node_screen_center(handle: Handle<UiNode>, ctx: &BuildContext) -> V
 }
 
 pub fn fetch_node_screen_center_ui(handle: Handle<UiNode>, ui: &UserInterface) -> Vector2<f32> {
-    ui.try_get(handle)
+    ui.try_get_node(handle)
         .map(|node| node.screen_bounds().center())
         .unwrap_or_default()
 }

--- a/editor/src/world/graph.rs
+++ b/editor/src/world/graph.rs
@@ -69,7 +69,7 @@ impl WorldViewerDataProvider for EditorSceneWrapper<'_> {
     fn children_of(&self, node: ErasedHandle) -> Vec<ErasedHandle> {
         self.scene
             .graph
-            .try_get(node.into())
+            .try_get_node(node.into())
             .map(|n| {
                 n.children()
                     .iter()
@@ -82,7 +82,7 @@ impl WorldViewerDataProvider for EditorSceneWrapper<'_> {
     fn child_count_of(&self, node: ErasedHandle) -> usize {
         self.scene
             .graph
-            .try_get(node.into())
+            .try_get_node(node.into())
             .map_or(0, |node| node.children().len())
     }
 
@@ -100,14 +100,14 @@ impl WorldViewerDataProvider for EditorSceneWrapper<'_> {
     fn is_node_has_child(&self, node: ErasedHandle, child: ErasedHandle) -> bool {
         self.scene
             .graph
-            .try_get(node.into())
+            .try_get_node(node.into())
             .is_some_and(|node| node.children().contains(&child.into()))
     }
 
     fn parent_of(&self, node: ErasedHandle) -> ErasedHandle {
         self.scene
             .graph
-            .try_get(node.into())
+            .try_get_node(node.into())
             .map(|node| node.parent().into())
             .unwrap_or_default()
     }
@@ -115,7 +115,7 @@ impl WorldViewerDataProvider for EditorSceneWrapper<'_> {
     fn name_of(&self, node: ErasedHandle) -> Option<Cow<str>> {
         self.scene
             .graph
-            .try_get(node.into())
+            .try_get_node(node.into())
             .map(|n| Cow::Borrowed(n.name()))
     }
 
@@ -124,7 +124,7 @@ impl WorldViewerDataProvider for EditorSceneWrapper<'_> {
     }
 
     fn icon_of(&self, node: ErasedHandle) -> Option<TextureResource> {
-        let node = self.scene.graph.try_get(node.into()).unwrap();
+        let node = self.scene.graph.try_get_node(node.into()).unwrap();
         if node.is_point_light() || node.is_directional_light() || node.is_spot_light() {
             load_image!("../../resources/light.png")
         } else if node.is_joint() || node.is_joint2d() {
@@ -143,7 +143,7 @@ impl WorldViewerDataProvider for EditorSceneWrapper<'_> {
     fn is_instance(&self, node: ErasedHandle) -> bool {
         self.scene
             .graph
-            .try_get(node.into())
+            .try_get_node(node.into())
             .is_some_and(|n| n.resource().is_some())
     }
 
@@ -188,7 +188,7 @@ impl WorldViewerDataProvider for EditorSceneWrapper<'_> {
                             if let Some((parents_parent, position)) =
                                 self.scene.graph.relative_position(parent, index_offset)
                             {
-                                if let Some(node) = self.scene.graph.try_get(node_handle) {
+                                if let Some(node) = self.scene.graph.try_get_node(node_handle) {
                                     if node.parent() != parents_parent {
                                         commands.push(LinkNodesCommand::new(
                                             node_handle,

--- a/editor/src/world/item.rs
+++ b/editor/src/world/item.rs
@@ -225,7 +225,7 @@ impl Control for SceneItem {
         } else if let Some(msg) = message.data::<WidgetMessage>() {
             match msg {
                 WidgetMessage::DragOver(_) => {
-                    if let Some(background) = ui.try_get(self.tree.background) {
+                    if let Some(background) = ui.try_get_node(self.tree.background) {
                         let cursor_pos = ui.cursor_position();
                         let bounds = background.screen_bounds();
                         let deflated_bounds = bounds.deflate(0.0, 5.0);

--- a/editor/src/world/menu.rs
+++ b/editor/src/world/menu.rs
@@ -91,7 +91,7 @@ fn resource_path_of_first_selected_node(
     if let Some(graph_selection) = editor_selection.as_graph() {
         if let Some(first) = graph_selection.nodes.first() {
             let scene = &engine.scenes[game_scene.scene];
-            if let Some(resource) = scene.graph.try_get(*first).and_then(|n| n.resource()) {
+            if let Some(resource) = scene.graph.try_get_node(*first).and_then(|n| n.resource()) {
                 return engine.resource_manager.resource_path(resource.as_ref());
             }
         }
@@ -395,7 +395,7 @@ impl SceneNodeContextMenu {
                         let scene = &engine.scenes[game_scene.scene];
                         let mut commands = Vec::new();
                         for node_handle in graph_selection.nodes.iter() {
-                            if let Some(node) = scene.graph.try_get(*node_handle) {
+                            if let Some(node) = scene.graph.try_get_node(*node_handle) {
                                 (node as &dyn Reflect).enumerate_fields_recursively(
                                     &mut |path, _, val| {
                                         val.as_inheritable_variable(&mut |inheritable| {

--- a/editor/src/world/mod.rs
+++ b/editor/src/world/mod.rs
@@ -704,7 +704,8 @@ impl WorldViewer {
             self.handle_drop(ui, data_provider, message.destination(), node);
         } else if let Some(ButtonMessage::Click) = message.data::<ButtonMessage>() {
             if let Some(&view) = self.breadcrumbs.get(&message.destination()) {
-                if let Some(graph_node) = ui.try_get_node(view).and_then(|n| n.cast::<SceneItem>()) {
+                if let Some(graph_node) = ui.try_get_node(view).and_then(|n| n.cast::<SceneItem>())
+                {
                     data_provider.on_selection_changed(&[graph_node.entity_handle]);
                 }
             } else if message.destination() == self.collapse_all {

--- a/editor/src/world/mod.rs
+++ b/editor/src/world/mod.rs
@@ -629,7 +629,7 @@ impl WorldViewer {
         self.colorize(ui);
 
         self.node_to_view_map
-            .retain(|k, v| data_provider.is_valid_handle(*k) && ui.try_get(*v).is_some());
+            .retain(|k, v| data_provider.is_valid_handle(*k) && ui.try_get_node(*v).is_some());
     }
 
     pub fn colorize(&mut self, ui: &UserInterface) {
@@ -704,7 +704,7 @@ impl WorldViewer {
             self.handle_drop(ui, data_provider, message.destination(), node);
         } else if let Some(ButtonMessage::Click) = message.data::<ButtonMessage>() {
             if let Some(&view) = self.breadcrumbs.get(&message.destination()) {
-                if let Some(graph_node) = ui.try_get(view).and_then(|n| n.cast::<SceneItem>()) {
+                if let Some(graph_node) = ui.try_get_node(view).and_then(|n| n.cast::<SceneItem>()) {
                     data_provider.on_selection_changed(&[graph_node.entity_handle]);
                 }
             } else if message.destination() == self.collapse_all {

--- a/editor/src/world/selection.rs
+++ b/editor/src/world/selection.rs
@@ -59,7 +59,7 @@ impl SelectionContainer for GraphSelection {
         if let Some(node) = self
             .nodes
             .first()
-            .and_then(|handle| scene.graph.try_get(*handle))
+            .and_then(|handle| scene.graph.try_get_node(*handle))
         {
             (callback)(node as &dyn Reflect, node.has_inheritance_parent());
         }

--- a/editor/src/world/selection.rs
+++ b/editor/src/world/selection.rs
@@ -82,7 +82,7 @@ impl SelectionContainer for GraphSelection {
                 game_scene.node_property_changed_handler.handle(
                     args,
                     node_handle,
-                    scene.graph.try_get_mut(node_handle)?,
+                    scene.graph.try_get_node_mut(node_handle)?,
                 )
             })
             .collect::<Vec<_>>();
@@ -103,7 +103,7 @@ impl SelectionContainer for GraphSelection {
                             ctx.get_mut::<GameSceneContext>()
                                 .scene
                                 .graph
-                                .try_get_mut(node_handle)
+                                .try_get_node_mut(node_handle)
                                 .map(|n| n as &mut dyn Reflect)
                         },
                     ))

--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -451,13 +451,13 @@ where
     }
 
     #[inline]
-    pub fn typed_ref<U: ObjectOrVariant<T>>(&self, handle: Handle<U>) -> Option<&U> {
+    pub fn try_get<U: ObjectOrVariant<T>>(&self, handle: Handle<U>) -> Option<&U> {
         let pool_object = self.try_borrow(handle.transmute())?;
         U::convert_to_dest_type(pool_object)
     }
 
     #[inline]
-    pub fn typed_mut<U: ObjectOrVariant<T>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
+    pub fn try_get_mut<U: ObjectOrVariant<T>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
         let pool_object = self.try_borrow_mut(handle.transmute())?;
         U::convert_to_dest_type_mut(pool_object)
     }
@@ -1412,7 +1412,7 @@ where
     type Output = U;
     #[inline]
     fn index(&self, index: Handle<U>) -> &Self::Output {
-        self.typed_ref(index).expect("The handle must be valid!")
+        self.try_get(index).expect("The handle must be valid!")
     }
 }
 
@@ -1424,7 +1424,7 @@ where
 {
     #[inline]
     fn index_mut(&mut self, index: Handle<U>) -> &mut Self::Output {
-        self.typed_mut(index).expect("The handle must be valid!")
+        self.try_get_mut(index).expect("The handle must be valid!")
     }
 }
 

--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -74,23 +74,60 @@ where
     free_stack: Vec<u32>,
 }
 
-pub trait BorrowAs<Object, Container: PayloadContainer<Element = Object>> {
-    type Target;
-    fn borrow_as_ref(self, pool: &Pool<Object, Container>) -> Option<&Self::Target>;
-    fn borrow_as_mut(self, pool: &mut Pool<Object, Container>) -> Option<&mut Self::Target>;
+/// This trait unifies pool objects and their variants.
+///
+/// If T is the pool object type, [`convert_to_dest_type`] returns the pool object itself.
+///
+/// If T is a variant of the pool object type, [`convert_to_dest_type`] returns the variant of the pool object.
+///
+/// The [`Pool`] struct uses this trait to unify the logic of retrieving both pool objects and their variants.
+pub trait ObjectOrVariant<T> {
+    fn convert_to_dest_type(object: &T) -> Option<&Self>;
+    fn convert_to_dest_type_mut(object: &mut T) -> Option<&mut Self>;
 }
 
-impl<Object, Container: PayloadContainer<Element = Object> + 'static> BorrowAs<Object, Container>
-    for Handle<Object>
-{
-    type Target = Object;
+/// This trait is a helper trait for implementing [`ObjectOrVariant`] indirectly in child crates.
+///
+/// To implement [`ObjectOrVariant`] for type `U` in a child crate, you need to implement [`ObjectOrVariantHelper`] for [`PhantomData<U>`].
+///
+/// This is necessary because Rust does not support `impl<T> ForeignTrait<LocalType> for T`
+///
+/// But Rust does support `impl<T> ForeignTrait<LocalType> for ForeignType<T>`
+///
+/// Details can be found in https://rust-lang.github.io/rfcs/2451-re-rebalancing-coherence.html#concrete-orphan-rules
+///
+/// Therefore, we cannot implement [`ObjectOrVariant`] directly using `impl<U: TraitBound> ObjectOrVariant<LocalType> for U`
+///
+/// but we can do `impl<U: TraitBound> ObjectOrVariantHelper<LocalType, U> for PhantomData<U>`
+///
+/// There is an indirection to get rid of [`PhantomData<U>`] because we want to have a clean API for pool methods
+/// where you can pass in `U` directly instead of [`PhantomData<U>`].
+pub trait ObjectOrVariantHelper<T, U> {
+    fn convert_to_dest_type_helper(object: &T) -> Option<&U>;
+    fn convert_to_dest_type_helper_mut(object: &mut T) -> Option<&mut U>;
+}
 
-    fn borrow_as_ref(self, pool: &Pool<Object, Container>) -> Option<&Object> {
-        pool.try_borrow(self)
+// This is the default implementation for pool object types.
+// For pool object variant types, they need to be implemented case by case, since Rust does not support multiple blanket implementations.
+impl<T> ObjectOrVariantHelper<T, T> for PhantomData<T> {
+    fn convert_to_dest_type_helper(object: &T) -> Option<&T> {
+        Some(object)
     }
+    fn convert_to_dest_type_helper_mut(object: &mut T) -> Option<&mut T> {
+        Some(object)
+    }
+}
 
-    fn borrow_as_mut(self, pool: &mut Pool<Object, Container>) -> Option<&mut Object> {
-        pool.try_borrow_mut(self)
+// This blanket implementation wraps types that implement ObjectOrVariantHelper with the ObjectOrVariant trait.
+impl<T, U> ObjectOrVariant<T> for U
+where
+    PhantomData<U>: ObjectOrVariantHelper<T, U>,
+{
+    fn convert_to_dest_type(object: &T) -> Option<&Self> {
+        PhantomData::<U>::convert_to_dest_type_helper(object)
+    }
+    fn convert_to_dest_type_mut(object: &mut T) -> Option<&mut Self> {
+        PhantomData::<U>::convert_to_dest_type_helper_mut(object)
     }
 }
 
@@ -414,16 +451,15 @@ where
     }
 
     #[inline]
-    pub fn typed_ref<Ref>(&self, handle: impl BorrowAs<T, P, Target = Ref>) -> Option<&Ref> {
-        handle.borrow_as_ref(self)
+    pub fn typed_ref<U: ObjectOrVariant<T>>(&self, handle: Handle<U>) -> Option<&U> {
+        let pool_object = self.try_borrow(handle.transmute())?;
+        U::convert_to_dest_type(pool_object)
     }
 
     #[inline]
-    pub fn typed_mut<Ref>(
-        &mut self,
-        handle: impl BorrowAs<T, P, Target = Ref>,
-    ) -> Option<&mut Ref> {
-        handle.borrow_as_mut(self)
+    pub fn typed_mut<U: ObjectOrVariant<T>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
+        let pool_object = self.try_borrow_mut(handle.transmute())?;
+        U::convert_to_dest_type_mut(pool_object)
     }
 
     #[inline]
@@ -1367,28 +1403,27 @@ where
     }
 }
 
-impl<Object, Container, Borrow, Ref> Index<Borrow> for Pool<Object, Container>
+impl<T, U, Container> Index<Handle<U>> for Pool<T, Container>
 where
-    Object: 'static,
-    Container: PayloadContainer<Element = Object> + 'static,
-    Borrow: BorrowAs<Object, Container, Target = Ref>,
+    T: 'static,
+    U: ObjectOrVariant<T>,
+    Container: PayloadContainer<Element = T> + 'static,
 {
-    type Output = Ref;
-
+    type Output = U;
     #[inline]
-    fn index(&self, index: Borrow) -> &Self::Output {
+    fn index(&self, index: Handle<U>) -> &Self::Output {
         self.typed_ref(index).expect("The handle must be valid!")
     }
 }
 
-impl<Object, Container, Borrow, Ref> IndexMut<Borrow> for Pool<Object, Container>
+impl<T, U, Container> IndexMut<Handle<U>> for Pool<T, Container>
 where
-    Object: 'static,
-    Container: PayloadContainer<Element = Object> + 'static,
-    Borrow: BorrowAs<Object, Container, Target = Ref>,
+    T: 'static,
+    U: ObjectOrVariant<T>,
+    Container: PayloadContainer<Element = T> + 'static,
 {
     #[inline]
-    fn index_mut(&mut self, index: Borrow) -> &mut Self::Output {
+    fn index_mut(&mut self, index: Handle<U>) -> &mut Self::Output {
         self.typed_mut(index).expect("The handle must be valid!")
     }
 }

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -703,10 +703,10 @@ pub trait BaseSceneGraph: AbstractSceneGraph {
     fn set_root(&mut self, root: Handle<Self::Node>);
 
     /// Tries to borrow a node, returns Some(node) if the handle is valid, None - otherwise.
-    fn try_get(&self, handle: Handle<Self::Node>) -> Option<&Self::Node>;
+    fn try_get_node(&self, handle: Handle<Self::Node>) -> Option<&Self::Node>;
 
     /// Tries to borrow a node, returns Some(node) if the handle is valid, None - otherwise.
-    fn try_get_mut(&mut self, handle: Handle<Self::Node>) -> Option<&mut Self::Node>;
+    fn try_get_node_mut(&mut self, handle: Handle<Self::Node>) -> Option<&mut Self::Node>;
 
     /// Checks whether the given node handle is valid or not.
     fn is_valid_handle(&self, handle: Handle<Self::Node>) -> bool;
@@ -729,12 +729,14 @@ pub trait BaseSceneGraph: AbstractSceneGraph {
 
     /// Borrows a node by its handle.
     fn node(&self, handle: Handle<Self::Node>) -> &Self::Node {
-        self.try_get(handle).expect("The handle must be valid!")
+        self.try_get_node(handle)
+            .expect("The handle must be valid!")
     }
 
     /// Borrows a node by its handle.
     fn node_mut(&mut self, handle: Handle<Self::Node>) -> &mut Self::Node {
-        self.try_get_mut(handle).expect("The handle must be valid!")
+        self.try_get_node_mut(handle)
+            .expect("The handle must be valid!")
     }
 
     /// Reorders the node hierarchy so the `new_root` becomes the root node for the entire hierarchy
@@ -852,7 +854,7 @@ pub trait SceneGraph: BaseSceneGraph {
     where
         T: 'static,
     {
-        self.try_get(handle)
+        self.try_get_node(handle)
             .and_then(|n| n.query_component_ref(TypeId::of::<T>()))
             .and_then(|c| c.downcast_ref())
     }
@@ -863,7 +865,7 @@ pub trait SceneGraph: BaseSceneGraph {
     where
         T: 'static,
     {
-        self.try_get_mut(handle)
+        self.try_get_node_mut(handle)
             .and_then(|n| n.query_component_mut(TypeId::of::<T>()))
             .and_then(|c| c.downcast_mut())
     }
@@ -890,7 +892,7 @@ pub trait SceneGraph: BaseSceneGraph {
         C: FnMut(&Self::Node) -> Option<&T>,
         T: ?Sized,
     {
-        self.try_get(root_node).and_then(|root| {
+        self.try_get_node(root_node).and_then(|root| {
             if let Some(x) = cmp(root) {
                 Some((root_node, x))
             } else {
@@ -911,7 +913,7 @@ pub trait SceneGraph: BaseSceneGraph {
         C: FnMut(&Self::Node) -> bool,
     {
         let mut handle = root_node;
-        while let Some(node) = self.try_get(handle) {
+        while let Some(node) = self.try_get_node(handle) {
             if cmp(node) {
                 return Some((handle, node));
             }
@@ -970,7 +972,7 @@ pub trait SceneGraph: BaseSceneGraph {
         T: ?Sized,
     {
         let mut handle = root_node;
-        while let Some(node) = self.try_get(handle) {
+        while let Some(node) = self.try_get_node(handle) {
             if let Some(x) = cmp(node) {
                 return Some((handle, x));
             }
@@ -1037,7 +1039,7 @@ pub trait SceneGraph: BaseSceneGraph {
     where
         C: FnMut(&Self::Node) -> bool,
     {
-        self.try_get(root_node).and_then(|root| {
+        self.try_get_node(root_node).and_then(|root| {
             if cmp(root) {
                 Some((root_node, root))
             } else {
@@ -1076,8 +1078,8 @@ pub trait SceneGraph: BaseSceneGraph {
         child: Handle<Self::Node>,
         offset: isize,
     ) -> Option<(Handle<Self::Node>, usize)> {
-        let parents_parent_handle = self.try_get(child)?.parent();
-        let parents_parent_ref = self.try_get(parents_parent_handle)?;
+        let parents_parent_handle = self.try_get_node(child)?.parent();
+        let parents_parent_ref = self.try_get_node(parents_parent_handle)?;
         let position = parents_parent_ref.child_position(child)?;
         Some((
             parents_parent_handle,
@@ -1300,7 +1302,7 @@ pub trait SceneGraph: BaseSceneGraph {
                         NodeMapping::UseHandles => {
                             // Use original handle directly.
                             resource_graph
-                                .try_get(node.original_handle_in_resource())
+                                .try_get_node(node.original_handle_in_resource())
                                 .map(|resource_node| {
                                     (resource_node, node.original_handle_in_resource())
                                 })
@@ -1863,11 +1865,11 @@ mod test {
             }
         }
 
-        fn try_get(&self, handle: Handle<Self::Node>) -> Option<&Self::Node> {
+        fn try_get_node(&self, handle: Handle<Self::Node>) -> Option<&Self::Node> {
             self.nodes.try_borrow(handle)
         }
 
-        fn try_get_mut(&mut self, handle: Handle<Self::Node>) -> Option<&mut Self::Node> {
+        fn try_get_node_mut(&mut self, handle: Handle<Self::Node>) -> Option<&mut Self::Node> {
             self.nodes.try_borrow_mut(handle)
         }
 

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -851,8 +851,6 @@ pub trait SceneGraph: BaseSceneGraph {
         &mut self,
         handle: Handle<U>,
     ) -> Option<&mut U>;
-        handle: Handle<U>,
-    ) -> Option<&mut U>;
 
     /// Tries to borrow a node and fetch its component of specified type.
     #[inline]

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -1905,11 +1905,11 @@ mod test {
         }
 
         fn typed_ref<U: ObjectOrVariant<Node>>(&self, handle: Handle<U>) -> Option<&U> {
-            self.nodes.typed_ref(handle)
+            self.nodes.try_get(handle)
         }
 
         fn typed_mut<U: ObjectOrVariant<Node>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
-            self.nodes.typed_mut(handle)
+            self.nodes.try_get_mut(handle)
         }
     }
 

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -24,6 +24,10 @@
 
 pub mod constructor;
 
+pub mod prelude {
+    pub use crate::{AbstractSceneGraph, BaseSceneGraph, SceneGraph};
+}
+
 use fxhash::FxHashMap;
 use fyrox_core::pool::{ErasedHandle, ObjectOrVariant, PayloadContainer};
 use fyrox_core::reflect::ReflectHandle;

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -841,9 +841,9 @@ pub trait SceneGraph: BaseSceneGraph {
     /// of nodes. It does *not* perform any tree traversal!
     fn linear_iter_mut(&mut self) -> impl Iterator<Item = &mut Self::Node>;
 
-    fn typed_ref<U: ObjectOrVariant<Self::ObjectType>>(&self, handle: Handle<U>) -> Option<&U>;
+    fn try_get<U: ObjectOrVariant<Self::ObjectType>>(&self, handle: Handle<U>) -> Option<&U>;
 
-    fn typed_mut<U: ObjectOrVariant<Self::ObjectType>>(
+    fn try_get_mut<U: ObjectOrVariant<Self::ObjectType>>(
         &mut self,
         handle: Handle<U>,
     ) -> Option<&mut U>;
@@ -1906,11 +1906,11 @@ mod test {
             self.nodes.iter_mut()
         }
 
-        fn typed_ref<U: ObjectOrVariant<Node>>(&self, handle: Handle<U>) -> Option<&U> {
+        fn try_get<U: ObjectOrVariant<Node>>(&self, handle: Handle<U>) -> Option<&U> {
             self.nodes.try_get(handle)
         }
 
-        fn typed_mut<U: ObjectOrVariant<Node>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
+        fn try_get_mut<U: ObjectOrVariant<Node>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
             self.nodes.try_get_mut(handle)
         }
     }

--- a/fyrox-impl/src/engine/hotreload.rs
+++ b/fyrox-impl/src/engine/hotreload.rs
@@ -38,6 +38,7 @@ use crate::{
     script::Script,
 };
 use fyrox_core::visitor::error::VisitError;
+use fyrox_graph::BaseSceneGraph;
 use std::{
     ops::Deref,
     sync::{mpsc::Sender, Arc},
@@ -74,7 +75,7 @@ impl SceneState {
 
         for index in 0..scene.graph.capacity() {
             let handle = scene.graph.handle_from_index(index);
-            let Some(node) = scene.graph.try_get_mut(handle) else {
+            let Some(node) = scene.graph.try_get_node_mut(handle) else {
                 continue;
             };
 

--- a/fyrox-impl/src/engine/mod.rs
+++ b/fyrox-impl/src/engine/mod.rs
@@ -2009,7 +2009,9 @@ impl Engine {
                 {
                     let payload = result.payload;
                     if let Some(scene) = self.scenes.try_get_mut(node_task_handler.scene_handle) {
-                        if let Some(node) = scene.graph.try_get_node_mut(node_task_handler.node_handle) {
+                        if let Some(node) =
+                            scene.graph.try_get_node_mut(node_task_handler.node_handle)
+                        {
                             if let Some(mut script) = node
                                 .scripts
                                 .get_mut(node_task_handler.script_index)

--- a/fyrox-impl/src/engine/mod.rs
+++ b/fyrox-impl/src/engine/mod.rs
@@ -634,7 +634,7 @@ impl ScriptMessageDispatcher {
                     ScriptMessageKind::Hierarchical { root, routing } => match routing {
                         RoutingStrategy::Up => {
                             let mut node = root;
-                            while let Some(node_ref) = scene.graph.try_get(node) {
+                            while let Some(node_ref) = scene.graph.try_get_node(node) {
                                 let parent = node_ref.parent();
 
                                 let mut context = ScriptMessageContext {

--- a/fyrox-impl/src/engine/mod.rs
+++ b/fyrox-impl/src/engine/mod.rs
@@ -2009,7 +2009,7 @@ impl Engine {
                 {
                     let payload = result.payload;
                     if let Some(scene) = self.scenes.try_get_mut(node_task_handler.scene_handle) {
-                        if let Some(node) = scene.graph.try_get_mut(node_task_handler.node_handle) {
+                        if let Some(node) = scene.graph.try_get_node_mut(node_task_handler.node_handle) {
                             if let Some(mut script) = node
                                 .scripts
                                 .get_mut(node_task_handler.script_index)
@@ -2037,7 +2037,7 @@ impl Engine {
                                 );
 
                                 if let Some(node) =
-                                    scene.graph.try_get_mut(node_task_handler.node_handle)
+                                    scene.graph.try_get_node_mut(node_task_handler.node_handle)
                                 {
                                     if let Some(entry) =
                                         node.scripts.get_mut(node_task_handler.script_index)

--- a/fyrox-impl/src/renderer/bundle.rs
+++ b/fyrox-impl/src/renderer/bundle.rs
@@ -891,7 +891,7 @@ impl RenderDataBundleStorage {
             if let Some(lod_group) = node.lod_group() {
                 for level in lod_group.levels.iter() {
                     for &object in level.objects.iter() {
-                        if let Some(object_ref) = graph.try_get(object) {
+                        if let Some(object_ref) = graph.try_get_node(object) {
                             let distance = observer_position
                                 .translation
                                 .metric_distance(&object_ref.global_position());

--- a/fyrox-impl/src/renderer/occlusion/mod.rs
+++ b/fyrox-impl/src/renderer/occlusion/mod.rs
@@ -114,7 +114,7 @@ impl TileBuffer {
 
 fn inflated_world_aabb(graph: &Graph, object: Handle<Node>) -> Option<AxisAlignedBoundingBox> {
     let mut aabb = graph
-        .try_get(object)
+        .try_get_node(object)
         .map(|node_ref| node_ref.world_bounding_box())?;
     aabb.inflate(Vector3::repeat(0.01));
     Some(aabb)
@@ -228,7 +228,7 @@ impl OcclusionTester {
         let mut lines = Vec::new();
         for (object_index, object) in self.objects_to_test.iter().enumerate() {
             let object_index = object_index as u32;
-            let Some(node_ref) = graph.try_get(*object) else {
+            let Some(node_ref) = graph.try_get_node(*object) else {
                 continue;
             };
 

--- a/fyrox-impl/src/renderer/visibility.rs
+++ b/fyrox-impl/src/renderer/visibility.rs
@@ -282,7 +282,7 @@ impl VisibilityCache {
     /// Updates the cache by removing unused data.
     pub fn update(&mut self, graph: &Graph) {
         self.observers.retain(|observer, data| {
-            let Some(observer_ref) = graph.try_get(*observer) else {
+            let Some(observer_ref) = graph.try_get_node(*observer) else {
                 return false;
             };
 

--- a/fyrox-impl/src/resource/gltf/animation.rs
+++ b/fyrox-impl/src/resource/gltf/animation.rs
@@ -112,7 +112,7 @@ impl ImportedTarget {
         self.binding.value_binding()
     }
     fn value_in_graph(&self, graph: &Graph) -> Option<Box<[f32]>> {
-        let node: &Node = graph.try_get(self.handle)?;
+        let node: &Node = graph.try_get_node(self.handle)?;
         match self.binding {
             ImportedBinding::Position => {
                 Some(node.local_transform().position().data.as_slice().into())

--- a/fyrox-impl/src/resource/gltf/node_names.rs
+++ b/fyrox-impl/src/resource/gltf/node_names.rs
@@ -170,13 +170,13 @@ fn get_ancestor_names<'a>(
 
 fn get_ancestor_name(mut handle: Handle<Node>, depth: usize, graph: &Graph) -> Option<&str> {
     for _ in 0..depth {
-        if let Some(n) = graph.try_get(handle) {
+        if let Some(n) = graph.try_get_node(handle) {
             handle = n.parent();
         } else {
             return None;
         }
     }
-    graph.try_get(handle).map(Node::name)
+    graph.try_get_node(handle).map(Node::name)
 }
 
 fn contains_duplicate_name(names: &[&str]) -> bool {
@@ -192,7 +192,7 @@ fn contains_duplicate_name(names: &[&str]) -> bool {
 
 fn count_ancestor_depth(mut handle: Handle<Node>, list: &[Handle<Node>], graph: &Graph) -> usize {
     let mut count: usize = 0;
-    while let Some(node) = graph.try_get(handle) {
+    while let Some(node) = graph.try_get_node(handle) {
         handle = node.parent();
         if list.contains(&handle) {
             count += 1;

--- a/fyrox-impl/src/scene/animation/absm.rs
+++ b/fyrox-impl/src/scene/animation/absm.rs
@@ -333,7 +333,7 @@ impl NodeTrait for AnimationBlendingStateMachine {
     fn validate(&self, scene: &Scene) -> Result<(), String> {
         if scene
             .graph
-            .try_get(*self.animation_player)
+            .try_get_node(*self.animation_player)
             .and_then(|n| n.component_ref::<AnimationPlayer>())
             .is_none()
         {

--- a/fyrox-impl/src/scene/animation/mod.rs
+++ b/fyrox-impl/src/scene/animation/mod.rs
@@ -119,7 +119,7 @@ impl AnimationPoseExt for AnimationPose {
         for (node, local_pose) in self.poses() {
             if node.is_none() {
                 Log::writeln(MessageKind::Error, "Invalid node handle found for animation pose, most likely it means that animation retargeting failed!");
-            } else if let Some(node) = graph.try_get_mut(*node) {
+            } else if let Some(node) = graph.try_get_node_mut(*node) {
                 local_pose.values.apply(node);
             }
         }
@@ -132,7 +132,7 @@ impl AnimationPoseExt for AnimationPose {
         for (node, local_pose) in self.poses() {
             if node.is_none() {
                 Log::writeln(MessageKind::Error, "Invalid node handle found for animation pose, most likely it means that animation retargeting failed!");
-            } else if let Some(node_ref) = graph.try_get_mut(*node) {
+            } else if let Some(node_ref) = graph.try_get_node_mut(*node) {
                 callback(node_ref, *node, local_pose);
             }
         }

--- a/fyrox-impl/src/scene/base.rs
+++ b/fyrox-impl/src/scene/base.rs
@@ -1124,7 +1124,7 @@ impl Base {
                 if let Some(ancestor_node) = model
                     .get_scene()
                     .graph
-                    .try_get(self.original_handle_in_resource)
+                    .try_get_node(self.original_handle_in_resource)
                 {
                     return if ancestor_node.resource.is_none() {
                         Some(resource.clone())

--- a/fyrox-impl/src/scene/collider.rs
+++ b/fyrox-impl/src/scene/collider.rs
@@ -1044,7 +1044,7 @@ impl NodeTrait for Collider {
 
         if scene
             .graph
-            .try_get(self.parent())
+            .try_get_node(self.parent())
             .and_then(|p| p.component_ref::<RigidBody>())
             .is_none()
         {

--- a/fyrox-impl/src/scene/dim2/collider.rs
+++ b/fyrox-impl/src/scene/dim2/collider.rs
@@ -703,7 +703,7 @@ impl NodeTrait for Collider {
 
         if scene
             .graph
-            .try_get(self.parent())
+            .try_get_node(self.parent())
             .and_then(|p| p.component_ref::<RigidBody>())
             .is_none()
         {

--- a/fyrox-impl/src/scene/dim2/joint.rs
+++ b/fyrox-impl/src/scene/dim2/joint.rs
@@ -594,13 +594,13 @@ impl NodeTrait for Joint {
     }
 
     fn validate(&self, scene: &Scene) -> Result<(), String> {
-        if scene.graph.typed_ref(self.body1()).is_none() {
+        if scene.graph.try_get(self.body1()).is_none() {
             return Err("2D Joint has invalid or unassigned handle to a \
             first body, the joint will not operate!"
                 .to_string());
         }
 
-        if scene.graph.typed_ref(self.body2()).is_none() {
+        if scene.graph.try_get(self.body2()).is_none() {
             return Err("2D Joint has invalid or unassigned handle to a \
             second body, the joint will not operate!"
                 .to_string());

--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -826,12 +826,12 @@ impl PhysicsWorld {
             }),
             exclude_collider: filter
                 .exclude_collider
-                .and_then(|h| graph.try_get(h))
+                .and_then(|h| graph.try_get_node(h))
                 .and_then(|n| n.component_ref::<dim2::collider::Collider>())
                 .map(|c| c.native.get()),
             exclude_rigid_body: filter
                 .exclude_collider
-                .and_then(|h| graph.try_get(h))
+                .and_then(|h| graph.try_get_node(h))
                 .and_then(|n| n.component_ref::<dim2::rigidbody::RigidBody>())
                 .map(|c| c.native.get()),
             predicate: Some(&predicate),

--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -1221,12 +1221,12 @@ impl PhysicsWorld {
 
         if let Some(native) = self.joints.set.get_mut(joint.native.get(), false) {
             joint.body1.try_sync_model(|v| {
-                if let Some(rigid_body_node) = nodes.typed_ref(v) {
+                if let Some(rigid_body_node) = nodes.try_get(v) {
                     native.body1 = rigid_body_node.native.get();
                 }
             });
             joint.body2.try_sync_model(|v| {
-                if let Some(rigid_body_node) = nodes.typed_ref(v) {
+                if let Some(rigid_body_node) = nodes.try_get(v) {
                     native.body2 = rigid_body_node.native.get();
                 }
             });
@@ -1274,10 +1274,9 @@ impl PhysicsWorld {
             });
             let mut local_frames = joint.local_frames.borrow_mut();
             if local_frames.is_none() {
-                if let (Some(body1), Some(body2)) = (
-                    nodes.typed_ref(joint.body1()),
-                    nodes.typed_ref(joint.body2()),
-                ) {
+                if let (Some(body1), Some(body2)) =
+                    (nodes.try_get(joint.body1()), nodes.try_get(joint.body2()))
+                {
                     let (local_frame1, local_frame2) = calculate_local_frames(joint, body1, body2);
                     native.data =
                         convert_joint_params((*joint.params).clone(), local_frame1, local_frame2);
@@ -1291,7 +1290,7 @@ impl PhysicsWorld {
 
             // A native joint can be created iff both rigid bodies are correctly assigned.
             if let (Some(body1), Some(body2)) =
-                (nodes.typed_ref(body1_handle), nodes.typed_ref(body2_handle))
+                (nodes.try_get(body1_handle), nodes.try_get(body2_handle))
             {
                 // Calculate local frames first (if needed).
                 let mut local_frames = joint.local_frames.borrow_mut();

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -1631,7 +1631,6 @@ impl<T: ObjectOrVariant<Node>> Index<Handle<T>> for Graph {
 }
 
 impl<T: ObjectOrVariant<Node>> IndexMut<Handle<T>> for Graph {
-impl<T: ObjectOrVariant<Node>> IndexMut<Handle<T>> for Graph {
     #[inline]
     fn index_mut(&mut self, index: Handle<T>) -> &mut Self::Output {
         self.try_get_mut(index)

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -66,7 +66,7 @@ use crate::{
         },
         mesh::Mesh,
         navmesh,
-        node::{container::NodeContainer, Node, NodeTrait, SyncContext, UpdateContext},
+        node::{container::NodeContainer, Node, SyncContext, UpdateContext},
         pivot::Pivot,
         sound::context::SoundContext,
         transform::TransformBuilder,
@@ -870,7 +870,7 @@ impl Graph {
         where
             F: FnMut(Handle<Node>, &Node) -> bool,
         {
-            graph.try_get(node).and_then(|n| {
+            graph.try_get_node(node).and_then(|n| {
                 if filter(node, n) {
                     let mut aabb = n.local_bounding_box();
                     if aabb.is_invalid_or_degenerate() {
@@ -1080,7 +1080,7 @@ impl Graph {
                 func: &mut impl FnMut(Handle<Node>),
             ) {
                 func(from);
-                if let Some(node) = graph.try_get(from) {
+                if let Some(node) = graph.try_get_node(from) {
                     for &child in node.children() {
                         traverse_recursive(graph, child, func)
                     }
@@ -1531,7 +1531,7 @@ impl Graph {
     #[inline]
     pub fn global_scale(&self, mut node: Handle<Node>) -> Vector3<f32> {
         let mut global_scale = Vector3::repeat(1.0);
-        while let Some(node_ref) = self.try_get(node) {
+        while let Some(node_ref) = self.try_get_node(node) {
             global_scale = global_scale.component_mul(node_ref.local_transform().scale());
             node = node_ref.parent;
         }
@@ -1545,7 +1545,7 @@ impl Graph {
     where
         T: ScriptTrait,
     {
-        self.try_get(node)
+        self.try_get_node(node)
             .and_then(|node| node.try_get_script::<T>())
     }
 
@@ -1557,7 +1557,7 @@ impl Graph {
         &self,
         node: Handle<Node>,
     ) -> Option<impl Iterator<Item = &T>> {
-        self.try_get(node).map(|n| n.try_get_scripts())
+        self.try_get_node(node).map(|n| n.try_get_scripts())
     }
 
     /// Tries to borrow a node using the given handle and searches the script buffer for a script
@@ -1590,7 +1590,7 @@ impl Graph {
     where
         C: Any,
     {
-        self.try_get(node)
+        self.try_get_node(node)
             .and_then(|node| node.try_get_script_component())
     }
 
@@ -1805,12 +1805,12 @@ impl BaseSceneGraph for Graph {
     }
 
     #[inline]
-    fn try_get(&self, handle: Handle<Self::Node>) -> Option<&Self::Node> {
+    fn try_get_node(&self, handle: Handle<Self::Node>) -> Option<&Self::Node> {
         self.pool.try_borrow(handle)
     }
 
     #[inline]
-    fn try_get_mut(&mut self, handle: Handle<Self::Node>) -> Option<&mut Self::Node> {
+    fn try_get_node_mut(&mut self, handle: Handle<Self::Node>) -> Option<&mut Self::Node> {
         self.pool.try_borrow_mut(handle)
     }
 

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -480,12 +480,6 @@ impl Graph {
         self.root
     }
 
-    /// Tries to mutably borrow a node, returns Some(node) if the handle is valid, None - otherwise.
-    #[inline]
-    pub fn try_get_mut(&mut self, handle: Handle<Node>) -> Option<&mut Node> {
-        self.pool.try_borrow_mut(handle)
-    }
-
     /// Begins multi-borrow that allows you borrow to as many shared references to the graph
     /// nodes as you need and only one mutable reference to a node. See
     /// [`MultiBorrowContext::try_get`] for more info.
@@ -1567,7 +1561,7 @@ impl Graph {
     where
         T: ScriptTrait,
     {
-        self.try_get_mut(node)
+        self.try_get_node_mut(node)
             .and_then(|node| node.try_get_script_mut::<T>())
     }
 
@@ -1579,7 +1573,7 @@ impl Graph {
         &mut self,
         node: Handle<Node>,
     ) -> Option<impl Iterator<Item = &mut T>> {
-        self.try_get_mut(node).map(|n| n.try_get_scripts_mut())
+        self.try_get_node_mut(node).map(|n| n.try_get_scripts_mut())
     }
 
     /// Tries to borrow a node and find a component of the given type `C` across **all** available
@@ -1602,7 +1596,7 @@ impl Graph {
     where
         C: Any,
     {
-        self.try_get_mut(node)
+        self.try_get_node_mut(node)
             .and_then(|node| node.try_get_script_component_mut())
     }
 

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -1625,7 +1625,7 @@ impl<T: ObjectOrVariant<Node>> Index<Handle<T>> for Graph {
 
     #[inline]
     fn index(&self, index: Handle<T>) -> &Self::Output {
-        self.typed_ref(index)
+        self.try_get(index)
             .expect("The node handle is invalid or the object it points to has different type.")
     }
 }
@@ -1633,7 +1633,7 @@ impl<T: ObjectOrVariant<Node>> Index<Handle<T>> for Graph {
 impl<T: ObjectOrVariant<Node>> IndexMut<Handle<T>> for Graph {
     #[inline]
     fn index_mut(&mut self, index: Handle<T>) -> &mut Self::Output {
-        self.typed_mut(index)
+        self.try_get_mut(index)
             .expect("The node handle is invalid or the object it points to has different type.")
     }
 }
@@ -1838,11 +1838,11 @@ impl SceneGraph for Graph {
         self.pool.iter_mut()
     }
 
-    fn typed_ref<U: ObjectOrVariant<Node>>(&self, handle: Handle<U>) -> Option<&U> {
+    fn try_get<U: ObjectOrVariant<Node>>(&self, handle: Handle<U>) -> Option<&U> {
         self.pool.try_get(handle)
     }
 
-    fn typed_mut<U: ObjectOrVariant<Node>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
+    fn try_get_mut<U: ObjectOrVariant<Node>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
         self.pool.try_get_mut(handle)
     }
 }

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -1845,11 +1845,11 @@ impl SceneGraph for Graph {
     }
 
     fn typed_ref<U: ObjectOrVariant<Node>>(&self, handle: Handle<U>) -> Option<&U> {
-        self.pool.typed_ref(handle)
+        self.pool.try_get(handle)
     }
 
     fn typed_mut<U: ObjectOrVariant<Node>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
-        self.pool.typed_mut(handle)
+        self.pool.try_get_mut(handle)
     }
 }
 
@@ -2346,7 +2346,7 @@ mod test {
         assert!(graph[c].global_visibility());
         assert!(graph[d].global_visibility());
 
-        assert!(!graph.pool.typed_ref(a).unwrap().is_globally_enabled());
+        assert!(!graph.pool.try_get(a).unwrap().is_globally_enabled());
         assert!(!graph[b].is_globally_enabled());
         assert!(!graph[c].is_globally_enabled());
         assert!(!graph[d].is_globally_enabled());
@@ -2358,21 +2358,18 @@ mod test {
         let pivot = PivotBuilder::new(BaseBuilder::new()).build(&mut graph);
         let rigid_body = RigidBodyBuilder::new(BaseBuilder::new()).build(&mut graph);
 
-        assert!(graph.pool.typed_ref(pivot).is_some());
-        assert!(graph.pool.typed_ref(pivot.transmute::<Pivot>()).is_some());
-        assert!(graph
-            .pool
-            .typed_ref(pivot.transmute::<RigidBody>())
-            .is_none());
+        assert!(graph.pool.try_get(pivot).is_some());
+        assert!(graph.pool.try_get(pivot.transmute::<Pivot>()).is_some());
+        assert!(graph.pool.try_get(pivot.transmute::<RigidBody>()).is_none());
 
-        assert!(graph.pool.typed_ref(rigid_body).is_some());
+        assert!(graph.pool.try_get(rigid_body).is_some());
         assert!(graph
             .pool
-            .typed_ref(rigid_body.transmute::<RigidBody>())
+            .try_get(rigid_body.transmute::<RigidBody>())
             .is_some());
         assert!(graph
             .pool
-            .typed_ref(rigid_body.transmute::<Pivot>())
+            .try_get(rigid_body.transmute::<Pivot>())
             .is_none());
     }
 }

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -1781,12 +1781,12 @@ impl PhysicsWorld {
 
         if let Some(native) = self.joints.set.get_mut(joint.native.get(), false) {
             joint.body1.try_sync_model(|v| {
-                if let Some(rigid_body_node) = nodes.typed_ref(v) {
+                if let Some(rigid_body_node) = nodes.try_get(v) {
                     native.body1 = rigid_body_node.native.get();
                 }
             });
             joint.body2.try_sync_model(|v| {
-                if let Some(rigid_body_node) = nodes.typed_ref(v) {
+                if let Some(rigid_body_node) = nodes.try_get(v) {
                     native.body2 = rigid_body_node.native.get();
                 }
             });
@@ -1839,8 +1839,8 @@ impl PhysicsWorld {
             let mut local_frames = joint.local_frames.borrow_mut();
             if local_frames.is_none() {
                 if let (Some(body1), Some(body2)) = (
-                    nodes.typed_ref(joint.body1()),
-                    nodes.typed_ref(joint.body2()),
+                    nodes.try_get(joint.body1()),
+                    nodes.try_get(joint.body2()),
                 ) {
                     let (local_frame1, local_frame2) = calculate_local_frames(joint, body1, body2);
                     native.data =
@@ -1857,10 +1857,10 @@ impl PhysicsWorld {
             // native bodies exists.
             if let (Some(body1), Some(body2)) = (
                 nodes
-                    .typed_ref(body1_handle)
+                    .try_get(body1_handle)
                     .filter(|b| self.bodies.get(b.native.get()).is_some()),
                 nodes
-                    .typed_ref(body2_handle)
+                    .try_get(body2_handle)
                     .filter(|b| self.bodies.get(b.native.get()).is_some()),
             ) {
                 // Calculate local frames first (if needed).

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -1838,10 +1838,9 @@ impl PhysicsWorld {
 
             let mut local_frames = joint.local_frames.borrow_mut();
             if local_frames.is_none() {
-                if let (Some(body1), Some(body2)) = (
-                    nodes.try_get(joint.body1()),
-                    nodes.try_get(joint.body2()),
-                ) {
+                if let (Some(body1), Some(body2)) =
+                    (nodes.try_get(joint.body1()), nodes.try_get(joint.body2()))
+                {
                     let (local_frame1, local_frame2) = calculate_local_frames(joint, body1, body2);
                     native.data =
                         convert_joint_params((*joint.params).clone(), local_frame1, local_frame2);

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -1310,12 +1310,12 @@ impl PhysicsWorld {
             }),
             exclude_collider: filter
                 .exclude_collider
-                .and_then(|h| graph.try_get(h))
+                .and_then(|h| graph.try_get_node(h))
                 .and_then(|n| n.component_ref::<collider::Collider>())
                 .map(|c| c.native.get()),
             exclude_rigid_body: filter
                 .exclude_collider
-                .and_then(|h| graph.try_get(h))
+                .and_then(|h| graph.try_get_node(h))
                 .and_then(|n| n.component_ref::<rigidbody::RigidBody>())
                 .map(|c| c.native.get()),
             predicate: Some(&predicate),

--- a/fyrox-impl/src/scene/joint.rs
+++ b/fyrox-impl/src/scene/joint.rs
@@ -679,13 +679,13 @@ impl NodeTrait for Joint {
     }
 
     fn validate(&self, scene: &Scene) -> Result<(), String> {
-        if scene.graph.typed_ref(self.body1()).is_none() {
+        if scene.graph.try_get(self.body1()).is_none() {
             return Err("3D Joint has invalid or unassigned handle to a \
             first body, the joint will not operate!"
                 .to_string());
         }
 
-        if scene.graph.typed_ref(self.body2()).is_none() {
+        if scene.graph.try_get(self.body2()).is_none() {
             return Err("3D Joint has invalid or unassigned handle to a \
             second body, the joint will not operate!"
                 .to_string());

--- a/fyrox-impl/src/scene/mesh/mod.rs
+++ b/fyrox-impl/src/scene/mesh/mod.rs
@@ -753,7 +753,7 @@ impl NodeTrait for Mesh {
                                     .bones
                                     .iter()
                                     .map(|bone_handle| {
-                                        if let Some(bone_node) = ctx.graph.try_get(*bone_handle) {
+                                        if let Some(bone_node) = ctx.graph.try_get_node(*bone_handle) {
                                             bone_node.global_transform()
                                                 * bone_node.inv_bind_pose_transform()
                                         } else {

--- a/fyrox-impl/src/scene/mesh/mod.rs
+++ b/fyrox-impl/src/scene/mesh/mod.rs
@@ -775,7 +775,9 @@ impl NodeTrait for Mesh {
                                     .bones
                                     .iter()
                                     .map(|bone_handle| {
-                                        if let Some(bone_node) = ctx.graph.try_get_node(*bone_handle) {
+                                        if let Some(bone_node) =
+                                            ctx.graph.try_get_node(*bone_handle)
+                                        {
                                             bone_node.global_transform()
                                                 * bone_node.inv_bind_pose_transform()
                                         } else {

--- a/fyrox-impl/src/scene/node/mod.rs
+++ b/fyrox-impl/src/scene/node/mod.rs
@@ -61,10 +61,11 @@ use crate::{
         Scene,
     },
 };
-use fyrox_core::define_as_any_trait;
+use fyrox_core::{define_as_any_trait, pool::ObjectOrVariantHelper};
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
+    marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
@@ -232,6 +233,17 @@ pub trait NodeTrait: BaseNodeTrait + Reflect + Visit + ComponentProvider {
     /// provide centralized diagnostics for scene graph.
     fn validate(&self, #[allow(unused_variables)] scene: &Scene) -> Result<(), String> {
         Ok(())
+    }
+}
+
+// Essentially implements ObjectOrVariant for NodeTrait types.
+// See ObjectOrVariantHelper for the cause of the indirection.
+impl<T: NodeTrait> ObjectOrVariantHelper<Node, T> for PhantomData<T> {
+    fn convert_to_dest_type_helper(node: &Node) -> Option<&T> {
+        NodeAsAny::as_any(node.0.deref()).downcast_ref()
+    }
+    fn convert_to_dest_type_helper_mut(node: &mut Node) -> Option<&mut T> {
+        NodeAsAny::as_any_mut(node.0.deref_mut()).downcast_mut()
     }
 }
 

--- a/fyrox-impl/src/script/mod.rs
+++ b/fyrox-impl/src/script/mod.rs
@@ -50,7 +50,7 @@ use std::{
 
 use crate::engine::input::InputState;
 pub use fyrox_core_derive::ScriptMessagePayload;
-
+use fyrox_graph::BaseSceneGraph;
 pub mod constructor;
 
 pub(crate) trait UniversalScriptContext {
@@ -424,7 +424,7 @@ pub struct ScriptContext<'a, 'b, 'c> {
 
 impl UniversalScriptContext for ScriptContext<'_, '_, '_> {
     fn node(&mut self) -> Option<&mut Node> {
-        self.scene.graph.try_get_mut(self.handle)
+        self.scene.graph.try_get_node_mut(self.handle)
     }
 
     fn destroy_script_deferred(&self, script: Script, index: usize) {
@@ -508,7 +508,7 @@ pub struct ScriptMessageContext<'a, 'b, 'c> {
 
 impl UniversalScriptContext for ScriptMessageContext<'_, '_, '_> {
     fn node(&mut self) -> Option<&mut Node> {
-        self.scene.graph.try_get_mut(self.handle)
+        self.scene.graph.try_get_node_mut(self.handle)
     }
 
     fn destroy_script_deferred(&self, script: Script, index: usize) {
@@ -583,7 +583,7 @@ pub struct ScriptDeinitContext<'a, 'b, 'c> {
 
 impl UniversalScriptContext for ScriptDeinitContext<'_, '_, '_> {
     fn node(&mut self) -> Option<&mut Node> {
-        self.scene.graph.try_get_mut(self.node_handle)
+        self.scene.graph.try_get_node_mut(self.node_handle)
     }
 
     fn destroy_script_deferred(&self, script: Script, index: usize) {

--- a/fyrox-ui/src/animation.rs
+++ b/fyrox-ui/src/animation.rs
@@ -38,7 +38,6 @@ use crate::{
     BuildContext, Control, UiNode, UserInterface,
 };
 use fyrox_graph::constructor::{ConstructorProvider, GraphNodeConstructor};
-use fyrox_graph::BaseSceneGraph;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -116,7 +115,7 @@ impl AnimationPoseExt for AnimationPose {
         for (node, local_pose) in self.poses() {
             if node.is_none() {
                 Log::writeln(MessageKind::Error, "Invalid node handle found for animation pose, most likely it means that animation retargeting failed!");
-            } else if let Some(node) = ui.try_get_mut(*node) {
+            } else if let Some(node) = ui.try_get_node_mut(*node) {
                 node.invalidate_layout();
 
                 local_pose.values.apply(node);

--- a/fyrox-ui/src/build.rs
+++ b/fyrox-ui/src/build.rs
@@ -146,7 +146,7 @@ impl BuildContext<'_> {
 
     /// Tries to fetch the node by its handle. Returns `None` if the handle is invalid.
     pub fn try_get_node(&self, node: Handle<UiNode>) -> Option<&UiNode> {
-        self.ui.try_get(node)
+        self.ui.try_get_node(node)
     }
 
     /// Tries to fetch the node by its handle. Returns `None` if the handle is invalid.

--- a/fyrox-ui/src/color/gradient.rs
+++ b/fyrox-ui/src/color/gradient.rs
@@ -285,7 +285,7 @@ impl Control for ColorGradientEditor {
                     gradient,
                 ));
             } else if message.destination() == self.remove_point
-                && ui.try_get(self.context_menu_target.get()).is_some()
+                && ui.try_get_node(self.context_menu_target.get()).is_some()
             {
                 let gradient = self.fetch_gradient(self.context_menu_target.get(), ui);
 
@@ -333,7 +333,7 @@ impl Control for ColorGradientEditor {
 
                 if message.destination() == self.point_context_menu.handle() {
                     if let Some(point) = ui
-                        .try_get(self.context_menu_target.get())
+                        .try_get_node(self.context_menu_target.get())
                         .and_then(|n| n.query_component::<ColorPoint>())
                     {
                         let mut msg = ColorFieldMessage::color(

--- a/fyrox-ui/src/control.rs
+++ b/fyrox-ui/src/control.rs
@@ -26,11 +26,12 @@ use crate::{
     widget::Widget,
     UiNode, UserInterface,
 };
-use fyrox_core::define_as_any_trait;
+use fyrox_core::{define_as_any_trait, pool::ObjectOrVariant};
 
 use fyrox_core::algebra::Matrix3;
 use std::{
     any::Any,
+    marker::PhantomData,
     ops::{Deref, DerefMut},
     sync::mpsc::Sender,
 };
@@ -354,5 +355,16 @@ pub trait Control:
         #[allow(unused_variables)] ui: &UserInterface,
     ) -> bool {
         *self.allow_drop
+    }
+}
+
+// Essentially implements ObjectOrVariant for NodeTrait types.
+// See ObjectOrVariantHelper for the cause of the indirection.
+impl<T: Control> ObjectOrVariant<UiNode> for PhantomData<T> {
+    fn convert_to_dest_type(node: &UiNode) -> Option<&Self> {
+        ControlAsAny::as_any(node.0.deref()).downcast_ref()
+    }
+    fn convert_to_dest_type_mut(node: &mut UiNode) -> Option<&mut Self> {
+        ControlAsAny::as_any_mut(node.0.deref_mut()).downcast_mut()
     }
 }

--- a/fyrox-ui/src/dock/config.rs
+++ b/fyrox-ui/src/dock/config.rs
@@ -76,7 +76,7 @@ impl TileContentDescriptor {
         match tile_content {
             TileContent::Empty => Self::Empty,
             TileContent::Window(window) => Self::Window(
-                ui.try_get(*window)
+                ui.try_get_node(*window)
                     .map(|w| w.name.clone())
                     .unwrap_or_default(),
             ),
@@ -86,7 +86,7 @@ impl TileContentDescriptor {
                     names: windows
                         .iter()
                         .map(|window| {
-                            ui.try_get(*window)
+                            ui.try_get_node(*window)
                                 .map(|w| w.name.clone())
                                 .unwrap_or_default()
                         })
@@ -151,7 +151,7 @@ fn find_window(
 
     if window_handle.is_none() {
         for other_window_handle in windows.iter().cloned() {
-            if let Some(window_node) = ui.try_get(other_window_handle) {
+            if let Some(window_node) = ui.try_get_node(other_window_handle) {
                 if &window_node.name == window_name {
                     return other_window_handle;
                 }
@@ -163,7 +163,7 @@ fn find_window(
 
 impl TileDescriptor {
     pub(super) fn from_tile_handle(handle: Handle<UiNode>, ui: &UserInterface) -> Self {
-        ui.try_get(handle)
+        ui.try_get_node(handle)
             .and_then(|t| t.query_component::<Tile>())
             .map(|t| Self {
                 content: TileContentDescriptor::from_tile(&t.content, ui),

--- a/fyrox-ui/src/dock/mod.rs
+++ b/fyrox-ui/src/dock/mod.rs
@@ -245,7 +245,7 @@ impl DockingManager {
                 .borrow()
                 .iter()
                 .filter_map(|h| {
-                    ui.try_get(*h).map(|w| FloatingWindowDescriptor {
+                    ui.try_get_node(*h).map(|w| FloatingWindowDescriptor {
                         name: w.name.clone(),
                         position: w.actual_local_position(),
                         size: w.actual_local_size(),
@@ -270,7 +270,7 @@ impl DockingManager {
             let mut stack = vec![root_tile_handle];
             while let Some(tile_handle) = stack.pop() {
                 if let Some(tile) = ui
-                    .try_get(tile_handle)
+                    .try_get_node(tile_handle)
                     .and_then(|n| n.query_component::<Tile>())
                 {
                     match tile.content {

--- a/fyrox-ui/src/file_browser/menu.rs
+++ b/fyrox-ui/src/file_browser/menu.rs
@@ -362,7 +362,7 @@ impl ItemContextMenu {
     }
 
     fn item_path(&self, ui: &UserInterface) -> Option<PathBuf> {
-        ui.try_get(self.base_menu.popup.placement.target())
+        ui.try_get_node(self.base_menu.popup.placement.target())
             .and_then(|n| n.user_data_cloned::<PathBuf>())
     }
 }

--- a/fyrox-ui/src/file_browser/mod.rs
+++ b/fyrox-ui/src/file_browser/mod.rs
@@ -500,7 +500,7 @@ impl Control for FileBrowser {
                 && message.direction() == MessageDirection::FromWidget
             {
                 if let Some(&first_selected) = selection.first() {
-                    if let Some(first_selected_ref) = ui.try_get(first_selected) {
+                    if let Some(first_selected_ref) = ui.try_get_node(first_selected) {
                         let mut path = first_selected_ref
                             .user_data_cloned::<PathBuf>()
                             .unwrap()

--- a/fyrox-ui/src/grid.rs
+++ b/fyrox-ui/src/grid.rs
@@ -446,7 +446,7 @@ impl Grid {
                         .iter()
                         .copied()
                         .filter(|&c| {
-                            let Some(child_ref) = ui.try_get(c) else {
+                            let Some(child_ref) = ui.try_get_node(c) else {
                                 return false;
                             };
                             child_ref.row() == row_index && child_ref.column() == column_index
@@ -470,7 +470,7 @@ impl Grid {
             }
         }
         for handle in self.children() {
-            let Some(node) = ui.try_get(*handle) else {
+            let Some(node) = ui.try_get_node(*handle) else {
                 continue;
             };
             let Some(row) = rows.get_mut(node.row()) else {
@@ -507,7 +507,7 @@ impl Grid {
         measure_width: bool,
         measure_height: bool,
     ) {
-        let Some(node) = ui.try_get(child) else {
+        let Some(node) = ui.try_get_node(child) else {
             return;
         };
         let mut rows = self.rows.borrow_mut();

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -673,7 +673,7 @@ impl Inspector {
     ) -> Option<&ContextEntry> {
         let mut parent_handle = from;
 
-        while let Some(parent) = ui.try_get(parent_handle) {
+        while let Some(parent) = ui.try_get_node(parent_handle) {
             for entry in self.context.entries.iter() {
                 if entry.property_container == parent_handle {
                     return Some(entry);

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -1292,7 +1292,7 @@ impl UserInterface {
                         func: &mut impl FnMut(Handle<UiNode>),
                     ) {
                         func(from);
-                        if let Some(node) = graph.try_get(from) {
+                        if let Some(node) = graph.try_get_node(from) {
                             for &child in node.children() {
                                 traverse_recursive(graph, child, func)
                             }
@@ -1351,10 +1351,10 @@ impl UserInterface {
             self.update_visual_transform(root);
 
             // Recalculate clip bounds, because they depend on the visual transform.
-            if let Some(root_ref) = self.try_get(root) {
+            if let Some(root_ref) = self.try_get_node(root) {
                 self.calculate_clip_bounds(
                     root,
-                    self.try_get(root_ref.parent())
+                    self.try_get_node(root_ref.parent())
                         .map(|c| c.clip_bounds())
                         .unwrap_or_else(|| {
                             Rect::new(0.0, 0.0, self.screen_size.x, self.screen_size.y)
@@ -1420,7 +1420,7 @@ impl UserInterface {
         self.style = style;
 
         fn notify_depth_first(node: Handle<UiNode>, ui: &UserInterface) {
-            if let Some(node_ref) = ui.try_get(node) {
+            if let Some(node_ref) = ui.try_get_node(node) {
                 for child in node_ref.children.iter() {
                     notify_depth_first(*child, ui);
                 }
@@ -2090,8 +2090,8 @@ impl UserInterface {
                             margin,
                         } => {
                             if let (Some(node), Some(relative_node)) = (
-                                self.try_get(message.destination()),
-                                self.try_get(*relative_to),
+                                self.try_get_node(message.destination()),
+                                self.try_get_node(*relative_to),
                             ) {
                                 // Calculate new anchor point in screen coordinate system.
                                 let relative_node_screen_size = relative_node.screen_bounds().size;
@@ -2147,7 +2147,7 @@ impl UserInterface {
                                     }
                                 }
 
-                                if let Some(parent) = self.try_get(node.parent()) {
+                                if let Some(parent) = self.try_get_node(node.parent()) {
                                     // Transform screen anchor point into the local coordinate system
                                     // of the parent node.
                                     let local_anchor_point =
@@ -2612,7 +2612,7 @@ impl UserInterface {
                 state,
                 text,
             } => {
-                if let Some(keyboard_focus_node) = self.try_get(self.keyboard_focus_node) {
+                if let Some(keyboard_focus_node) = self.try_get_node(self.keyboard_focus_node) {
                     if keyboard_focus_node.is_globally_visible() {
                         match state {
                             ButtonState::Pressed => {
@@ -3262,12 +3262,12 @@ impl BaseSceneGraph for UserInterface {
     }
 
     #[inline]
-    fn try_get(&self, handle: Handle<Self::Node>) -> Option<&Self::Node> {
+    fn try_get_node(&self, handle: Handle<Self::Node>) -> Option<&Self::Node> {
         self.nodes.try_borrow(handle)
     }
 
     #[inline]
-    fn try_get_mut(&mut self, handle: Handle<Self::Node>) -> Option<&mut Self::Node> {
+    fn try_get_node_mut(&mut self, handle: Handle<Self::Node>) -> Option<&mut Self::Node> {
         self.nodes.try_borrow_mut(handle)
     }
 

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -3386,11 +3386,11 @@ impl SceneGraph for UserInterface {
     }
 
     fn typed_ref<U: ObjectOrVariant<UiNode>>(&self, handle: Handle<U>) -> Option<&U> {
-        self.nodes.typed_ref(handle)
+        self.nodes.try_get(handle)
     }
 
     fn typed_mut<U: ObjectOrVariant<UiNode>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
-        self.nodes.typed_mut(handle)
+        self.nodes.try_get_mut(handle)
     }
 }
 

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -3385,11 +3385,11 @@ impl SceneGraph for UserInterface {
         self.nodes.iter_mut()
     }
 
-    fn typed_ref<U: ObjectOrVariant<UiNode>>(&self, handle: Handle<U>) -> Option<&U> {
+    fn try_get<U: ObjectOrVariant<UiNode>>(&self, handle: Handle<U>) -> Option<&U> {
         self.nodes.try_get(handle)
     }
 
-    fn typed_mut<U: ObjectOrVariant<UiNode>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
+    fn try_get_mut<U: ObjectOrVariant<UiNode>>(&mut self, handle: Handle<U>) -> Option<&mut U> {
         self.nodes.try_get_mut(handle)
     }
 }

--- a/fyrox-ui/src/log.rs
+++ b/fyrox-ui/src/log.rs
@@ -85,7 +85,7 @@ impl ContextMenu {
         } else if let Some(MenuItemMessage::Click) = message.data() {
             if message.destination() == self.copy {
                 if let Some(field) = ui
-                    .try_get(self.placement_target)
+                    .try_get_node(self.placement_target)
                     .and_then(|n| n.query_component::<Text>())
                 {
                     let text = field.text();

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -1314,7 +1314,7 @@ impl Control for ContextMenu {
 
         if let Some(WidgetMessage::KeyDown(key_code)) = message.data() {
             if !message.handled() {
-                if let Some(parent_menu_item) = ui.try_get(self.parent_menu_item) {
+                if let Some(parent_menu_item) = ui.try_get_node(self.parent_menu_item) {
                     if keyboard_navigation(
                         ui,
                         *key_code,

--- a/fyrox-ui/src/popup.rs
+++ b/fyrox-ui/src/popup.rs
@@ -358,13 +358,13 @@ fn adjust_placement_position(
 
 impl Popup {
     fn left_top_placement(&self, ui: &UserInterface, target: Handle<UiNode>) -> Vector2<f32> {
-        ui.try_get(target)
+        ui.try_get_node(target)
             .map(|n| n.screen_position())
             .unwrap_or_default()
     }
 
     fn right_top_placement(&self, ui: &UserInterface, target: Handle<UiNode>) -> Vector2<f32> {
-        ui.try_get(target)
+        ui.try_get_node(target)
             .map(|n| n.screen_position() + Vector2::new(n.actual_global_size().x, 0.0))
             .unwrap_or_else(|| {
                 Vector2::new(ui.screen_size().x - self.widget.actual_global_size().x, 0.0)
@@ -372,13 +372,13 @@ impl Popup {
     }
 
     fn center_placement(&self, ui: &UserInterface, target: Handle<UiNode>) -> Vector2<f32> {
-        ui.try_get(target)
+        ui.try_get_node(target)
             .map(|n| n.screen_position() + n.actual_global_size().scale(0.5))
             .unwrap_or_else(|| (ui.screen_size - self.widget.actual_global_size()).scale(0.5))
     }
 
     fn left_bottom_placement(&self, ui: &UserInterface, target: Handle<UiNode>) -> Vector2<f32> {
-        ui.try_get(target)
+        ui.try_get_node(target)
             .map(|n| n.screen_position() + Vector2::new(0.0, n.actual_global_size().y))
             .unwrap_or_else(|| {
                 Vector2::new(0.0, ui.screen_size().y - self.widget.actual_global_size().y)
@@ -386,7 +386,7 @@ impl Popup {
     }
 
     fn right_bottom_placement(&self, ui: &UserInterface, target: Handle<UiNode>) -> Vector2<f32> {
-        ui.try_get(target)
+        ui.try_get_node(target)
             .map(|n| n.screen_position() + n.actual_global_size())
             .unwrap_or_else(|| ui.screen_size - self.widget.actual_global_size())
     }

--- a/fyrox-ui/src/scroll_panel.rs
+++ b/fyrox-ui/src/scroll_panel.rs
@@ -205,7 +205,7 @@ impl ScrollPanel {
         children_size
     }
     fn bring_into_view(&self, ui: &UserInterface, handle: Handle<UiNode>) {
-        let Some(node_to_focus_ref) = ui.try_get(handle) else {
+        let Some(node_to_focus_ref) = ui.try_get_node(handle) else {
             return;
         };
         let mut parent = handle;

--- a/fyrox-ui/src/tree.rs
+++ b/fyrox-ui/src/tree.rs
@@ -1042,7 +1042,7 @@ impl Control for TreeRoot {
                     KeyCode::ArrowLeft => {
                         if let Some(selection) = self.selected.first() {
                             if let Some(item) = ui
-                                .try_get(*selection)
+                                .try_get_node(*selection)
                                 .and_then(|n| n.component_ref::<Tree>())
                             {
                                 if item.is_expanded {
@@ -1109,7 +1109,7 @@ impl TreeRoot {
     fn move_selection(&self, ui: &UserInterface, direction: Direction, expand: bool) {
         if let Some(selected_item) = self.selected.first() {
             let Some(item) = ui
-                .try_get(*selected_item)
+                .try_get_node(*selected_item)
                 .and_then(|n| n.component_ref::<Tree>())
             else {
                 return;

--- a/template-core/src/lib.rs
+++ b/template-core/src/lib.rs
@@ -506,7 +506,7 @@ version = "0.1.0"
 edition = "2021"
 
 [package.metadata.android]
-# This folder is used as a temporary storage for assets. Project exporter will clone everything 
+# This folder is used as a temporary storage for assets. Project exporter will clone everything
 # from data folder to this folder and cargo-apk will create the apk with these assets.
 assets = "assets"
 strip = "strip"
@@ -668,6 +668,7 @@ pub fn init_script(root_path: &Path, raw_name: &str) -> Result<(), String> {
 use fyrox::{{
     core::{{visitor::prelude::*, reflect::prelude::*, type_traits::prelude::*}},
     event::Event, script::{{ScriptContext, ScriptDeinitContext, ScriptTrait}},
+    graph::prelude::*,
 }};
 
 #[derive(Visit, Reflect, Default, Debug, Clone, TypeUuidProvider, ComponentProvider)]

--- a/template-core/src/lib.rs
+++ b/template-core/src/lib.rs
@@ -159,6 +159,7 @@ dylib-engine = ["fyrox/dylib"]
 use fyrox::{
     core::pool::Handle, core::visitor::prelude::*, core::reflect::prelude::*,
     event::Event,
+    graph::prelude::*,
     gui::{message::UiMessage, UserInterface},
     plugin::{Plugin, PluginContext, PluginRegistrationContext},
     scene::Scene,

--- a/template-core/src/lib.rs
+++ b/template-core/src/lib.rs
@@ -156,10 +156,11 @@ dylib-engine = ["fyrox/dylib"]
     write_file(
         base_path.join("game/src/lib.rs"),
         r#"//! Game project.
+#[allow(unused_imports)]
+use fyrox::graph::prelude::*;
 use fyrox::{
     core::pool::Handle, core::visitor::prelude::*, core::reflect::prelude::*,
     event::Event,
-    graph::prelude::*,
     gui::{message::UiMessage, UserInterface},
     plugin::{Plugin, PluginContext, PluginRegistrationContext},
     scene::Scene,
@@ -667,10 +668,11 @@ pub fn init_script(root_path: &Path, raw_name: &str) -> Result<(), String> {
         file_name,
         format!(
             r#"
+#[allow(unused_imports)]
+use fyrox::graph::prelude::*;
 use fyrox::{{
     core::{{visitor::prelude::*, reflect::prelude::*, type_traits::prelude::*}},
     event::Event, script::{{ScriptContext, ScriptDeinitContext, ScriptTrait}},
-    graph::prelude::*,
 }};
 
 #[derive(Visit, Reflect, Default, Debug, Clone, TypeUuidProvider, ComponentProvider)]


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
We need a uniform naming convention for the functionality of retrieving pool objects or their variants from the pool and the graph. Currently there are `typed_ref`, `try_get_of_type`, etc. I think it is beneficial to unify them into the vanilla name `try_get`. For current occurrences of `try_get` for the Graph, I renamed it to `try_get_node`. Specifying "node" for Graph is appropriate because `Graph` uses `Node` as the pool object type.

I also added a prelude module for the fyrox_graph crate containing `AbstractSceneGraph`, `BaseSceneGraph` and `SceneGraph`, and added `use fyrox::graph::prelude::*` in the script template so that functionalities like try_get are exposed by default.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
The code passed all auto tests.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
