### PR TITLE
fixed ObjectOrVariantHelper implementation for UiNode variants

### DIFF
--- a/fyrox-ui/src/control.rs
+++ b/fyrox-ui/src/control.rs
@@ -26,7 +26,7 @@ use crate::{
     widget::Widget,
     UiNode, UserInterface,
 };
-use fyrox_core::{define_as_any_trait, pool::ObjectOrVariant};
+use fyrox_core::{define_as_any_trait, pool::ObjectOrVariantHelper};
 
 use fyrox_core::algebra::Matrix3;
 use std::{
@@ -358,13 +358,13 @@ pub trait Control:
     }
 }
 
-// Essentially implements ObjectOrVariant for NodeTrait types.
+// Essentially implements ObjectOrVariant for Control types.
 // See ObjectOrVariantHelper for the cause of the indirection.
-impl<T: Control> ObjectOrVariant<UiNode> for PhantomData<T> {
-    fn convert_to_dest_type(node: &UiNode) -> Option<&Self> {
+impl<T: Control> ObjectOrVariantHelper<UiNode, T> for PhantomData<T> {
+    fn convert_to_dest_type_helper(node: &UiNode) -> Option<&T> {
         ControlAsAny::as_any(node.0.deref()).downcast_ref()
     }
-    fn convert_to_dest_type_mut(node: &mut UiNode) -> Option<&mut Self> {
+    fn convert_to_dest_type_helper_mut(node: &mut UiNode) -> Option<&mut T> {
         ControlAsAny::as_any_mut(node.0.deref_mut()).downcast_mut()
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Sorry, but in the previous pull request from me that added ObjectOrVariant trait, I implemented the ObjectOrVariant trait for UiNode variants incorrectly. I am supposed to implement ObjectOrVariantHelper for PhantomData<T> where T: Control, but I instead implemented ObjectOrVariant for PhantomData<T> where T: Control.

I found the bug when I tried to use typed_ref method of a UserInterface to get a UiNode variant. Now it should be fixed.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->

## Screenshots/GIFs
<img width="1919" height="330" alt="image" src="https://github.com/user-attachments/assets/b6fb63b0-7d4d-4073-9ab5-2246f997cc33" />


## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
