### PR TITLE
Improving debugging for graphs and visitors.

### DIFF
--- a/editor/src/plugins/inspector/editors/surface.rs
+++ b/editor/src/plugins/inspector/editors/surface.rs
@@ -207,15 +207,19 @@ fn surface_data_info(resource_manager: &ResourceManager, data: &SurfaceResource)
         .resource_path(data.as_ref())
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|| "External".to_string());
-    let guard = data.data_ref();
-    format!(
-        "{}\nVertices: {}\nTriangles: {}\nUse Count: {}\nId: {}",
-        kind,
-        guard.vertex_buffer.vertex_count(),
-        guard.geometry_buffer.len(),
-        use_count,
-        id
-    )
+    if data.is_ok() {
+        let guard = data.data_ref();
+        format!(
+            "{}\nVertices: {}\nTriangles: {}\nUse Count: {}\nId: {}",
+            kind,
+            guard.vertex_buffer.vertex_count(),
+            guard.geometry_buffer.len(),
+            use_count,
+            id
+        )
+    } else {
+        format!("{}\nNot loaded\nUse Count: {}\nId: {}", kind, use_count, id)
+    }
 }
 
 impl SurfaceDataPropertyEditor {

--- a/fyrox-core/src/io.rs
+++ b/fyrox-core/src/io.rs
@@ -27,6 +27,8 @@ pub enum FileError {
     Custom(String),
 }
 
+impl std::error::Error for FileError {}
+
 impl Display for FileError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -64,7 +64,6 @@ const INVALID_GENERATION: u32 = 0;
 /// block. It allows to create and delete objects much faster than if they'll
 /// be allocated on heap. Also since objects stored in contiguous memory block
 /// they can be effectively accessed because such memory layout is cache-friendly.
-#[derive(Debug)]
 pub struct Pool<T, P = Option<T>>
 where
     T: Sized,
@@ -72,6 +71,16 @@ where
 {
     records: Vec<PoolRecord<T, P>>,
     free_stack: Vec<u32>,
+}
+
+impl<T: Sized + Debug, P: PayloadContainer<Element = T> + 'static> Debug for Pool<T, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = f.debug_struct("Pool");
+        for (handle, value) in self.pair_iter() {
+            s.field(&handle.to_string(), value);
+        }
+        s.finish()
+    }
 }
 
 /// This trait unifies pool objects and their variants.

--- a/fyrox-core/src/visitor/impls.rs
+++ b/fyrox-core/src/visitor/impls.rs
@@ -56,7 +56,7 @@ macro_rules! impl_visit_as_field {
                             }),
                         }
                     } else {
-                        Err(VisitError::FieldDoesNotExist(name.to_owned()))
+                        Err(VisitError::field_does_not_exist(name, visitor))
                     }
                 } else if visitor.find_field(name).is_some() {
                     Err(VisitError::FieldAlreadyExists(name.to_owned()))
@@ -240,7 +240,7 @@ impl Visit for String {
                     }),
                 }
             } else {
-                Err(VisitError::FieldDoesNotExist(name.to_owned()))
+                Err(VisitError::field_does_not_exist(name, visitor))
             }
         } else if visitor.find_field(name).is_some() {
             Err(VisitError::FieldAlreadyExists(name.to_owned()))
@@ -319,11 +319,23 @@ where
                 if let Ok(res) = Rc::downcast::<T>(ptr.clone()) {
                     *self = res;
                 } else {
-                    return Err(VisitError::TypeMismatch);
+                    return Err(VisitError::TypeMismatch {
+                        expected: std::any::type_name::<T>(),
+                        actual: region.type_name_map.get(&id).unwrap_or(&"MISSING"),
+                    });
                 }
             } else {
+                region.type_name_map.insert(id, std::any::type_name::<T>());
                 region.rc_map.insert(id, self.clone());
-                unsafe { rc_to_raw(self).visit("RcData", &mut region)? };
+                let result = unsafe { rc_to_raw(self).visit("RcData", &mut region) };
+                // Sometimes visiting is done experimentally, just to see if it would succeed, and visiting continues along a different
+                // path on failure. This means that the visitor must be in a valid state even after a failure, so we must remove
+                // the invalid rc_map entry if visiting failed.
+                if result.is_err() {
+                    region.type_name_map.remove(&id);
+                    region.rc_map.remove(&id);
+                    return result;
+                }
             }
         } else {
             let (mut id, serialize_data) = region.rc_id(self);
@@ -410,11 +422,23 @@ where
                 if let Ok(res) = Arc::downcast::<T>(ptr.clone()) {
                     *self = res;
                 } else {
-                    return Err(VisitError::TypeMismatch);
+                    return Err(VisitError::TypeMismatch {
+                        expected: std::any::type_name::<T>(),
+                        actual: region.type_name_map.get(&id).unwrap_or(&"MISSING"),
+                    });
                 }
             } else {
+                region.type_name_map.insert(id, std::any::type_name::<T>());
                 region.arc_map.insert(id, self.clone());
-                unsafe { arc_to_raw(self).visit("ArcData", &mut region)? };
+                let result = unsafe { arc_to_raw(self).visit("ArcData", &mut region) };
+                // Sometimes visiting is done experimentally, just to see if it would succeed, and visiting continues along a different
+                // path on failure. This means that the visitor must be in a valid state even after a failure, so we must remove
+                // the invalid arc_map entry if visiting failed.
+                if result.is_err() {
+                    region.type_name_map.remove(&id);
+                    region.arc_map.remove(&id);
+                    return result;
+                }
             }
         } else {
             let (mut id, serialize_data) = region.arc_id(self);
@@ -444,14 +468,26 @@ where
                     if let Ok(res) = Rc::downcast::<T>(ptr.clone()) {
                         *self = Rc::downgrade(&res);
                     } else {
-                        return Err(VisitError::TypeMismatch);
+                        return Err(VisitError::TypeMismatch {
+                            expected: std::any::type_name::<T>(),
+                            actual: region.type_name_map.get(&id).unwrap_or(&"MISSING"),
+                        });
                     }
                 } else {
                     // Create new value wrapped into Rc and deserialize it.
                     let rc = Rc::new(T::default());
+                    region.type_name_map.insert(id, std::any::type_name::<T>());
                     region.rc_map.insert(id, rc.clone());
 
-                    unsafe { rc_to_raw(&rc).visit("RcData", &mut region)? };
+                    let result = unsafe { rc_to_raw(&rc).visit("RcData", &mut region) };
+                    // Sometimes visiting is done experimentally, just to see if it would succeed, and visiting continues along a different
+                    // path on failure. This means that the visitor must be in a valid state even after a failure, so we must remove
+                    // the invalid rc_map entry if visiting failed.
+                    if result.is_err() {
+                        region.type_name_map.remove(&id);
+                        region.rc_map.remove(&id);
+                        return result;
+                    }
 
                     *self = Rc::downgrade(&rc);
                 }
@@ -487,12 +523,24 @@ where
                     if let Ok(res) = Arc::downcast::<T>(ptr.clone()) {
                         *self = Arc::downgrade(&res);
                     } else {
-                        return Err(VisitError::TypeMismatch);
+                        return Err(VisitError::TypeMismatch {
+                            expected: std::any::type_name::<T>(),
+                            actual: region.type_name_map.get(&id).unwrap_or(&"MISSING"),
+                        });
                     }
                 } else {
                     let arc = Arc::new(T::default());
+                    region.type_name_map.insert(id, std::any::type_name::<T>());
                     region.arc_map.insert(id, arc.clone());
-                    unsafe { arc_to_raw(&arc).visit("ArcData", &mut region)? };
+                    let result = unsafe { arc_to_raw(&arc).visit("ArcData", &mut region) };
+                    // Sometimes visiting is done experimentally, just to see if it would succeed, and visiting continues along a different
+                    // path on failure. This means that the visitor must be in a valid state even after a failure, so we must remove
+                    // the invalid arc_map entry if visiting failed.
+                    if result.is_err() {
+                        region.type_name_map.remove(&id);
+                        region.arc_map.remove(&id);
+                        return result;
+                    }
                     *self = Arc::downgrade(&arc);
                 }
             }

--- a/fyrox-core/src/visitor/reader/ascii.rs
+++ b/fyrox-core/src/visitor/reader/ascii.rs
@@ -404,6 +404,7 @@ impl Reader for AsciiReader<'_> {
         let mut visitor = Visitor {
             nodes: Pool::new(),
             unique_id_counter: 1,
+            type_name_map: Default::default(),
             rc_map: Default::default(),
             arc_map: Default::default(),
             reading: true,

--- a/fyrox-core/src/visitor/reader/binary.rs
+++ b/fyrox-core/src/visitor/reader/binary.rs
@@ -257,6 +257,7 @@ impl Reader for BinaryReader<'_> {
         let mut visitor = Visitor {
             nodes: Pool::new(),
             unique_id_counter: 1,
+            type_name_map: Default::default(),
             rc_map: Default::default(),
             arc_map: Default::default(),
             reading: true,

--- a/fyrox-impl/src/engine/mod.rs
+++ b/fyrox-impl/src/engine/mod.rs
@@ -1059,8 +1059,8 @@ impl ResourceGraphVertex {
 
     pub fn resolve(&self) {
         Log::info(format!(
-            "Resolving {} resource from dependency graph...",
-            self.resource.kind()
+            "Resolving {:?} resource from dependency graph...",
+            self.resource.resource_uuid()
         ));
 
         // Wait until resource is fully loaded, then resolve.
@@ -2416,8 +2416,8 @@ impl Engine {
             if let ResourceEvent::Reloaded(resource) = event {
                 if let Some(model) = resource.try_cast::<Model>() {
                     Log::info(format!(
-                        "A model resource {} was reloaded, propagating changes...",
-                        model.kind()
+                        "A model resource {:?} was reloaded, propagating changes...",
+                        model.resource_uuid()
                     ));
 
                     // Build resource dependency graph and resolve it first.
@@ -2799,7 +2799,10 @@ impl Engine {
 
         // Deserialize prefab scene content.
         for (model, scene_state) in prefab_scenes {
-            Log::info(format!("Deserializing {} prefab content...", model.kind()));
+            Log::info(format!(
+                "Deserializing {:?} prefab content...",
+                model.resource_uuid()
+            ));
 
             scene_state.deserialize_into_prefab_scene(
                 &model,

--- a/fyrox-impl/src/renderer/cache/texture.rs
+++ b/fyrox-impl/src/renderer/cache/texture.rs
@@ -255,8 +255,7 @@ impl TextureCache {
                     drop(texture_data_guard);
                     err_once!(
                         texture_resource.key() as usize,
-                        "Failed to create GPU texture from {} texture. Reason: {:?}",
-                        texture_resource.kind(),
+                        "Failed to create GPU texture from texture. Reason: {:?}",
                         e,
                     );
                 }

--- a/fyrox-impl/src/resource/gltf/material.rs
+++ b/fyrox-impl/src/resource/gltf/material.rs
@@ -18,7 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     asset::{manager::ResourceManager, state::LoadError, untyped::ResourceKind, Resource},
@@ -96,6 +99,24 @@ pub enum GltfMaterialError {
     Load(LoadError),
     Base64(base64::DecodeError),
     Texture(TextureError),
+}
+
+impl std::error::Error for GltfMaterialError {}
+
+impl Display for GltfMaterialError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GltfMaterialError::ShaderLoadFailed => f.write_str("Shader load failed"),
+            GltfMaterialError::InvalidIndex => f.write_str("Invalid material index"),
+            GltfMaterialError::UnsupportedURI(uri) => {
+                write!(f, "Unsupported material URI {uri:?}")
+            }
+            GltfMaterialError::TextureNotFound(uri) => write!(f, "Texture not found: {uri:?}"),
+            GltfMaterialError::Load(error) => Display::fmt(error, f),
+            GltfMaterialError::Base64(error) => Display::fmt(error, f),
+            GltfMaterialError::Texture(error) => Display::fmt(error, f),
+        }
+    }
 }
 
 impl From<LoadError> for GltfMaterialError {

--- a/fyrox-impl/src/resource/gltf/mod.rs
+++ b/fyrox-impl/src/resource/gltf/mod.rs
@@ -47,6 +47,7 @@ use crate::scene::Scene;
 use gltf::json;
 use gltf::Document;
 use gltf::Gltf;
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -85,6 +86,27 @@ enum GltfLoadError {
     Material(GltfMaterialError),
     Surface(SurfaceDataError),
     JSON(json::Error),
+}
+
+impl std::error::Error for GltfLoadError {}
+
+impl Display for GltfLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GltfLoadError::InvalidIndex => f.write_str("Invalid index"),
+            GltfLoadError::InvalidPath => f.write_str("Invalid path"),
+            GltfLoadError::UnsupportedURI(uri) => write!(f, "Unsupported URL {uri:?}"),
+            GltfLoadError::MissingEmbeddedBin => f.write_str("Missing embedded bin"),
+            GltfLoadError::Gltf(error) => Display::fmt(error, f),
+            GltfLoadError::Texture(error) => Display::fmt(error, f),
+            GltfLoadError::File(error) => Display::fmt(error, f),
+            GltfLoadError::Base64(error) => Display::fmt(error, f),
+            GltfLoadError::Load(error) => Display::fmt(error, f),
+            GltfLoadError::Material(error) => Display::fmt(error, f),
+            GltfLoadError::Surface(error) => Display::fmt(error, f),
+            GltfLoadError::JSON(error) => Display::fmt(error, f),
+        }
+    }
 }
 
 impl From<json::Error> for GltfLoadError {

--- a/fyrox-impl/src/resource/gltf/surface.rs
+++ b/fyrox-impl/src/resource/gltf/surface.rs
@@ -41,6 +41,7 @@ use crate::{
     scene::mesh::buffer::{VertexAttributeUsage, VertexReadTrait},
 };
 
+use std::fmt::Display;
 use std::num::TryFromIntError;
 
 /// This type represents any error that may occur while importing mesh data from glTF.
@@ -83,6 +84,30 @@ pub enum SurfaceDataError {
     Fetch(buffer::VertexFetchError),
 }
 
+impl std::error::Error for SurfaceDataError {}
+
+impl Display for SurfaceDataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SurfaceDataError::CountMismatch => f.write_str("Count mismatch"),
+            SurfaceDataError::MissingPosition => f.write_str("Missing position"),
+            SurfaceDataError::MissingNormal => f.write_str("Missing normal"),
+            SurfaceDataError::MissingTexCoords => f.write_str("Missing texcoords"),
+            SurfaceDataError::MissingBoneWeight => f.write_str("Missing bone weight"),
+            SurfaceDataError::MissingBoneIndex => f.write_str("Missing bone index"),
+            SurfaceDataError::InvalidBoneIndex => f.write_str("Invalid bone index"),
+            SurfaceDataError::InvalidMode => f.write_str("Invalid mode"),
+            SurfaceDataError::InvalidIndex => f.write_str("Invalid index"),
+            SurfaceDataError::Int(error) => Display::fmt(error, f),
+            SurfaceDataError::InvalidVertexCount(geometry_type, count) => {
+                write!(f, "Cannot have {count} vertices {geometry_type}.")
+            }
+            SurfaceDataError::Validation(error) => Display::fmt(error, f),
+            SurfaceDataError::Fetch(error) => Display::fmt(error, f),
+        }
+    }
+}
+
 impl From<ValidationError> for SurfaceDataError {
     fn from(error: ValidationError) -> Self {
         SurfaceDataError::Validation(error)
@@ -106,6 +131,16 @@ pub enum GeometryType {
     Triangles,
     TriangleStrip,
     TriangleFan,
+}
+
+impl Display for GeometryType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GeometryType::Triangles => f.write_str("triangles"),
+            GeometryType::TriangleStrip => f.write_str("triangle strip"),
+            GeometryType::TriangleFan => f.write_str("triangle fan"),
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/fyrox-impl/src/resource/model/mod.rs
+++ b/fyrox-impl/src/resource/model/mod.rs
@@ -491,6 +491,12 @@ impl ModelResourceExtension for ModelResource {
     }
 
     fn begin_instantiation<'a>(&'a self, dest_scene: &'a mut Scene) -> InstantiationContext<'a> {
+        if !self.is_ok() {
+            Log::err(format!(
+                "Instantiating a model from a resource that is not loaded: {self:?}"
+            ));
+            panic!();
+        }
         InstantiationContext {
             model: self,
             dest_scene,

--- a/fyrox-impl/src/scene/camera.rs
+++ b/fyrox-impl/src/scene/camera.rs
@@ -860,7 +860,7 @@ impl Display for ColorGradingLutCreationError {
                 )
             }
             ColorGradingLutCreationError::Texture(v) => {
-                write!(f, "Texture load error: {v:?}")
+                write!(f, "Texture load error: {v}")
             }
         }
     }

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -517,6 +517,9 @@ fn make_trimesh(
 
             for surface in mesh.surfaces() {
                 let shared_data = surface.data();
+                if !shared_data.is_ok() {
+                    continue;
+                }
                 let shared_data = shared_data.data_ref();
 
                 let vertices = &shared_data.vertex_buffer;

--- a/fyrox-impl/src/scene/mesh/mod.rs
+++ b/fyrox-impl/src/scene/mesh/mod.rs
@@ -639,8 +639,10 @@ impl NodeTrait for Mesh {
             } else {
                 for surface in self.surfaces.iter() {
                     let data = surface.data();
-                    let data = data.data_ref();
-                    extend_aabb_from_vertex_buffer(&data.vertex_buffer, &mut bounding_box);
+                    if data.is_ok() {
+                        let data = data.data_ref();
+                        extend_aabb_from_vertex_buffer(&data.vertex_buffer, &mut bounding_box);
+                    }
                 }
             }
 
@@ -721,6 +723,9 @@ impl NodeTrait for Mesh {
             RdcControlFlow::Break
         } else {
             for surface in self.surfaces().iter() {
+                if !surface.data_ref().is_ok() {
+                    continue;
+                }
                 let is_skinned = !surface.bones.is_empty();
 
                 let world = if is_skinned {

--- a/fyrox-impl/src/scene/mesh/surface.rs
+++ b/fyrox-impl/src/scene/mesh/surface.rs
@@ -336,7 +336,7 @@ impl SurfaceData {
             if v1 == v2 || v1 == v3 || v2 == v3 {
                 Log::warn(format!(
                     "Degenerated triangle found when calculating tangents. Lighting may be \
-                    incorrect! Triangle indices: {triangle:?}. Triangle vertices: {v1} {v2} {v3}",
+                    incorrect! Triangle indices: {triangle:?}. Triangle vertices: {v1:?} {v2:?} {v3:?}",
                 ));
             }
 

--- a/fyrox-impl/src/scene/mod.rs
+++ b/fyrox-impl/src/scene/mod.rs
@@ -435,7 +435,13 @@ impl SceneLoader {
         ));
 
         // Wait everything.
-        join_all(used_resources.into_iter()).await;
+        let results = join_all(used_resources.into_iter()).await;
+
+        for result in results {
+            if let Err(err) = result {
+                Log::err(format!("Scene resource loading error: {:?}", err));
+            }
+        }
 
         Log::info(format!(
             "SceneLoader::finish() - All {used_resources_count} resources have finished loading."

--- a/fyrox-impl/src/script/mod.rs
+++ b/fyrox-impl/src/script/mod.rs
@@ -859,6 +859,20 @@ impl Script {
         }
     }
 
+    /// Generate a brief summary of this script for debugging purposes.
+    pub fn summary(&self) -> String {
+        let mut summary = String::new();
+        if self.initialized {
+            summary.push_str("init ");
+        }
+        if self.started {
+            summary.push_str("start ");
+        }
+        use std::fmt::Write;
+        write!(summary, "{:?}", self.instance).unwrap();
+        summary
+    }
+
     /// Performs downcasting to a particular type.
     #[inline]
     pub fn cast<T: ScriptTrait>(&self) -> Option<&T> {

--- a/fyrox-resource/src/state.rs
+++ b/fyrox-resource/src/state.rs
@@ -29,6 +29,7 @@ use crate::{
 use fyrox_core::reflect::ReflectHandle;
 use fyrox_core::warn;
 use std::any::{Any, TypeId};
+use std::fmt::Display;
 use std::path::PathBuf;
 use std::{
     ops::{Deref, DerefMut},
@@ -65,15 +66,26 @@ impl DerefMut for WakersList {
     }
 }
 
-/// Arbitrary loading error, that could be optionally be empty.  
+/// Arbitrary loading error, that could be optionally be empty.
 #[derive(Reflect, Debug, Clone, Default)]
 #[reflect(hide_all)]
 pub struct LoadError(pub Option<Arc<dyn ResourceLoadError>>);
+
+impl std::error::Error for LoadError {}
 
 impl LoadError {
     /// Creates new loading error from a value of the given type.
     pub fn new<T: ResourceLoadError>(value: T) -> Self {
         Self(Some(Arc::new(value)))
+    }
+}
+
+impl Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            None => f.write_str("None"),
+            Some(x) => Display::fmt(x, f),
+        }
     }
 }
 

--- a/fyrox-sound/src/source.rs
+++ b/fyrox-sound/src/source.rs
@@ -242,6 +242,9 @@ impl SoundSource {
             match buffer.state().data() {
                 None => return Err(SoundError::BufferFailedToLoad),
                 Some(locked_buffer) => {
+                    if locked_buffer.duration() == Duration::ZERO {
+                        panic!("Zero duration buffer: {:?}", locked_buffer);
+                    }
                     // Check new buffer if streaming - it must not be used by anyone else.
                     if let SoundBuffer::Streaming(ref mut streaming) = *locked_buffer {
                         if streaming.use_count != 0 {

--- a/fyrox-ui/src/control.rs
+++ b/fyrox-ui/src/control.rs
@@ -80,6 +80,22 @@ where
 pub trait Control:
     BaseControl + Deref<Target = Widget> + DerefMut + Reflect + Visit + ComponentProvider
 {
+    /// Brief debugging information about this node.
+    fn summary(&self) -> String {
+        use std::fmt::Write;
+        let mut result = String::new();
+        let type_name = BaseControl::type_name(self)
+            .strip_prefix("fyrox_ui::")
+            .unwrap_or(BaseControl::type_name(self));
+        write!(result, "{} {}<{}>", self.handle(), self.name(), type_name,).unwrap();
+        if self.children().len() == 1 {
+            result.push_str(" 1 child");
+        } else if self.children().len() > 1 {
+            write!(result, " {} children", self.children().len()).unwrap();
+        }
+        result
+    }
+
     /// This method will be called before the widget is destroyed (dropped). At the moment, when this
     /// method is called, the widget is still in the widget graph and can be accessed via handles. It
     /// is guaranteed to be called once, and only if the widget is deleted via [`crate::widget::WidgetMessage::remove`].


### PR DESCRIPTION
## Description
Working on a recent project led to dissatisfaction with how errors are reported and how debugging information is presented, especially in graphs and visitors. This pull request makes several improvements to errors, especially by implementing `Display` and `Debug` for various types.

* `Pool` now has a `Debug` implementation that shows the content of the pool, instead of the useless derived implementation.
* `VisitError::TypeMismatch` now has the names of the types that did not match.
* `Visitor::type_name_map` stores the type names to allow `TypeMismatch` to know the name of the type that failed to match.
* `VisitError::Multiple` is a new variant of `VisitError` that contains a list of errors, for cases when a series of errors cause a visit to fail. This can happen when there is more than one potential way to visit some value, and all of them fail. With this variant, we are no longer forced to only report one of those failures.
* `VisitError::FieldDoesNotExist` now has the full breadcrumbs of the missing field.
* `VisitError::RegionDoesNotExist` now has the name of the missing region in addition to the breadcrumbs.
* `Visitor::arc_map` and `Visitor::rc_map` now remove the invalid entry when visiting that entry fails.
* `BaseSceneGraph::summary` is a new method that creates a formatted brief representation of the entire tree of the graph, which is far more readable than trying to decipher the debug of the pool.
* In several places a resource's kind was being used as if the kind identified the resource, which comes from the obsolete notion that the kind includes the path of external resources. Since kind no longer contains that information, I have corrected this.

## Checklist
- [X] My code follows the project's code style guidelines
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
- [X] My changes don't generate new warnings or errors
- [X] No unsafe code introduced (or if introduced, thoroughly justified and documented)
