### PR TITLE
Fix `expected string literal` error in some `include_str!` macros

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -281,7 +281,7 @@ lazy_static! {
     static ref GIZMO_SHADER: ShaderResource = {
         ShaderResource::from_str(
             Uuid::new_v4(),
-            include_str!("../resources/shaders/gizmo.shader",),
+            include_str!("../resources/shaders/gizmo.shader"),
             Default::default(),
         )
         .unwrap()

--- a/editor/src/plugins/collider/mod.rs
+++ b/editor/src/plugins/collider/mod.rs
@@ -273,7 +273,7 @@ lazy_static! {
     static ref GIZMO_SHADER: ShaderResource = {
         ShaderResource::from_str(
             Uuid::new_v4(),
-            include_str!("../../../resources/shaders/sprite_gizmo.shader",),
+            include_str!("../../../resources/shaders/sprite_gizmo.shader"),
             Default::default(),
         )
         .unwrap()

--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -151,7 +151,7 @@ lazy_static! {
     static ref GRID_SHADER: ShaderResource = {
         ShaderResource::from_str(
             Uuid::new_v4(),
-            include_str!("../../resources/shaders/grid.shader",),
+            include_str!("../../resources/shaders/grid.shader"),
             Default::default(),
         )
         .unwrap()


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
The project builds fine, but rust-analyzer keeps complaining about `expected string literal` error in some `include_str!` macros (see screenshot below) whenever I open any of the files that this PR edits. Removing trailing comma from `include_str!` seems to resolve the issue.

`rust-analyzer 1.90.0 (1159e78 2025-09-14)`

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
This one is from `editor/src/scene/mod.rs:154`

<img width="721" height="281" alt="Screenshot_20251008_112711" src="https://github.com/user-attachments/assets/aad5db07-b1d9-43b5-8f9e-ce36aea89986" />

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
