### PR TITLE
Protecting FormattedText against unloaded resource panic

### DIFF
--- a/fyrox-ui/src/formatted_text.rs
+++ b/fyrox-ui/src/formatted_text.rs
@@ -777,6 +777,7 @@ impl FormattedText {
         self
     }
 
+    /// Returns once all fonts used by this FormattedText are finished loading.
     pub async fn wait_for_fonts(&mut self) -> Result<(), LoadError> {
         (*self.font).clone().await?;
         for run in self.runs.iter() {
@@ -787,6 +788,8 @@ impl FormattedText {
         Ok(())
     }
 
+    /// Returns true if all fonts used by this resource are Ok.
+    /// This `FormattedText` will not build successfully unless this returns true.
     pub fn are_fonts_loaded(&self) -> bool {
         if !self.font.is_ok() {
             return false;
@@ -804,6 +807,7 @@ impl FormattedText {
     pub fn build(&mut self) -> Vector2<f32> {
         let mut lines = std::mem::take(&mut self.lines);
         lines.clear();
+        // Fail early if any font is not available.
         if !self.are_fonts_loaded() {
             Log::err(format!(
                 "Text failed to build due to unloaded fonts. {:?}",


### PR DESCRIPTION
## Description
The project I am working on involving resources recently accidentally caused all resources to fail to load, and this caused `FormattedText` to panic. Therefore I would like to suggest this change that will allow `FormattedText` to fail gracefully, without panicking, even if its `Font` resources fail to load.

Ideally the `FormattedText` would wait until the fonts finish loading and only fail of the loading fails, but `block_on` panics if it is called from `FormattedText::build`. This PR simply logs an error and renders no text, but I imagine better solutions could be possible.

## Checklist
- [X] My code follows the project's code style guidelines
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
- [X] My changes don't generate new warnings or errors
- [X] No unsafe code introduced (or if introduced, thoroughly justified and documented)
