### PR TITLE
Correcting panic from TileCollider load failure

### DIFF
--- a/editor/src/plugins/tilemap/collider_editor.rs
+++ b/editor/src/plugins/tilemap/collider_editor.rs
@@ -308,11 +308,18 @@ impl TileEditor for TileColliderEditor {
         send_visibility(ui, self.custom_field, self.value.is_custom());
         send_visibility(ui, self.error_field, false);
         if let TileCollider::Custom(custom) = &self.value {
-            let text = custom.data_ref().to_string();
-            send_sync_message(
-                ui,
-                TextMessage::text(self.custom_field, MessageDirection::ToWidget, text),
-            );
+            if custom.is_ok() {
+                let text = custom.data_ref().to_string();
+                send_sync_message(
+                    ui,
+                    TextMessage::text(self.custom_field, MessageDirection::ToWidget, text),
+                );
+            } else {
+                send_sync_message(
+                    ui,
+                    TextMessage::text(self.custom_field, MessageDirection::ToWidget, String::new()),
+                );
+            }
         }
         highlight_tool_button(
             self.show_button,

--- a/fyrox-impl/src/scene/tilemap/tile_collider.rs
+++ b/fyrox-impl/src/scene/tilemap/tile_collider.rs
@@ -82,7 +82,13 @@ impl Debug for TileCollider {
         match self {
             Self::None => write!(f, "None"),
             Self::Rectangle => write!(f, "Rectangle"),
-            Self::Custom(r) => write!(f, "Custom({})", r.data_ref().deref()),
+            Self::Custom(r) => {
+                if r.is_ok() {
+                    write!(f, "Custom({})", r.data_ref().deref())
+                } else {
+                    f.write_str("Custom(unloaded)")
+                }
+            }
             Self::Mesh => write!(f, "Mesh"),
         }
     }
@@ -151,9 +157,11 @@ impl TileCollider {
                 triangles.push([origin, origin + 2, origin + 3]);
             }
             TileCollider::Custom(resource) => {
-                resource
-                    .data_ref()
-                    .build_collider_shape(transform, position, vertices, triangles);
+                if resource.is_ok() {
+                    resource
+                        .data_ref()
+                        .build_collider_shape(transform, position, vertices, triangles);
+                }
             }
             TileCollider::Mesh => (), // TODO: Add image-to-mesh conversion
         }


### PR DESCRIPTION
## Description
Custom tile collider geometry is stored as an embedded resource within tilesets, and due to being embedded it was assumed that this resource would always be ok. Some issue with loading legacy tilesets has proven this assumption incorrect. This is not an issue for tilesets that are saved with the latest commit, but loading legacy tilesets should not cause a panic. Ideally the legacy collider geometry should be successfully loaded, but I do not know the reason for that failure.

Instead, this PR prevents the panic and makes it possible for the tileset to be edited and saved to eliminate the problem, at the cost of needing to recreate custom collider geometry from scratch.

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
