### PR TITLE
Putting space in FormattedText for tabs.

### DIFF
--- a/fyrox-ui/src/formatted_text.rs
+++ b/fyrox-ui/src/formatted_text.rs
@@ -41,6 +41,9 @@ use textwrapper::*;
 mod run;
 mod textwrapper;
 
+/// Width of a tab when multiplied by font size.
+const TAB_WIDTH: f32 = 2.0;
+
 /// Defines a position in the text. It is just a coordinates of a character in text.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Visit, Reflect)]
 pub struct Position {
@@ -178,6 +181,17 @@ fn build_glyph(
 
     x = x.floor();
     y = y.floor();
+
+    if character == '\t' {
+        let rect = Rect::new(x, y + ascender, font_size * TAB_WIDTH, font_size);
+        let text_glyph = TextGlyph {
+            bounds: rect,
+            tex_coords: [Vector2::default(); 4],
+            atlas_page_index: 0,
+            source_char_index,
+        };
+        return (text_glyph, rect.w());
+    }
 
     // Request larger glyph with super sampling scaling.
     match metrics.glyph(character, super_sampling_scale) {


### PR DESCRIPTION
## Description
Fonts do not supply glyphs to represent '\\t' characters, so this PR modifies `FormattedText` so that it creates a blank space of roughly appropriate size when it encounters a '\\t' instead of treating it as an unknown character.

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
