### PR TITLE
Improving UX of `TextBox`

### DIFF
--- a/editor/src/plugins/tilemap/collider_editor.rs
+++ b/editor/src/plugins/tilemap/collider_editor.rs
@@ -140,15 +140,12 @@ impl TileColliderEditor {
         let name_field = TextBuilder::new(WidgetBuilder::new().on_column(3))
             .with_text(collider_layer.name.clone())
             .build(ctx);
-        let custom_field = TextBoxBuilder::new(
-            WidgetBuilder::new()
-                .with_visibility(value.is_custom())
-                .with_min_size(Vector2::new(0.0, 100.0)),
-        )
-        .with_multiline(true)
-        .with_wrap(WrapMode::Word)
-        .with_text_commit_mode(TextCommitMode::Changed)
-        .build(ctx);
+        let custom_field =
+            TextBoxBuilder::new(WidgetBuilder::new().with_visibility(value.is_custom()))
+                .with_multiline(true)
+                .with_wrap(WrapMode::Word)
+                .with_text_commit_mode(TextCommitMode::Changed)
+                .build(ctx);
         let error_field = TextBuilder::new(WidgetBuilder::new().with_visibility(false))
             .with_wrap(WrapMode::Word)
             .with_horizontal_text_alignment(HorizontalAlignment::Center)

--- a/editor/src/ui_scene/bbcode.rs
+++ b/editor/src/ui_scene/bbcode.rs
@@ -2,7 +2,7 @@ use fyrox::{
     core::{pool::Handle, variable::InheritableVariable},
     engine::Engine,
     gui::{
-        formatted_text::RunSet,
+        formatted_text::{RunSet, WrapMode},
         message::{MessageDirection, UiMessage},
         stack_panel::StackPanelBuilder,
         text::{Text, TextBuilder, TextMessage},
@@ -29,6 +29,8 @@ impl BBCodePanel {
     pub fn new(inspector_head: Handle<UiNode>, ctx: &mut BuildContext) -> Self {
         let text_box = TextBoxBuilder::new(WidgetBuilder::new())
             .with_text_commit_mode(TextCommitMode::Changed)
+            .with_multiline(true)
+            .with_wrap(WrapMode::Word)
             .build(ctx);
         let root_widget = StackPanelBuilder::new(
             WidgetBuilder::new()

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -671,6 +671,7 @@ impl TextBox {
             self.char_index_to_position(position + 1)
                 .unwrap_or_default(),
         );
+        self.invalidate_layout();
         if *self.commit_mode == TextCommitMode::Immediate {
             ui.send_message(TextMessage::text(
                 self.handle,
@@ -701,6 +702,7 @@ impl TextBox {
             self.char_index_to_position(position + str.chars().count())
                 .unwrap_or_default(),
         );
+        self.invalidate_layout();
         if *self.commit_mode == TextCommitMode::Immediate {
             ui.send_message(TextMessage::text(
                 self.handle,
@@ -724,6 +726,7 @@ impl TextBox {
         self.formatted_text.borrow_mut().remove_range(range);
         self.selection_range.set_value_and_mark_modified(None);
         self.set_caret_position(selection.left());
+        self.invalidate_layout();
     }
 
     /// Returns current text length in characters.
@@ -808,6 +811,7 @@ impl TextBox {
             text.remove_at(position);
             text.build();
             drop(text);
+            self.invalidate_layout();
 
             if *self.commit_mode == TextCommitMode::Immediate {
                 ui.send_message(TextMessage::text(
@@ -833,6 +837,7 @@ impl TextBox {
         self.formatted_text.borrow_mut().build();
         self.set_caret_position(selection.left());
         self.selection_range.set_value_and_mark_modified(None);
+        self.invalidate_layout();
         if *self.commit_mode == TextCommitMode::Immediate {
             ui.send_message(TextMessage::text(
                 self.handle(),
@@ -1153,7 +1158,7 @@ impl Control for TextBox {
                                 self.remove_char(HorizontalDirection::Right, ui);
                             }
                             KeyCode::NumpadEnter | KeyCode::Enter if *self.editable => {
-                                if *self.multiline {
+                                if *self.multiline && !ui.keyboard_modifiers.shift {
                                     self.insert_char('\n', ui);
                                 } else if *self.commit_mode == TextCommitMode::LostFocusPlusEnter {
                                     ui.send_message(TextMessage::text(


### PR DESCRIPTION
## Description
`TextBox` widgets have long suffered from the issue that they do not expand when the user enters more text than the widget can contain at its original size. This is because nothing calls `invalidate_layout` as the user types. This PR allows a `TextBox` to expand and shrink as needed while the user types.

It also allows the user to submit the content of a multiline text box while typing by pressing shift+enter.

Slight modifications are made to the tile collider editor in the tileset editor window and to the BBCode editor to take advantage of these improvements to `TextBox`.

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
