### PR TITLE
Improving how selection changes are handled in Editor

### DIFF
--- a/editor/src/camera/panel.rs
+++ b/editor/src/camera/panel.rs
@@ -107,24 +107,29 @@ impl CameraPreviewControlPanel {
         &mut self,
         message: &Message,
         editor_selection: &Selection,
-        game_scene: &mut GameScene,
+        mut game_scene: Option<&mut GameScene>,
         engine: &mut Engine,
     ) {
-        if let Message::DoCommand(_)
-        | Message::UndoCurrentSceneCommand
-        | Message::RedoCurrentSceneCommand = message
-        {
-            self.leave_preview_mode(game_scene, engine);
+        if let Some(game_scene) = game_scene.as_mut() {
+            if let Message::DoCommand(_)
+            | Message::UndoCurrentSceneCommand
+            | Message::RedoCurrentSceneCommand = message
+            {
+                self.leave_preview_mode(game_scene, engine);
+            }
         }
 
         if let Message::SelectionChanged { .. } = message {
-            let scene = &engine.scenes[game_scene.scene];
-
-            let any_camera = editor_selection.as_graph().is_some_and(|s| {
-                s.nodes
-                    .iter()
-                    .any(|n| scene.graph.try_get_of_type::<Camera>(*n).is_some())
-            });
+            let any_camera = if let Some(game_scene) = game_scene {
+                let scene = &engine.scenes[game_scene.scene];
+                editor_selection.as_graph().is_some_and(|s| {
+                    s.nodes
+                        .iter()
+                        .any(|n| scene.graph.try_get_of_type::<Camera>(*n).is_some())
+                })
+            } else {
+                false
+            };
             if any_camera {
                 engine.user_interfaces.first_mut().send(
                     self.window,

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -1183,12 +1183,18 @@ impl Editor {
             }
         }
 
+        let old_selection = self
+            .scenes
+            .current_scene_entry_ref()
+            .map(|s| s.selection.clone())
+            .unwrap_or_default();
+
         self.scenes.add_and_select(entry);
 
         self.scene_viewer
             .reset_camera_projection(self.engine.user_interfaces.first());
 
-        self.on_scene_changed();
+        self.on_scene_changed(old_selection);
     }
 
     pub fn handle_hotkeys(&mut self, message: &UiMessage) {
@@ -2211,7 +2217,7 @@ impl Editor {
             entry.before_drop(engine);
 
             if closing_current_scene {
-                self.on_scene_changed();
+                self.on_scene_changed(entry.selection);
             }
 
             true
@@ -2221,12 +2227,17 @@ impl Editor {
     }
 
     fn set_current_scene(&mut self, id: Uuid) {
+        let old_selection = self
+            .scenes
+            .current_scene_entry_ref()
+            .map(|s| s.selection.clone())
+            .unwrap_or_default();
         if self.scenes.set_current_scene(id) {
-            self.on_scene_changed();
+            self.on_scene_changed(old_selection);
         }
     }
 
-    fn on_scene_changed(&mut self) {
+    fn on_scene_changed(&mut self, old_selection: Selection) {
         let ui = &self.engine.user_interfaces.first();
         if let Some(entry) = self.scenes.current_scene_entry_ref() {
             if let Some(game_scene) = entry.controller.downcast_ref::<GameScene>() {
@@ -2242,6 +2253,9 @@ impl Editor {
 
             self.menu.on_scene_changed(&*entry.controller, ui);
         }
+
+        self.message_sender
+            .send(Message::SelectionChanged { old_selection });
 
         self.world_viewer.clear(ui);
 
@@ -2548,39 +2562,36 @@ impl Editor {
                 if let Some(entry) = self.scenes.current_scene_entry_mut() {
                     self.asset_browser
                         .on_message(&mut self.engine, entry, &message, &self.plugins);
-                    if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
-                        self.particle_system_control_panel.handle_message(
-                            &message,
-                            &entry.selection,
-                            game_scene,
-                            &mut self.engine,
-                        );
-                        self.camera_control_panel.handle_message(
-                            &message,
-                            &entry.selection,
-                            game_scene,
-                            &mut self.engine,
-                        );
-                        self.mesh_control_panel.handle_message(
-                            &message,
-                            &entry.selection,
-                            game_scene,
-                            &mut self.engine,
-                        );
-                        self.audio_preview_panel.handle_message(
-                            &message,
-                            &entry.selection,
-                            game_scene,
-                            &mut self.engine,
-                        );
-                    } else if let Some(ui_scene) = entry.controller.downcast_mut::<UiScene>() {
-                        self.bbcode_panel.handle_message(
-                            &message,
-                            &entry.selection,
-                            ui_scene,
-                            &mut self.engine,
-                        );
-                    }
+                    self.particle_system_control_panel.handle_message(
+                        &message,
+                        &entry.selection,
+                        entry.controller.downcast_mut::<GameScene>(),
+                        &mut self.engine,
+                    );
+                    self.camera_control_panel.handle_message(
+                        &message,
+                        &entry.selection,
+                        entry.controller.downcast_mut::<GameScene>(),
+                        &mut self.engine,
+                    );
+                    self.mesh_control_panel.handle_message(
+                        &message,
+                        &entry.selection,
+                        entry.controller.downcast_mut::<GameScene>(),
+                        &mut self.engine,
+                    );
+                    self.audio_preview_panel.handle_message(
+                        &message,
+                        &entry.selection,
+                        entry.controller.downcast_mut::<GameScene>(),
+                        &mut self.engine,
+                    );
+                    self.bbcode_panel.handle_message(
+                        &message,
+                        &entry.selection,
+                        entry.controller.downcast_ref::<UiScene>(),
+                        &mut self.engine,
+                    );
                     needs_sync |=
                         entry
                             .controller

--- a/editor/src/mesh.rs
+++ b/editor/src/mesh.rs
@@ -262,20 +262,23 @@ impl MeshControlPanel {
         &mut self,
         message: &Message,
         editor_selection: &Selection,
-        game_scene: &mut GameScene,
+        game_scene: Option<&mut GameScene>,
         engine: &mut Engine,
     ) {
         let Message::SelectionChanged { .. } = message else {
             return;
         };
 
-        let scene = &engine.scenes[game_scene.scene];
-
-        let any_mesh = editor_selection.as_graph().is_some_and(|s| {
-            s.nodes()
-                .iter()
-                .any(|n| scene.graph.try_get_of_type::<Mesh>(*n).is_some())
-        });
+        let any_mesh = if let Some(game_scene) = game_scene {
+            let scene = &engine.scenes[game_scene.scene];
+            editor_selection.as_graph().is_some_and(|s| {
+                s.nodes()
+                    .iter()
+                    .any(|n| scene.graph.try_get_of_type::<Mesh>(*n).is_some())
+            })
+        } else {
+            false
+        };
         engine
             .user_interfaces
             .first()

--- a/editor/src/particle.rs
+++ b/editor/src/particle.rs
@@ -215,23 +215,29 @@ impl ParticleSystemPreviewControlPanel {
         &mut self,
         message: &Message,
         editor_selection: &Selection,
-        game_scene: &mut GameScene,
+        mut game_scene: Option<&mut GameScene>,
         engine: &mut Engine,
     ) {
-        if let Message::DoCommand(_)
-        | Message::UndoCurrentSceneCommand
-        | Message::RedoCurrentSceneCommand = message
-        {
-            self.leave_preview_mode(game_scene, engine);
+        if let Some(game_scene) = game_scene.as_mut() {
+            if let Message::DoCommand(_)
+            | Message::UndoCurrentSceneCommand
+            | Message::RedoCurrentSceneCommand = message
+            {
+                self.leave_preview_mode(game_scene, engine);
+            }
         }
 
         if let Message::SelectionChanged { .. } = message {
-            let scene = &engine.scenes[game_scene.scene];
-            let any_particle_system_selected = editor_selection.as_graph().is_some_and(|s| {
-                s.nodes
-                    .iter()
-                    .any(|n| scene.graph.try_get_of_type::<ParticleSystem>(*n).is_some())
-            });
+            let any_particle_system_selected = if let Some(game_scene) = game_scene {
+                let scene = &engine.scenes[game_scene.scene];
+                editor_selection.as_graph().is_some_and(|s| {
+                    s.nodes
+                        .iter()
+                        .any(|n| scene.graph.try_get_of_type::<ParticleSystem>(*n).is_some())
+                })
+            } else {
+                false
+            };
             engine.user_interfaces.first().send(
                 self.root_widget,
                 WidgetMessage::Visibility(any_particle_system_selected),

--- a/editor/src/ui_scene/bbcode.rs
+++ b/editor/src/ui_scene/bbcode.rs
@@ -1,6 +1,7 @@
 use fyrox::{
     core::{pool::Handle, variable::InheritableVariable},
     engine::Engine,
+    graph::BaseSceneGraph,
     gui::{
         formatted_text::{RunSet, WrapMode},
         message::UiMessage,
@@ -76,16 +77,14 @@ impl BBCodePanel {
         &mut self,
         message: &Message,
         editor_selection: &Selection,
-        ui_scene: &mut UiScene,
+        ui_scene: Option<&UiScene>,
         engine: &mut Engine,
     ) {
         if let Message::SelectionChanged { .. } = message {
             let text_selected = editor_selection.as_ui().is_some_and(|s| {
                 s.widgets.iter().any(|n| {
                     ui_scene
-                        .ui
-                        .try_get_node_mut(*n)
-                        .map(|n| n.cast::<Text>().is_some())
+                        .and_then(|s| s.ui.try_get_node(*n).map(|n| n.cast::<Text>().is_some()))
                         .unwrap_or_default()
                 })
             });


### PR DESCRIPTION
## Description
Previously, several Editor panels would ignore messages when the wrong kind of scene was open. A panel for a `GameScene` would not even receive messages while a `UiScene` was open, thereby preventing the panel from becoming invisible when selecting a `UiNode`. I have found some of these Editor UI elements and modified them to no longer ignore messages despite the wrong kind of scene being open. There may be others that still have this problem.

I have modified the editor so that `Message::SelectionChanged` is sent when the scene is changed, since this does in fact cause the selection to change and UI elements should be notified of this. `Editor::on_scene_changed` now needs to be passed `old_selection` as a parameter so that it can construct the `Message::SelectionChanged`.

## Review Guidance
This PR has potentially wide-reaching consequences to multiple aspects of the editor. I have attempted to test these changes in all the ways I can think of, but it would be wise for reviewers to do further testing and perhaps catch something I have missed. I am especially concerned about how this PR sends additional `Message::SelectionChanged` since it is difficult to be sure who might be listening for that and what all the consequences may be, but in my testing everything seems fine.

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
