### PR TITLE
Using a null `SceneController` to simplify the editor when no scene is open.

### DIFF
--- a/editor/src/menu/mod.rs
+++ b/editor/src/menu/mod.rs
@@ -80,7 +80,7 @@ pub struct Panels<'b> {
 
 pub struct MenuContext<'a, 'b> {
     pub engine: &'a mut Engine,
-    pub game_scene: Option<&'b mut EditorSceneEntry>,
+    pub game_scene: &'b mut EditorSceneEntry,
     pub panels: Panels<'b>,
     pub settings: &'b mut Settings,
     pub icon_request_sender: Sender<IconRequest>,
@@ -182,23 +182,22 @@ impl Menu {
     }
 
     pub fn handle_ui_message(&mut self, message: &UiMessage, mut ctx: MenuContext) {
-        if let Some(entry) = ctx.game_scene.as_mut() {
-            self.edit_menu.handle_ui_message(
-                message,
-                &self.message_sender,
-                &entry.selection,
-                &mut *entry.controller,
-                ctx.engine,
-            );
+        let entry = ctx.game_scene;
+        self.edit_menu.handle_ui_message(
+            message,
+            &self.message_sender,
+            &entry.selection,
+            &mut *entry.controller,
+            ctx.engine,
+        );
 
-            self.create_entity_menu.handle_ui_message(
-                message,
-                &self.message_sender,
-                &mut *entry.controller,
-                &entry.selection,
-                ctx.engine,
-            );
-        }
+        self.create_entity_menu.handle_ui_message(
+            message,
+            &self.message_sender,
+            &mut *entry.controller,
+            &entry.selection,
+            ctx.engine,
+        );
 
         self.utils_menu.handle_ui_message(
             message,
@@ -208,7 +207,7 @@ impl Menu {
         self.file_menu.handle_ui_message(
             message,
             &self.message_sender,
-            ctx.game_scene,
+            Some(entry),
             ctx.engine,
             ctx.settings,
             &mut ctx.panels,

--- a/editor/src/plugins/absm/mod.rs
+++ b/editor/src/plugins/absm/mod.rs
@@ -743,7 +743,7 @@ impl EditorPlugin for AbsmEditorPlugin {
     }
 
     fn on_sync_to_model(&mut self, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let absm_editor = some_or_return!(self.absm_editor.as_mut());
         let ui = editor.engine.user_interfaces.first_mut();
         if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
@@ -782,35 +782,34 @@ impl EditorPlugin for AbsmEditorPlugin {
             }
         }
 
-        if let Some(entry) = editor.scenes.current_scene_entry_mut() {
-            let ui = editor.engine.user_interfaces.first_mut();
-            if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
-                let graph = &mut editor.engine.scenes[game_scene.scene].graph;
-                absm_editor.handle_ui_message(
-                    message,
-                    &editor.message_sender,
-                    &entry.selection,
-                    graph,
-                    ui,
-                    game_scene.graph_switches.node_overrides.as_mut().unwrap(),
-                );
-            } else if let Some(ui_scene) = entry.controller.downcast_mut::<UiScene>() {
-                absm_editor.handle_ui_message(
-                    message,
-                    &editor.message_sender,
-                    &entry.selection,
-                    &mut ui_scene.ui,
-                    ui,
-                    ui_scene.ui_update_switches.node_overrides.as_mut().unwrap(),
-                );
-            }
+        let entry = editor.scenes.current_scene_entry_mut();
+        let ui = editor.engine.user_interfaces.first_mut();
+        if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
+            let graph = &mut editor.engine.scenes[game_scene.scene].graph;
+            absm_editor.handle_ui_message(
+                message,
+                &editor.message_sender,
+                &entry.selection,
+                graph,
+                ui,
+                game_scene.graph_switches.node_overrides.as_mut().unwrap(),
+            );
+        } else if let Some(ui_scene) = entry.controller.downcast_mut::<UiScene>() {
+            absm_editor.handle_ui_message(
+                message,
+                &editor.message_sender,
+                &entry.selection,
+                &mut ui_scene.ui,
+                ui,
+                ui_scene.ui_update_switches.node_overrides.as_mut().unwrap(),
+            );
         }
 
         self.absm_editor = Some(absm_editor);
     }
 
     fn on_leave_preview_mode(&mut self, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let absm_editor = some_or_return!(self.absm_editor.as_mut());
         if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
             let engine = &mut editor.engine;
@@ -836,7 +835,7 @@ impl EditorPlugin for AbsmEditorPlugin {
     }
 
     fn on_update(&mut self, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let absm_editor = some_or_return!(self.absm_editor.as_mut());
         if let Some(game_scene) = entry.controller.downcast_ref::<GameScene>() {
             absm_editor.update(
@@ -872,7 +871,7 @@ impl EditorPlugin for AbsmEditorPlugin {
             self.on_sync_to_model(editor);
         }
 
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let absm_editor = some_or_return!(self.absm_editor.as_mut());
         if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
             absm_editor.handle_message(

--- a/editor/src/plugins/animation/mod.rs
+++ b/editor/src/plugins/animation/mod.rs
@@ -888,7 +888,7 @@ impl EditorPlugin for AnimationEditorPlugin {
     }
 
     fn on_sync_to_model(&mut self, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let animation_editor = some_or_return!(self.animation_editor.as_mut());
         let ui = editor.engine.user_interfaces.first_mut();
         if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
@@ -927,40 +927,39 @@ impl EditorPlugin for AnimationEditorPlugin {
             }
         }
 
-        if let Some(entry) = editor.scenes.current_scene_entry_mut() {
-            let ui = editor.engine.user_interfaces.first_mut();
-            if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
-                let graph = &mut editor.engine.scenes[game_scene.scene].graph;
-                animation_editor.handle_ui_message(
-                    message,
-                    &entry.selection,
-                    graph,
-                    game_scene.scene_content_root,
-                    ui,
-                    &editor.engine.resource_manager,
-                    &editor.message_sender,
-                    game_scene.graph_switches.node_overrides.as_mut().unwrap(),
-                );
-            } else if let Some(ui_scene) = entry.controller.downcast_mut::<UiScene>() {
-                let ui_root = ui_scene.ui.root();
-                animation_editor.handle_ui_message(
-                    message,
-                    &entry.selection,
-                    &mut ui_scene.ui,
-                    ui_root,
-                    ui,
-                    &editor.engine.resource_manager,
-                    &editor.message_sender,
-                    ui_scene.ui_update_switches.node_overrides.as_mut().unwrap(),
-                );
-            }
+        let entry = editor.scenes.current_scene_entry_mut();
+        let ui = editor.engine.user_interfaces.first_mut();
+        if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
+            let graph = &mut editor.engine.scenes[game_scene.scene].graph;
+            animation_editor.handle_ui_message(
+                message,
+                &entry.selection,
+                graph,
+                game_scene.scene_content_root,
+                ui,
+                &editor.engine.resource_manager,
+                &editor.message_sender,
+                game_scene.graph_switches.node_overrides.as_mut().unwrap(),
+            );
+        } else if let Some(ui_scene) = entry.controller.downcast_mut::<UiScene>() {
+            let ui_root = ui_scene.ui.root();
+            animation_editor.handle_ui_message(
+                message,
+                &entry.selection,
+                &mut ui_scene.ui,
+                ui_root,
+                ui,
+                &editor.engine.resource_manager,
+                &editor.message_sender,
+                ui_scene.ui_update_switches.node_overrides.as_mut().unwrap(),
+            );
         }
 
         self.animation_editor = Some(animation_editor);
     }
 
     fn on_leave_preview_mode(&mut self, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let animation_editor = some_or_return!(self.animation_editor.as_mut());
         if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
             let engine = &mut editor.engine;
@@ -984,7 +983,7 @@ impl EditorPlugin for AnimationEditorPlugin {
     }
 
     fn on_update(&mut self, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let animation_editor = some_or_return!(self.animation_editor.as_mut());
         if let Some(game_scene) = entry.controller.downcast_ref::<GameScene>() {
             animation_editor.update(
@@ -1016,7 +1015,7 @@ impl EditorPlugin for AnimationEditorPlugin {
             self.on_sync_to_model(editor);
         }
 
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let animation_editor = some_or_return!(self.animation_editor.as_mut());
         if let Some(game_scene) = entry.controller.downcast_mut::<GameScene>() {
             animation_editor.handle_message(

--- a/editor/src/plugins/collider/mod.rs
+++ b/editor/src/plugins/collider/mod.rs
@@ -686,7 +686,7 @@ pub struct ColliderPlugin {
 impl ColliderPlugin {
     fn on_selection(&mut self, editor: &mut Editor) -> bool {
         let mut needs_panel = false;
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut(), false);
+        let entry = editor.scenes.current_scene_entry_mut();
         let game_scene = some_or_return!(entry.controller.downcast_mut::<GameScene>(), false);
         let scene = &mut editor.engine.scenes[game_scene.scene];
         if let Some(mode) = entry
@@ -729,7 +729,7 @@ impl ColliderPlugin {
 
 impl EditorPlugin for ColliderPlugin {
     fn on_ui_message(&mut self, message: &mut UiMessage, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let game_scene = some_or_return!(entry.controller.downcast_mut::<GameScene>());
         let panel = some_or_return!(self.panel.as_mut());
         panel.handle_ui_message(

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -371,10 +371,7 @@ impl EditorPlugin for InspectorPlugin {
     fn on_sync_to_model(&mut self, editor: &mut Editor) {
         let ui = editor.engine.user_interfaces.first_mut();
 
-        let Some(entry) = editor.scenes.current_scene_entry_mut() else {
-            self.clear(ui);
-            return;
-        };
+        let entry = editor.scenes.current_scene_entry_mut();
 
         let mut need_clear = true;
 
@@ -434,9 +431,7 @@ impl EditorPlugin for InspectorPlugin {
     }
 
     fn on_ui_message(&mut self, message: &mut UiMessage, editor: &mut Editor) {
-        let Some(entry) = editor.scenes.current_scene_entry_mut() else {
-            return;
-        };
+        let entry = editor.scenes.current_scene_entry_mut();
 
         if (message.destination() == self.inspector
             || editor

--- a/editor/src/plugins/probe.rs
+++ b/editor/src/plugins/probe.rs
@@ -321,7 +321,7 @@ pub struct ReflectionProbePlugin {
 
 impl EditorPlugin for ReflectionProbePlugin {
     fn on_ui_message(&mut self, message: &mut UiMessage, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let game_scene = some_or_return!(entry.controller.downcast_mut::<GameScene>());
         let panel = some_or_return!(self.panel.as_mut());
         panel.handle_ui_message(
@@ -334,7 +334,7 @@ impl EditorPlugin for ReflectionProbePlugin {
     }
 
     fn on_message(&mut self, message: &Message, editor: &mut Editor) {
-        let entry = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let entry = editor.scenes.current_scene_entry_mut();
         let game_scene = some_or_return!(entry.controller.downcast_mut::<GameScene>());
 
         let scene = &mut editor.engine.scenes[game_scene.scene];

--- a/editor/src/plugins/ragdoll.rs
+++ b/editor/src/plugins/ragdoll.rs
@@ -1269,7 +1269,7 @@ impl EditorPlugin for RagdollPlugin {
 
         let ui = editor.engine.user_interfaces.first_mut();
         let wizard = some_or_return!(self.ragdoll_wizard.as_mut());
-        let current_scene = some_or_return!(editor.scenes.current_scene_entry_mut());
+        let current_scene = editor.scenes.current_scene_entry_mut();
         let game_scene = some_or_return!(current_scene.controller.downcast_mut::<GameScene>());
         let graph = &mut editor.engine.scenes[game_scene.scene].graph;
         wizard.handle_ui_message(message, ui, graph, game_scene, &editor.message_sender);

--- a/editor/src/scene/mod.rs
+++ b/editor/src/scene/mod.rs
@@ -112,6 +112,7 @@ use std::{
 
 pub mod clipboard;
 pub mod dialog;
+mod nullscene;
 pub mod property;
 pub mod selector;
 pub mod settings;

--- a/editor/src/scene/nullscene.rs
+++ b/editor/src/scene/nullscene.rs
@@ -1,0 +1,277 @@
+// Copyright (c) 2019-present Dmitry Stepanov and Fyrox Engine contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//! The module for [`NullSceneController`] that provides a [`SceneController`] for when
+//! there is no scene to control.
+
+use fyrox::core::ComponentProvider;
+
+use crate::command::CommandContext;
+
+use super::*;
+
+/// The [`CommandContext`] that is used when the current scene is the
+/// null scene.
+#[derive(ComponentProvider)]
+pub struct NullSceneContext {
+    #[component(include)]
+    pub selection: &'static mut Selection,
+    #[component(include)]
+    pub message_sender: MessageSender,
+    #[component(include)]
+    pub resource_manager: ResourceManager,
+}
+
+impl CommandContext for NullSceneContext {}
+
+impl NullSceneContext {
+    pub fn exec<'a, F>(
+        selection: &'a mut Selection,
+        message_sender: MessageSender,
+        resource_manager: ResourceManager,
+        func: F,
+    ) where
+        F: FnOnce(&mut NullSceneContext),
+    {
+        // SAFETY: Temporarily extend lifetime to 'static and execute external closure with it.
+        // The closure accepts this extended context by reference, so there's no way it escapes to
+        // outer world. The initial lifetime is still preserved by this function call.
+        func(unsafe {
+            &mut Self {
+                selection: std::mem::transmute::<&'a mut _, &'static mut _>(selection),
+                message_sender,
+                resource_manager,
+            }
+        });
+    }
+}
+
+/// A scene controller for when there is no scene to control.
+/// Everything it does is as close to nothing as possible, since it
+/// controls no scene, but it allows commands to be added and undone
+/// with some minimal context provided by [`NullSceneContext`].
+pub struct NullSceneController {
+    pub sender: MessageSender,
+    pub resource_manager: ResourceManager,
+}
+
+#[allow(unused_variables)]
+impl SceneController for NullSceneController {
+    fn on_key_up(&mut self, key: KeyCode, engine: &mut Engine, key_bindings: &KeyBindings) -> bool {
+        false
+    }
+
+    fn on_key_down(
+        &mut self,
+        key: KeyCode,
+        engine: &mut Engine,
+        key_bindings: &KeyBindings,
+    ) -> bool {
+        false
+    }
+
+    fn on_mouse_move(
+        &mut self,
+        pos: Vector2<f32>,
+        offset: Vector2<f32>,
+        screen_bounds: Rect<f32>,
+        engine: &mut Engine,
+        settings: &Settings,
+    ) {
+    }
+
+    fn on_mouse_up(
+        &mut self,
+        button: MouseButton,
+        pos: Vector2<f32>,
+        screen_bounds: Rect<f32>,
+        engine: &mut Engine,
+        settings: &Settings,
+    ) {
+    }
+
+    fn on_mouse_down(
+        &mut self,
+        button: MouseButton,
+        pos: Vector2<f32>,
+        screen_bounds: Rect<f32>,
+        engine: &mut Engine,
+        settings: &Settings,
+    ) {
+    }
+
+    fn on_mouse_wheel(&mut self, amount: f32, engine: &mut Engine, settings: &Settings) {}
+
+    fn on_mouse_leave(&mut self, engine: &mut Engine, settings: &Settings) {}
+
+    fn on_drag_over(
+        &mut self,
+        handle: Handle<UiNode>,
+        screen_bounds: Rect<f32>,
+        engine: &mut Engine,
+        settings: &Settings,
+    ) {
+    }
+
+    fn on_drop(
+        &mut self,
+        handle: Handle<UiNode>,
+        screen_bounds: Rect<f32>,
+        engine: &mut Engine,
+        settings: &Settings,
+    ) {
+    }
+
+    fn render_target(&self, engine: &Engine) -> Option<fyrox::gui::texture::TextureResource> {
+        None
+    }
+
+    fn extension(&self) -> &str {
+        ""
+    }
+
+    fn save(
+        &mut self,
+        path: &std::path::Path,
+        settings: &Settings,
+        engine: &mut Engine,
+    ) -> Result<String, String> {
+        Err("Cannot save null scene".into())
+    }
+
+    fn do_command(
+        &mut self,
+        command_stack: &mut CommandStack,
+        command: crate::command::Command,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    ) {
+        NullSceneContext::exec(
+            selection,
+            self.sender.clone(),
+            engine.resource_manager.clone(),
+            |ctx| command_stack.do_command(command, ctx),
+        );
+    }
+
+    fn undo(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    ) {
+        NullSceneContext::exec(
+            selection,
+            self.sender.clone(),
+            engine.resource_manager.clone(),
+            |ctx| command_stack.undo(ctx),
+        );
+    }
+
+    fn redo(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    ) {
+        NullSceneContext::exec(
+            selection,
+            self.sender.clone(),
+            engine.resource_manager.clone(),
+            |ctx| command_stack.redo(ctx),
+        );
+    }
+
+    fn clear_command_stack(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        scenes: &mut fyrox::scene::SceneContainer,
+    ) {
+        NullSceneContext::exec(
+            selection,
+            self.sender.clone(),
+            self.resource_manager.clone(),
+            |ctx| command_stack.clear(ctx),
+        );
+    }
+
+    fn on_before_render(&mut self, editor_selection: &Selection, engine: &mut Engine) {}
+
+    fn on_after_render(&mut self, engine: &mut Engine) {}
+
+    fn update(
+        &mut self,
+        editor_selection: &Selection,
+        engine: &mut Engine,
+        dt: f32,
+        path: Option<&std::path::Path>,
+        settings: &mut Settings,
+        screen_bounds: Rect<f32>,
+    ) -> Option<fyrox::gui::texture::TextureResource> {
+        None
+    }
+
+    fn is_interacting(&self) -> bool {
+        false
+    }
+
+    fn on_destroy(
+        &mut self,
+        command_stack: &mut CommandStack,
+        engine: &mut Engine,
+        selection: &mut Selection,
+    ) {
+        panic!("The NullSceneController was destroyed!")
+    }
+
+    fn on_message(
+        &mut self,
+        message: &crate::Message,
+        selection: &Selection,
+        engine: &mut Engine,
+    ) -> bool {
+        false
+    }
+
+    fn command_names(
+        &mut self,
+        command_stack: &mut CommandStack,
+        selection: &mut Selection,
+        engine: &mut Engine,
+    ) -> Vec<String> {
+        command_stack
+            .commands
+            .iter_mut()
+            .map(|c| {
+                let mut name = String::new();
+                NullSceneContext::exec(
+                    selection,
+                    self.sender.clone(),
+                    engine.resource_manager.clone(),
+                    |ctx| {
+                        name = c.name(ctx);
+                    },
+                );
+                name
+            })
+            .collect::<Vec<_>>()
+    }
+}


### PR DESCRIPTION
## Description
This PR adds `null_scene` to `SceneContainer` to eliminate the need for `SceneContainer::current_scene_entry_mut()` to return an `Option`. Now there will always be a current scene entry, even when no scene is open, because there is a `NullSceneController` that acts as a `SceneController` for no scene, doing nothing in most of its methods, but still handling commands as necessary.

This means that the Asset Browser is able to function when no scene is open, because formerly the UI handling for the Asset Browser was effectively disabled since there was no practical way to make the Asset Browser work when the scene entry was `None`. With this PR the scene entry is never `None`.

This change has far-reaching consequences because it allows code to be simplified in many places in the editor that had to check whether the current scene was `None`, and thereby added another level of indenting to keep track of. A world where the scene entry is never `None` is a simpler world, and should make the editor easier to maintain from now on.

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
