### PR TITLE
Fix for macos fast scroll when pixel delta is received

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ fabric.properties
 # Resource Metadata
 *.meta
 *.registry
+.DS_Store


### PR DESCRIPTION
Fixes scroll sensitivity from: https://github.com/FyroxEngine/Fyrox/issues/892

There is still issue of scrollbar not rendering correct.

https://github.com/user-attachments/assets/778a5085-2d29-4470-b68d-895ddf683440

