### PR TITLE
Fix relative path resolution for symlinked asset directories

### DIFF
--- a/fyrox-core/src/lib.rs
+++ b/fyrox-core/src/lib.rs
@@ -329,6 +329,23 @@ pub fn make_relative_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, std::io::E
     } else {
         Path::new(".")
     };
+
+    let cwd = std::env::current_dir()?;
+
+    // Try without canonicalization first to preserve symlinks.
+    let non_canon_dir = if dir.is_absolute() {
+        dir.to_path_buf()
+    } else {
+        cwd.join(dir)
+    };
+    if non_canon_dir.is_dir() {
+        let non_canon_path = non_canon_dir.join(file_name);
+        if let Ok(relative_path) = non_canon_path.strip_prefix(&cwd) {
+            return Ok(replace_slashes(relative_path));
+        }
+    }
+
+    // Canonicalize to resolve `.` and `..` components.
     let canon_path = dir
         .canonicalize()
         .map_err(|err| {
@@ -338,13 +355,49 @@ pub fn make_relative_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, std::io::E
             ))
         })?
         .join(file_name);
-    match canon_path.strip_prefix(std::env::current_dir()?.canonicalize()?) {
-        Ok(relative_path) => Ok(replace_slashes(relative_path)),
-        Err(err) => Err(std::io::Error::other(format!(
-            "unable to strip prefix from '{}'! Reason: {err}",
-            canon_path.display()
-        ))),
+    let canon_cwd = cwd.canonicalize()?;
+    if let Ok(relative_path) = canon_path.strip_prefix(&canon_cwd) {
+        return Ok(replace_slashes(relative_path));
     }
+
+    // Last resort: resolve via symlinks in cwd to map canonical paths back to project-relative paths.
+    if let Some(relative) = find_symlink_relative_path(&cwd, &canon_path) {
+        return Ok(replace_slashes(relative));
+    }
+
+    Err(std::io::Error::other(format!(
+        "unable to strip prefix from '{}'! Reason: prefix not found",
+        canon_path.display()
+    )))
+}
+
+/// Searches `base_dir` (up to 4 levels deep) for a symlink whose target is a prefix of
+/// `canon_path`, returning the relative path through that symlink.
+fn find_symlink_relative_path(base_dir: &Path, canon_path: &Path) -> Option<PathBuf> {
+    fn walk(dir: &Path, prefix: &Path, canon_path: &Path, depth: u32) -> Option<PathBuf> {
+        const MAX_DEPTH: u32 = 4;
+        if depth > MAX_DEPTH {
+            return None;
+        }
+        let entries = std::fs::read_dir(dir).ok()?;
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if entry_path.is_symlink() {
+                if let Ok(link_target) = entry_path.canonicalize() {
+                    if let Ok(rest) = canon_path.strip_prefix(&link_target) {
+                        let relative_link = entry_path.strip_prefix(prefix).ok()?;
+                        return Some(relative_link.join(rest));
+                    }
+                }
+            } else if entry_path.is_dir() {
+                if let Some(result) = walk(&entry_path, prefix, canon_path, depth + 1) {
+                    return Some(result);
+                }
+            }
+        }
+        None
+    }
+    walk(base_dir, base_dir, canon_path, 0)
 }
 
 /// "Transmutes" array of any sized type to a slice of bytes.

--- a/fyrox-core/src/lib.rs
+++ b/fyrox-core/src/lib.rs
@@ -808,6 +808,47 @@ mod test {
         make_relative_path(Path::new("Cargo.toml").canonicalize().unwrap()).unwrap();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_make_relative_path_with_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let cwd = std::env::current_dir().unwrap();
+        let tmp = std::env::temp_dir().join("fyrox_symlink_test");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let project_dir = tmp.join("project");
+        let real_assets = tmp.join("real_assets");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::create_dir_all(&real_assets).unwrap();
+        std::fs::write(real_assets.join("test.txt"), "hello").unwrap();
+        symlink(&real_assets, project_dir.join("data")).unwrap();
+
+        std::env::set_current_dir(&project_dir).unwrap();
+
+        let real_path = real_assets.join("test.txt");
+        let result = make_relative_path(&real_path).unwrap();
+        assert_eq!(result, Path::new("data/test.txt"));
+
+        let symlink_path = project_dir.join("data").join("test.txt");
+        let result = make_relative_path(&symlink_path).unwrap();
+        assert_eq!(result, Path::new("data/test.txt"));
+
+        let real_textures = tmp.join("real_textures");
+        let assets_dir = project_dir.join("assets");
+        std::fs::create_dir_all(&assets_dir).unwrap();
+        std::fs::create_dir_all(&real_textures).unwrap();
+        std::fs::write(real_textures.join("brick.png"), "img").unwrap();
+        symlink(&real_textures, assets_dir.join("textures")).unwrap();
+
+        let real_path = real_textures.join("brick.png");
+        let result = make_relative_path(&real_path).unwrap();
+        assert_eq!(result, Path::new("assets/textures/brick.png"));
+
+        std::env::set_current_dir(cwd).unwrap();
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
     #[test]
     fn tests_case_insensitive_str_comparison() {
         assert!(cmp_strings_case_insensitive("FooBar", "FOOBaR"));


### PR DESCRIPTION
## Description

`make_relative_path` fails when asset directories are symlinks pointing outside the project. `canonicalize()` resolves symlinks to their real filesystem paths, so `strip_prefix` can no longer match the working directory and scene saving breaks entirely.

This PR adds a 3-step fallback strategy to `make_relative_path` in fyrox-core:

1. **Without canonicalization**: try `strip_prefix` on the raw path first, preserving symlinks. This handles the common case where the path already goes through the symlink textually.
2. **With canonicalization**: resolve `.` and `..` components and retry. This is the original behavior for non-symlink cases.
3. **Reverse symlink lookup**: if both fail, scan the working directory tree (up to 4 levels deep) for symlinks whose canonical target is a prefix of the resolved path, then reconstruct the relative path through that symlink.

A helper function `find_symlink_relative_path` was extracted for step 3 to keep things readable.

## Related Issue(s)

Fixes #907

## Review Guidance

The core change is in `fyrox-core/src/lib.rs`, function `make_relative_path`. No other files were modified.

The symlink scan (step 3) only runs as a last resort. Normal paths return at step 1 or 2 without any extra filesystem access. The recursive walk is capped at `MAX_DEPTH = 4` to avoid expensive traversals.

The test `test_make_relative_path_with_symlinks` covers both top-level symlinks (`project/data -> real_assets/`) and nested symlinks (`project/assets/textures -> real_textures/`), using both resolved and unresolved input paths. It is `#[cfg(unix)]` since symlinks behave differently on Windows. Both symlink scenarios are in a single test to avoid race conditions from the process-global `set_current_dir`.

## Screenshots/GIFs

N/A, this is a logic fix with no UI changes.

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)