### PR TITLE
Add `UI_FONT_SIZE` const in editor

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -716,6 +716,8 @@ fn make_light_style() -> StyleResource {
 }
 
 impl Editor {
+    pub const UI_FONT_SIZE: &'static str = "Editor.UI.Font.Size";
+
     pub fn new(startup_data: Option<StartupData>) -> Self {
         Self::new_with_settings(startup_data, Default::default())
     }

--- a/fyrox-ui/src/formatted_text.rs
+++ b/fyrox-ui/src/formatted_text.rs
@@ -25,7 +25,7 @@ use crate::{
         variable::InheritableVariable, visitor::prelude::*,
     },
     font::{Font, FontGlyph, FontHeight, FontResource, BUILT_IN_FONT},
-    style::StyledProperty,
+    style::{resource::StyleResource, StyledProperty},
     HorizontalAlignment, Thickness, VerticalAlignment,
 };
 use fyrox_resource::state::{LoadError, ResourceState};
@@ -724,6 +724,11 @@ impl FormattedText {
     /// Sets desired shadow offset in units.
     pub fn set_shadow_offset(&mut self, offset: Vector2<f32>) -> &mut Self {
         self.shadow_offset.set_value_and_mark_modified(offset);
+        self
+    }
+
+    pub fn set_style(&mut self, style: &StyleResource) -> &mut Self {
+        self.font_size.update(style);
         self
     }
 

--- a/fyrox-ui/src/formatted_text.rs
+++ b/fyrox-ui/src/formatted_text.rs
@@ -727,6 +727,7 @@ impl FormattedText {
         self
     }
 
+    /// Sets desired style.
     pub fn set_style(&mut self, style: &StyleResource) -> &mut Self {
         self.font_size.update(style);
         self

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -36,6 +36,7 @@ use crate::{
     style::{resource::StyleResourceExt, Style, StyledProperty},
     widget::{Widget, WidgetBuilder},
     BBCode, BuildContext, Control, HorizontalAlignment, UiNode, UserInterface, VerticalAlignment,
+    WidgetMessage,
 };
 use fyrox_core::algebra::Matrix3;
 use fyrox_core::variable::InheritableVariable;
@@ -401,7 +402,15 @@ impl Control for Text {
         self.widget.handle_routed_message(ui, message);
 
         if message.destination() == self.handle() {
-            if let Some(msg) = message.data::<TextMessage>() {
+            if let Some(msg) = message.data::<WidgetMessage>() {
+                match msg {
+                    WidgetMessage::Style(style) => {
+                        self.formatted_text.borrow_mut().set_style(style);
+                        self.invalidate_layout();
+                    }
+                    _ => {}
+                }
+            } else if let Some(msg) = message.data::<TextMessage>() {
                 let mut text_ref = self.formatted_text.borrow_mut();
                 match msg {
                     TextMessage::BBCode(text) => {

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -403,12 +403,9 @@ impl Control for Text {
 
         if message.destination() == self.handle() {
             if let Some(msg) = message.data::<WidgetMessage>() {
-                match msg {
-                    WidgetMessage::Style(style) => {
-                        self.formatted_text.borrow_mut().set_style(style);
-                        self.invalidate_layout();
-                    }
-                    _ => {}
+                if let WidgetMessage::Style(style) = msg {
+                    self.formatted_text.borrow_mut().set_style(style);
+                    self.invalidate_layout();
                 }
             } else if let Some(msg) = message.data::<TextMessage>() {
                 let mut text_ref = self.formatted_text.borrow_mut();

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -1316,6 +1316,10 @@ impl Control for TextBox {
                         self.selecting = false;
                         ui.release_mouse_capture();
                     }
+                    WidgetMessage::Style(style) => {
+                        self.formatted_text.borrow_mut().set_style(style);
+                        self.invalidate_layout();
+                    }
                     _ => {}
                 }
             } else if let Some(msg) = message.data::<TextMessage>() {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Adds a unique Style key in Editor to be used over the default used in fyrox-ui. (Not yet implemented)

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Related issue: #910 , prerequisite for future changes.

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
- No visible change in editor, this is a back-end only change that lays the foundation for the future.
- In [`editor/lib.rs`](https://github.com/CopeFiend/Fyrox/commit/0d0b070867e65ac37a9ec5c978e4e1c40af61e9e#diff-a35a0aa5817de64d944704d9e22747a6f1a25a308fe06ff674555de9135b1a7f), added new constant
```rust
pub const UI_FONT_SIZE: &'static str = "Editor.UI.Font.Size";
```
to be used over `pub const FONT_SIZE` as declared in `fyrox-ui/src/style/mod.rs`
- Added style update handling in [`fyrox-ui/src/text.rs`](https://github.com/CopeFiend/Fyrox/commit/0d0b070867e65ac37a9ec5c978e4e1c40af61e9e#diff-d5b2435b3d09f17e3012ffcae03219b68bc596496e4db89999a7b4ced2dd13dd)
- Added `pub fn set_style()` in [`fyrox-ui/formatted_text.rs`](https://github.com/FyroxEngine/Fyrox/pull/914/changes#diff-7313cfbf5a8cf817fd16330f2dc402f7dcc36559c0897ebd3eb1032c7c639b85#L730-L734)

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
N/A

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
