### PR TITLE
Refactor TextBuilder initialization

### DIFF
--- a/editor/src/asset/dependency.rs
+++ b/editor/src/asset/dependency.rs
@@ -73,11 +73,12 @@ fn build_tree_recursively(
     TreeBuilder::new(WidgetBuilder::new())
         .with_items(children)
         .with_content(
-            TextBuilder::new(
-                WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Center),
-            )
-            .with_text(format!("{name} ({data_type})"))
-            .build(ctx),
+            TextBuilder::new()
+                .with_widget_builder(
+                    WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Center),
+                )
+                .with_text(format!("{name} ({data_type})"))
+                .build(ctx),
         )
         .build(ctx)
 }

--- a/editor/src/asset/item.rs
+++ b/editor/src/asset/item.rs
@@ -350,14 +350,15 @@ fn make_tooltip(ctx: &mut BuildContext, text: &str) -> RcUiNodeHandle {
             .with_background(ctx.style.property(Style::BRUSH_TEXT))
             .with_max_size(Vector2::new(300.0, f32::INFINITY))
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::uniform(2.0))
-                        .with_foreground(ctx.style.property(Style::BRUSH_DARKER)),
-                )
-                .with_wrap(WrapMode::Letter)
-                .with_text(text)
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::uniform(2.0))
+                            .with_foreground(ctx.style.property(Style::BRUSH_DARKER)),
+                    )
+                    .with_wrap(WrapMode::Letter)
+                    .with_text(text)
+                    .build(ctx),
             ),
     )
     .build(ctx);
@@ -409,7 +410,10 @@ impl AssetItemBuilder {
                         .property(AssetItem::DESELECTED_TEXT_BORDER_BACKGROUND),
                 )
                 .with_child(
-                    TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(2.0)))
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
+                        )
                         .with_vertical_text_alignment(VerticalAlignment::Center)
                         .with_horizontal_text_alignment(HorizontalAlignment::Center)
                         .with_wrap(WrapMode::Word)

--- a/editor/src/asset/menu.rs
+++ b/editor/src/asset/menu.rs
@@ -153,16 +153,17 @@ impl AssetRenameDialogBuilder {
         let content = GridBuilder::new(
             WidgetBuilder::new()
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .on_row(0)
-                            .with_margin(Thickness::uniform(2.0)),
-                    )
-                    .with_text(format!(
-                        "Enter a new name for {old_file_name}.{extension} resource."
-                    ))
-                    .with_wrap(WrapMode::Word)
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .on_row(0)
+                                .with_margin(Thickness::uniform(2.0)),
+                        )
+                        .with_text(format!(
+                            "Enter a new name for {old_file_name}.{extension} resource."
+                        ))
+                        .with_wrap(WrapMode::Word)
+                        .build(ctx),
                 )
                 .with_child({
                     name_field = TextBoxBuilder::new(

--- a/editor/src/asset/preview/mod.rs
+++ b/editor/src/asset/preview/mod.rs
@@ -723,7 +723,7 @@ impl AssetPreviewGenerator for FontPreview {
             let mut ui = UserInterface::new(asset::item::DEFAULT_VEC_SIZE);
             ScreenBuilder::new(
                 WidgetBuilder::new().with_child(
-                    TextBuilder::new(WidgetBuilder::new())
+                    TextBuilder::new()
                         .with_font(font)
                         .with_font_size(16.0.into())
                         .with_vertical_text_alignment(VerticalAlignment::Center)

--- a/editor/src/asset/selector.rs
+++ b/editor/src/asset/selector.rs
@@ -181,22 +181,23 @@ impl ItemBuilder {
 
         let content = GridBuilder::new(
             WidgetBuilder::new().with_child(image).with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .on_row(1)
-                        .with_width(64.0)
-                        .with_margin(Thickness::uniform(1.0)),
-                )
-                .with_vertical_text_alignment(VerticalAlignment::Top)
-                .with_horizontal_text_alignment(HorizontalAlignment::Center)
-                .with_wrap(WrapMode::Word)
-                .with_text(
-                    self.path
-                        .file_name()
-                        .map(|file_name| file_name.to_string_lossy().to_string())
-                        .unwrap_or_default(),
-                )
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .on_row(1)
+                            .with_width(64.0)
+                            .with_margin(Thickness::uniform(1.0)),
+                    )
+                    .with_vertical_text_alignment(VerticalAlignment::Top)
+                    .with_horizontal_text_alignment(HorizontalAlignment::Center)
+                    .with_wrap(WrapMode::Word)
+                    .with_text(
+                        self.path
+                            .file_name()
+                            .map(|file_name| file_name.to_string_lossy().to_string())
+                            .unwrap_or_default(),
+                    )
+                    .build(ctx),
             ),
         )
         .add_row(Row::auto())

--- a/editor/src/audio/bus.rs
+++ b/editor/src/audio/bus.rs
@@ -108,18 +108,20 @@ fn make_items(buses: &[(Handle<AudioBus>, String)], ctx: &mut BuildContext) -> V
 
 fn make_effect_names(names: &[String], ctx: &mut BuildContext) -> Vec<Handle<UiNode>> {
     if names.is_empty() {
-        vec![TextBuilder::new(
-            WidgetBuilder::new().with_foreground(ctx.style.property(Style::BRUSH_LIGHTER)),
-        )
-        .with_text("No Effects")
-        .with_horizontal_text_alignment(HorizontalAlignment::Center)
-        .build(ctx)
-        .to_base()]
+        vec![TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new().with_foreground(ctx.style.property(Style::BRUSH_LIGHTER)),
+            )
+            .with_text("No Effects")
+            .with_horizontal_text_alignment(HorizontalAlignment::Center)
+            .build(ctx)
+            .to_base()]
     } else {
         names
             .iter()
             .map(|n| {
-                TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
+                TextBuilder::new()
+                    .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
                     .with_text(n)
                     .with_horizontal_text_alignment(HorizontalAlignment::Center)
                     .build(ctx)
@@ -186,13 +188,14 @@ impl AudioBusViewBuilder {
             WidgetBuilder::new()
                 .with_child(
                     BorderBuilder::new(WidgetBuilder::new().on_row(0).on_column(0).with_child({
-                        name = TextBuilder::new(
-                            WidgetBuilder::new()
-                                .with_horizontal_alignment(HorizontalAlignment::Center)
-                                .with_vertical_alignment(VerticalAlignment::Center),
-                        )
-                        .with_text(self.name)
-                        .build(ctx);
+                        name = TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new()
+                                    .with_horizontal_alignment(HorizontalAlignment::Center)
+                                    .with_vertical_alignment(VerticalAlignment::Center),
+                            )
+                            .with_text(self.name)
+                            .build(ctx);
                         name
                     }))
                     .build(ctx),

--- a/editor/src/audio/mod.rs
+++ b/editor/src/audio/mod.rs
@@ -243,13 +243,14 @@ impl AudioPanel {
                                 WidgetBuilder::new()
                                     .on_row(0)
                                     .with_child(
-                                        TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .with_margin(Thickness::uniform(1.0)),
-                                        )
-                                        .with_vertical_text_alignment(VerticalAlignment::Center)
-                                        .with_text("DM")
-                                        .build(ctx),
+                                        TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .with_margin(Thickness::uniform(1.0)),
+                                            )
+                                            .with_vertical_text_alignment(VerticalAlignment::Center)
+                                            .with_text("DM")
+                                            .build(ctx),
                                     )
                                     .with_child({
                                         distance_model = DropdownListBuilder::new(
@@ -274,13 +275,14 @@ impl AudioPanel {
                                         distance_model
                                     })
                                     .with_child(
-                                        TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .with_margin(Thickness::uniform(1.0)),
-                                        )
-                                        .with_vertical_text_alignment(VerticalAlignment::Center)
-                                        .with_text("Renderer")
-                                        .build(ctx),
+                                        TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .with_margin(Thickness::uniform(1.0)),
+                                            )
+                                            .with_vertical_text_alignment(VerticalAlignment::Center)
+                                            .with_text("Renderer")
+                                            .build(ctx),
                                     )
                                     .with_child({
                                         renderer = DropdownListBuilder::new(

--- a/editor/src/audio/preview.rs
+++ b/editor/src/audio/preview.rs
@@ -86,13 +86,14 @@ impl AudioPreviewPanel {
                                         .with_margin(Thickness::uniform(1.0)),
                                 )
                                 .with_content(
-                                    TextBuilder::new(
-                                        WidgetBuilder::new()
-                                            .on_column(0)
-                                            .with_vertical_alignment(VerticalAlignment::Center),
-                                    )
-                                    .with_text("Preview")
-                                    .build(ctx),
+                                    TextBuilder::new()
+                                        .with_widget_builder(
+                                            WidgetBuilder::new()
+                                                .on_column(0)
+                                                .with_vertical_alignment(VerticalAlignment::Center),
+                                        )
+                                        .with_text("Preview")
+                                        .build(ctx),
                                 )
                                 .build(ctx);
                                 preview
@@ -127,12 +128,13 @@ impl AudioPreviewPanel {
                         WidgetBuilder::new()
                             .on_row(1)
                             .with_child(
-                                TextBuilder::new(
-                                    WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
-                                )
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .with_text("Time, s")
-                                .build(ctx),
+                                TextBuilder::new()
+                                    .with_widget_builder(
+                                        WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
+                                    )
+                                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                                    .with_text("Time, s")
+                                    .build(ctx),
                             )
                             .with_child({
                                 time = ScrollBarBuilder::new(

--- a/editor/src/command/panel.rs
+++ b/editor/src/command/panel.rs
@@ -177,19 +177,20 @@ impl CommandStackViewer {
                     ui.style.property(Style::BRUSH_LIGHTEST)
                 };
 
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness {
-                            left: 2.0,
-                            top: 1.0,
-                            right: 2.0,
-                            bottom: 0.0,
-                        })
-                        .with_foreground(brush),
-                )
-                .with_text(name)
-                .build(&mut ui.build_ctx())
-                .to_base()
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness {
+                                left: 2.0,
+                                top: 1.0,
+                                right: 2.0,
+                                bottom: 0.0,
+                            })
+                            .with_foreground(brush),
+                    )
+                    .with_text(name)
+                    .build(&mut ui.build_ctx())
+                    .to_base()
             })
             .collect();
 

--- a/editor/src/configurator.rs
+++ b/editor/src/configurator.rs
@@ -84,7 +84,8 @@ fn make_history_entry_widget(ctx: &mut BuildContext, entry: &HistoryEntry) -> Ha
                 bottom: 1.0,
             })
             .with_child(
-                TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::left(5.0)))
+                TextBuilder::new()
+                    .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::left(5.0)))
                     .with_text(format!("{}", entry.work_dir.display(),))
                     .with_vertical_text_alignment(VerticalAlignment::Center)
                     .build(ctx),
@@ -143,7 +144,10 @@ impl Configurator {
                 WidgetBuilder::new()
                     .with_margin(Thickness::uniform(1.0))
                     .with_child(
-                        TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
+                        TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
+                            )
                             .with_text(message)
                             .with_wrap(WrapMode::Word)
                             .build(ctx),
@@ -153,15 +157,16 @@ impl Configurator {
                             WidgetBuilder::new()
                                 .on_row(1)
                                 .with_child(
-                                    TextBuilder::new(
-                                        WidgetBuilder::new()
-                                            .on_row(0)
-                                            .on_column(0)
-                                            .with_margin(Thickness::uniform(1.0))
-                                            .with_vertical_alignment(VerticalAlignment::Center),
-                                    )
-                                    .with_text("Working Directory")
-                                    .build(ctx),
+                                    TextBuilder::new()
+                                        .with_widget_builder(
+                                            WidgetBuilder::new()
+                                                .on_row(0)
+                                                .on_column(0)
+                                                .with_margin(Thickness::uniform(1.0))
+                                                .with_vertical_alignment(VerticalAlignment::Center),
+                                        )
+                                        .with_text("Working Directory")
+                                        .build(ctx),
                                 )
                                 .with_child({
                                     tb_work_dir = TextBoxBuilder::new(
@@ -201,14 +206,15 @@ impl Configurator {
                         .build(ctx),
                     )
                     .with_child(
-                        TextBuilder::new(
-                            WidgetBuilder::new()
-                                .with_margin(Thickness::uniform(5.0))
-                                .on_row(2),
-                        )
-                        .with_text("Previous Configurations")
-                        .with_horizontal_text_alignment(HorizontalAlignment::Center)
-                        .build(ctx),
+                        TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new()
+                                    .with_margin(Thickness::uniform(5.0))
+                                    .on_row(2),
+                            )
+                            .with_text("Previous Configurations")
+                            .with_horizontal_text_alignment(HorizontalAlignment::Center)
+                            .build(ctx),
                     )
                     .with_child({
                         lv_history = ListViewBuilder::new(

--- a/editor/src/export/mod.rs
+++ b/editor/src/export/mod.rs
@@ -82,14 +82,15 @@ pub struct ExportWindow {
 }
 
 fn make_title_text(text: &str, row: usize, ctx: &mut BuildContext) -> Handle<Text> {
-    TextBuilder::new(
-        WidgetBuilder::new()
-            .on_row(row)
-            .with_foreground(ctx.style.property(ExportWindow::TITLE_BRUSH))
-            .with_margin(Thickness::uniform(2.0)),
-    )
-    .with_text(text)
-    .build(ctx)
+    TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new()
+                .on_row(row)
+                .with_foreground(ctx.style.property(ExportWindow::TITLE_BRUSH))
+                .with_margin(Thickness::uniform(2.0)),
+        )
+        .with_text(text)
+        .build(ctx)
 }
 
 impl ExportWindow {
@@ -135,7 +136,7 @@ impl ExportWindow {
                                         .with_height(50.0)
                                         .with_margin(Thickness::uniform(1.0))
                                         .with_child(
-                                            TextBuilder::new(WidgetBuilder::new())
+                                            TextBuilder::new()
                                                 .with_vertical_text_alignment(
                                                     VerticalAlignment::Center,
                                                 )
@@ -163,7 +164,10 @@ impl ExportWindow {
             WidgetBuilder::new()
                 .on_row(2)
                 .with_child(
-                    TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(2.0)))
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
+                        )
                         .with_vertical_text_alignment(VerticalAlignment::Center)
                         .with_text("Build Target")
                         .build(ctx),
@@ -288,14 +292,15 @@ impl ExportWindow {
                 GridBuilder::new(
                     WidgetBuilder::new()
                         .with_child(
-                            TextBuilder::new(
-                                WidgetBuilder::new()
-                                    .on_row(0)
-                                    .with_margin(Thickness::uniform(2.0)),
-                            )
-                            .with_wrap(WrapMode::Word)
-                            .with_text(instructions)
-                            .build(ctx),
+                            TextBuilder::new()
+                                .with_widget_builder(
+                                    WidgetBuilder::new()
+                                        .on_row(0)
+                                        .with_margin(Thickness::uniform(2.0)),
+                                )
+                                .with_wrap(WrapMode::Word)
+                                .with_text(instructions)
+                                .build(ctx),
                         )
                         .with_child(platform_section)
                         .with_child(grid)
@@ -483,14 +488,15 @@ impl ExportWindow {
                     MessageKind::Warning => ctx.style.property(Style::BRUSH_WARNING),
                     MessageKind::Error => ctx.style.property(Style::BRUSH_ERROR),
                 };
-                let entry = TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::uniform(1.0))
-                        .with_foreground(foreground),
-                )
-                .with_wrap(WrapMode::Letter)
-                .with_text(format!("> {}", message.content))
-                .build(ctx);
+                let entry = TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::uniform(1.0))
+                            .with_foreground(foreground),
+                    )
+                    .with_wrap(WrapMode::Letter)
+                    .with_text(format!("> {}", message.content))
+                    .build(ctx);
 
                 ui.send(entry, WidgetMessage::link_with(self.log));
                 ui.send(self.log_scroll_viewer, ScrollViewerMessage::ScrollToEnd);

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -553,7 +553,7 @@ pub struct SceneLoadingWindow {
 
 impl SceneLoadingWindow {
     pub fn new(ctx: &mut BuildContext) -> Self {
-        let scene_list_text = TextBuilder::new(WidgetBuilder::new()).build(ctx);
+        let scene_list_text = TextBuilder::new().build(ctx);
         let window = WindowBuilder::new(WidgetBuilder::new().with_width(300.0).with_height(100.0))
             .with_title(WindowTitle::text("Please wait..."))
             .can_close(false)
@@ -566,15 +566,16 @@ impl SceneLoadingWindow {
                     WidgetBuilder::new()
                         .with_margin(Thickness::uniform(2.0))
                         .with_child(
-                            TextBuilder::new(
-                                WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
-                            )
-                            .with_wrap(WrapMode::Word)
-                            .with_text(
-                                "Please wait until the following scene(s) are \
+                            TextBuilder::new()
+                                .with_widget_builder(
+                                    WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
+                                )
+                                .with_wrap(WrapMode::Word)
+                                .with_text(
+                                    "Please wait until the following scene(s) are \
                                 fully loaded.",
-                            )
-                            .build(ctx),
+                                )
+                                .build(ctx),
                         )
                         .with_child(scene_list_text),
                 )
@@ -2272,7 +2273,10 @@ impl Editor {
         .with_text("Click Me!")
         .build(&mut ui.build_ctx());
 
-        TextBuilder::new(WidgetBuilder::new().with_desired_position(Vector2::new(300.0, 300.0)))
+        TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new().with_desired_position(Vector2::new(300.0, 300.0)),
+            )
             .with_text("This is some text.")
             .build(&mut ui.build_ctx());
 

--- a/editor/src/light.rs
+++ b/editor/src/light.rs
@@ -123,7 +123,8 @@ impl ProgressWindow {
                 GridBuilder::new(
                     WidgetBuilder::new()
                         .with_child(
-                            TextBuilder::new(WidgetBuilder::new().on_row(0))
+                            TextBuilder::new()
+                                .with_widget_builder(WidgetBuilder::new().on_row(0))
                                 .with_text(
                                     "Please wait until light map is fully generated. It may \
                                 take different amount of time depending on the settings.",
@@ -139,13 +140,14 @@ impl ProgressWindow {
                             progress_bar
                         })
                         .with_child({
-                            text = TextBuilder::new(
-                                WidgetBuilder::new()
-                                    .on_row(1)
-                                    .with_horizontal_alignment(HorizontalAlignment::Center)
-                                    .with_vertical_alignment(VerticalAlignment::Center),
-                            )
-                            .build(ctx);
+                            text = TextBuilder::new()
+                                .with_widget_builder(
+                                    WidgetBuilder::new()
+                                        .on_row(1)
+                                        .with_horizontal_alignment(HorizontalAlignment::Center)
+                                        .with_vertical_alignment(VerticalAlignment::Center),
+                                )
+                                .build(ctx);
                             text
                         })
                         .with_child({

--- a/editor/src/mesh.rs
+++ b/editor/src/mesh.rs
@@ -331,9 +331,11 @@ impl SurfaceDataViewer {
 
         let ctx = &mut engine.user_interfaces.first_mut().build_ctx();
 
-        let info =
-            TextBuilder::new(WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Top))
-                .build(ctx);
+        let info = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Top),
+            )
+            .build(ctx);
 
         let content = GridBuilder::new(
             WidgetBuilder::new()

--- a/editor/src/particle.rs
+++ b/editor/src/particle.rs
@@ -78,13 +78,14 @@ impl ParticleSystemPreviewControlPanel {
                             .with_margin(Thickness::uniform(1.0)),
                     )
                     .with_content(
-                        TextBuilder::new(
-                            WidgetBuilder::new()
-                                .with_vertical_alignment(VerticalAlignment::Center)
-                                .with_margin(Thickness::uniform(1.0)),
-                        )
-                        .with_text("Preview")
-                        .build(ctx),
+                        TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new()
+                                    .with_vertical_alignment(VerticalAlignment::Center)
+                                    .with_margin(Thickness::uniform(1.0)),
+                            )
+                            .with_text("Preview")
+                            .build(ctx),
                     )
                     .build(ctx);
                     preview
@@ -154,14 +155,15 @@ impl ParticleSystemPreviewControlPanel {
                             .on_row(1)
                             .on_column(0)
                             .with_child(
-                                TextBuilder::new(
-                                    WidgetBuilder::new()
-                                        .on_column(0)
-                                        .with_vertical_alignment(VerticalAlignment::Center)
-                                        .with_margin(Thickness::uniform(1.0)),
-                                )
-                                .with_text("Playback Time")
-                                .build(ctx),
+                                TextBuilder::new()
+                                    .with_widget_builder(
+                                        WidgetBuilder::new()
+                                            .on_column(0)
+                                            .with_vertical_alignment(VerticalAlignment::Center)
+                                            .with_margin(Thickness::uniform(1.0)),
+                                    )
+                                    .with_text("Playback Time")
+                                    .build(ctx),
                             )
                             .with_child({
                                 time = NumericUpDownBuilder::new(

--- a/editor/src/plugins/absm/blendspace.rs
+++ b/editor/src/plugins/absm/blendspace.rs
@@ -622,13 +622,14 @@ impl BlendSpaceFieldPointBuilder {
                 .with_cursor(Some(CursorIcon::Grab))
                 .with_clip_to_bounds(false)
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .with_margin(Thickness::left(10.0))
-                            .with_clip_to_bounds(false),
-                    )
-                    .with_text(format!("{:?}", self.index))
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .with_margin(Thickness::left(10.0))
+                                .with_clip_to_bounds(false),
+                        )
+                        .with_text(format!("{:?}", self.index))
+                        .build(ctx),
                 )
                 .with_width(10.0)
                 .with_height(10.0)
@@ -679,37 +680,46 @@ impl BlendSpaceEditor {
                             GridBuilder::new(
                                 WidgetBuilder::new()
                                     .with_child({
-                                        max_y = TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .on_row(0)
-                                                .with_margin(Thickness::uniform(1.0))
-                                                .with_height(22.0)
-                                                .with_vertical_alignment(VerticalAlignment::Top),
-                                        )
-                                        .build(ctx);
+                                        max_y = TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .on_row(0)
+                                                    .with_margin(Thickness::uniform(1.0))
+                                                    .with_height(22.0)
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Top,
+                                                    ),
+                                            )
+                                            .build(ctx);
                                         max_y
                                     })
                                     .with_child({
-                                        y_axis_name = TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .with_height(22.0)
-                                                .on_row(1)
-                                                .with_margin(Thickness::uniform(1.0))
-                                                .with_vertical_alignment(VerticalAlignment::Center),
-                                        )
-                                        .with_vertical_text_alignment(VerticalAlignment::Center)
-                                        .build(ctx);
+                                        y_axis_name = TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .with_height(22.0)
+                                                    .on_row(1)
+                                                    .with_margin(Thickness::uniform(1.0))
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Center,
+                                                    ),
+                                            )
+                                            .with_vertical_text_alignment(VerticalAlignment::Center)
+                                            .build(ctx);
                                         y_axis_name
                                     })
                                     .with_child({
-                                        min_y = TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .with_height(22.0)
-                                                .on_row(2)
-                                                .with_margin(Thickness::uniform(1.0))
-                                                .with_vertical_alignment(VerticalAlignment::Bottom),
-                                        )
-                                        .build(ctx);
+                                        min_y = TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .with_height(22.0)
+                                                    .on_row(2)
+                                                    .with_margin(Thickness::uniform(1.0))
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Bottom,
+                                                    ),
+                                            )
+                                            .build(ctx);
                                         min_y
                                     }),
                             )
@@ -726,44 +736,49 @@ impl BlendSpaceEditor {
                                     .on_row(1)
                                     .on_column(1)
                                     .with_child({
-                                        min_x = TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .on_column(0)
-                                                .with_margin(Thickness::uniform(1.0))
-                                                .with_width(50.0)
-                                                .with_horizontal_alignment(
-                                                    HorizontalAlignment::Left,
-                                                ),
-                                        )
-                                        .build(ctx);
+                                        min_x = TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .on_column(0)
+                                                    .with_margin(Thickness::uniform(1.0))
+                                                    .with_width(50.0)
+                                                    .with_horizontal_alignment(
+                                                        HorizontalAlignment::Left,
+                                                    ),
+                                            )
+                                            .build(ctx);
                                         min_x
                                     })
                                     .with_child({
-                                        x_axis_name = TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .on_column(1)
-                                                .with_margin(Thickness::uniform(1.0))
-                                                .with_width(50.0)
-                                                .with_horizontal_alignment(
-                                                    HorizontalAlignment::Center,
-                                                ),
-                                        )
-                                        .with_vertical_text_alignment(VerticalAlignment::Center)
-                                        .build(ctx);
+                                        x_axis_name = TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .on_column(1)
+                                                    .with_margin(Thickness::uniform(1.0))
+                                                    .with_width(50.0)
+                                                    .with_horizontal_alignment(
+                                                        HorizontalAlignment::Center,
+                                                    ),
+                                            )
+                                            .with_vertical_text_alignment(VerticalAlignment::Center)
+                                            .build(ctx);
                                         x_axis_name
                                     })
                                     .with_child({
-                                        max_x = TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .on_column(2)
-                                                .with_margin(Thickness::uniform(1.0))
-                                                .with_width(50.0)
-                                                .with_horizontal_alignment(
-                                                    HorizontalAlignment::Right,
-                                                ),
-                                        )
-                                        .with_horizontal_text_alignment(HorizontalAlignment::Right)
-                                        .build(ctx);
+                                        max_x = TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .on_column(2)
+                                                    .with_margin(Thickness::uniform(1.0))
+                                                    .with_width(50.0)
+                                                    .with_horizontal_alignment(
+                                                        HorizontalAlignment::Right,
+                                                    ),
+                                            )
+                                            .with_horizontal_text_alignment(
+                                                HorizontalAlignment::Right,
+                                            )
+                                            .build(ctx);
                                         max_x
                                     }),
                             )

--- a/editor/src/plugins/absm/node.rs
+++ b/editor/src/plugins/absm/node.rs
@@ -368,13 +368,14 @@ where
                         WidgetBuilder::new()
                             .on_column(1)
                             .with_child({
-                                name = TextBuilder::new(
-                                    WidgetBuilder::new().with_width(150.0).with_height(75.0),
-                                )
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .with_horizontal_text_alignment(HorizontalAlignment::Center)
-                                .with_text(format!("{} ({})", self.name, self.model_handle))
-                                .build(ctx);
+                                name = TextBuilder::new()
+                                    .with_widget_builder(
+                                        WidgetBuilder::new().with_width(150.0).with_height(75.0),
+                                    )
+                                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                                    .with_horizontal_text_alignment(HorizontalAlignment::Center)
+                                    .with_text(format!("{} ({})", self.name, self.model_handle))
+                                    .build(ctx);
                                 name
                             })
                             .with_child(if self.editable {
@@ -417,16 +418,19 @@ where
                                     .with_height(24.0)
                                     .with_background(ctx.style.property(Style::BRUSH_DARKER))
                                     .with_child(
-                                        TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .with_vertical_alignment(VerticalAlignment::Center)
-                                                .with_horizontal_alignment(
-                                                    HorizontalAlignment::Center,
-                                                )
-                                                .with_margin(Thickness::uniform(2.0)),
-                                        )
-                                        .with_text(title)
-                                        .build(ctx),
+                                        TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .with_vertical_alignment(
+                                                        VerticalAlignment::Center,
+                                                    )
+                                                    .with_horizontal_alignment(
+                                                        HorizontalAlignment::Center,
+                                                    )
+                                                    .with_margin(Thickness::uniform(2.0)),
+                                            )
+                                            .with_text(title)
+                                            .build(ctx),
                                     ),
                             )
                             .with_pad_by_corner_radius(false)

--- a/editor/src/plugins/absm/socket.rs
+++ b/editor/src/plugins/absm/socket.rs
@@ -195,12 +195,13 @@ impl SocketBuilder {
                                 pin
                             })
                             .with_child(if self.show_index {
-                                TextBuilder::new(
-                                    WidgetBuilder::new().with_margin(Thickness::left(2.0)),
-                                )
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .with_text(format!("{:?}", self.index))
-                                .build(ctx)
+                                TextBuilder::new()
+                                    .with_widget_builder(
+                                        WidgetBuilder::new().with_margin(Thickness::left(2.0)),
+                                    )
+                                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                                    .with_text(format!("{:?}", self.index))
+                                    .build(ctx)
                             } else {
                                 Handle::NONE
                             }),

--- a/editor/src/plugins/animation/toolbar.rs
+++ b/editor/src/plugins/animation/toolbar.rs
@@ -121,7 +121,8 @@ struct RootMotionDropdownArea {
 impl RootMotionDropdownArea {
     fn new(ctx: &mut BuildContext) -> Self {
         fn text(text: &str, row: usize, ctx: &mut BuildContext) -> Handle<Text> {
-            TextBuilder::new(WidgetBuilder::new().on_row(row).on_column(0))
+            TextBuilder::new()
+                .with_widget_builder(WidgetBuilder::new().on_row(row).on_column(0))
                 .with_vertical_text_alignment(VerticalAlignment::Center)
                 .with_text(text)
                 .build(ctx)
@@ -532,7 +533,7 @@ impl Toolbar {
                                         )),
                                 )
                                 .with_content(
-                                    TextBuilder::new(WidgetBuilder::new())
+                                    TextBuilder::new()
                                         .with_vertical_text_alignment(VerticalAlignment::Center)
                                         .with_text("Enabled")
                                         .build(ctx),

--- a/editor/src/plugins/animation/track.rs
+++ b/editor/src/plugins/animation/track.rs
@@ -517,14 +517,15 @@ impl TrackViewBuilder {
                     track_enabled_switch
                 })
                 .with_child({
-                    name_text = TextBuilder::new(
-                        WidgetBuilder::new()
-                            .with_margin(Thickness::uniform(1.0))
-                            .with_vertical_alignment(VerticalAlignment::Center)
-                            .on_column(1),
-                    )
-                    .with_text(self.name)
-                    .build(ctx);
+                    name_text = TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .with_margin(Thickness::uniform(1.0))
+                                .with_vertical_alignment(VerticalAlignment::Center)
+                                .on_column(1),
+                        )
+                        .with_text(self.name)
+                        .build(ctx);
                     name_text
                 }),
         )
@@ -1507,7 +1508,7 @@ impl TrackList {
                                 let ctx = &mut ui.build_ctx();
                                 let group = TreeBuilder::new(WidgetBuilder::new())
                                     .with_content(
-                                        TextBuilder::new(WidgetBuilder::new())
+                                        TextBuilder::new()
                                             .with_vertical_text_alignment(VerticalAlignment::Center)
                                             .with_text(format!(
                                                 "{} ({}:{})",
@@ -1583,17 +1584,18 @@ impl TrackList {
                                                 .build(ctx),
                                             )
                                             .with_child(
-                                                TextBuilder::new(
-                                                    WidgetBuilder::new().on_column(1).with_margin(
-                                                        Thickness {
-                                                            top: 2.0,
-                                                            left: 3.0,
-                                                            ..Default::default()
-                                                        },
-                                                    ),
-                                                )
-                                                .with_text(curve_name)
-                                                .build(ctx),
+                                                TextBuilder::new()
+                                                    .with_widget_builder(
+                                                        WidgetBuilder::new()
+                                                            .on_column(1)
+                                                            .with_margin(Thickness {
+                                                                top: 2.0,
+                                                                left: 3.0,
+                                                                ..Default::default()
+                                                            }),
+                                                    )
+                                                    .with_text(curve_name)
+                                                    .build(ctx),
                                             ),
                                     )
                                     .add_row(Row::auto())

--- a/editor/src/plugins/inspector/editors/font.rs
+++ b/editor/src/plugins/inspector/editors/font.rs
@@ -176,7 +176,7 @@ impl FontFieldBuilder {
             .widget_builder
             .with_allow_drop(true)
             .with_child({
-                text_preview = TextBuilder::new(WidgetBuilder::new())
+                text_preview = TextBuilder::new()
                     .with_wrap(WrapMode::Word)
                     .with_text(make_name(&resource_manager, &self.font))
                     .with_font(self.font.clone())

--- a/editor/src/plugins/inspector/editors/handle.rs
+++ b/editor/src/plugins/inspector/editors/handle.rs
@@ -367,18 +367,19 @@ impl<T: Reflect> HandlePropertyEditorBuilder<T> {
     }
 
     pub fn build(self, ctx: &mut BuildContext) -> Handle<HandlePropertyEditor<T>> {
-        let text = TextBuilder::new(
-            WidgetBuilder::new()
-                .on_column(0)
-                .with_vertical_alignment(VerticalAlignment::Center),
-        )
-        .with_vertical_text_alignment(VerticalAlignment::Center)
-        .with_text(if self.value.is_none() {
-            "Unassigned".to_owned()
-        } else {
-            "Err: Desync!".to_owned()
-        })
-        .build(ctx);
+        let text = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .on_column(0)
+                    .with_vertical_alignment(VerticalAlignment::Center),
+            )
+            .with_vertical_text_alignment(VerticalAlignment::Center)
+            .with_text(if self.value.is_none() {
+                "Unassigned".to_owned()
+            } else {
+                "Err: Desync!".to_owned()
+            })
+            .build(ctx);
         let locate_img = include_bytes!("../../../../resources/locate.png");
         let locate = make_button(ctx, locate_img, Color::repeat(180), 2, "Locate Object");
         let select_img = include_bytes!("../../../../resources/select_in_wv.png");

--- a/editor/src/plugins/inspector/editors/resource.rs
+++ b/editor/src/plugins/inspector/editors/resource.rs
@@ -328,14 +328,15 @@ where
                                 image
                             })
                             .with_child({
-                                name = TextBuilder::new(
-                                    WidgetBuilder::new()
-                                        .on_column(1)
-                                        .with_margin(Thickness::uniform(3.0)),
-                                )
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .with_text(resource_path(&resource_manager, &self.resource))
-                                .build(ctx);
+                                name = TextBuilder::new()
+                                    .with_widget_builder(
+                                        WidgetBuilder::new()
+                                            .on_column(1)
+                                            .with_margin(Thickness::uniform(3.0)),
+                                    )
+                                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                                    .with_text(resource_path(&resource_manager, &self.resource))
+                                    .build(ctx);
                                 name
                             })
                             .with_child({

--- a/editor/src/plugins/inspector/editors/script.rs
+++ b/editor/src/plugins/inspector/editors/script.rs
@@ -341,7 +341,8 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
                 .with_tooltip(make_simple_tooltip(ctx.build_context, "Open in IDE")),
         )
         .with_content(
-            TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(3.0)))
+            TextBuilder::new()
+                .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(3.0)))
                 .with_text("Edit...")
                 .with_vertical_text_alignment(VerticalAlignment::Center)
                 .build(ctx.build_context),

--- a/editor/src/plugins/inspector/editors/spritesheet/mod.rs
+++ b/editor/src/plugins/inspector/editors/spritesheet/mod.rs
@@ -108,13 +108,14 @@ impl SpriteSheetFramesPropertyEditor {
         let grid = GridBuilder::new(
             WidgetBuilder::new()
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .with_margin(Thickness::uniform(1.0))
-                            .on_column(0),
-                    )
-                    .with_text(format!("Frames: {}", container.len()))
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .with_margin(Thickness::uniform(1.0))
+                                .on_column(0),
+                        )
+                        .with_text(format!("Frames: {}", container.len()))
+                        .build(ctx),
                 )
                 .with_child({
                     edit_button = ButtonBuilder::new(

--- a/editor/src/plugins/inspector/editors/spritesheet/window.rs
+++ b/editor/src/plugins/inspector/editors/spritesheet/window.rs
@@ -261,16 +261,17 @@ impl SpriteSheetFramesEditorWindow {
                 .on_column(0)
                 .on_row(1)
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .with_margin(Thickness::uniform(2.0))
-                            .on_column(0)
-                            .on_row(0)
-                            .with_vertical_alignment(VerticalAlignment::Center)
-                            .with_tooltip(make_simple_tooltip(ctx, column_tooltip)),
-                    )
-                    .with_text("Width")
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .with_margin(Thickness::uniform(2.0))
+                                .on_column(0)
+                                .on_row(0)
+                                .with_vertical_alignment(VerticalAlignment::Center)
+                                .with_tooltip(make_simple_tooltip(ctx, column_tooltip)),
+                        )
+                        .with_text("Width")
+                        .build(ctx),
                 )
                 .with_child({
                     width = NumericUpDownBuilder::new(WidgetBuilder::new().on_column(1).on_row(0))
@@ -280,16 +281,17 @@ impl SpriteSheetFramesEditorWindow {
                     width
                 })
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .with_margin(Thickness::uniform(2.0))
-                            .on_column(0)
-                            .on_row(1)
-                            .with_vertical_alignment(VerticalAlignment::Center)
-                            .with_tooltip(make_simple_tooltip(ctx, row_tooltip)),
-                    )
-                    .with_text("Height")
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .with_margin(Thickness::uniform(2.0))
+                                .on_column(0)
+                                .on_row(1)
+                                .with_vertical_alignment(VerticalAlignment::Center)
+                                .with_tooltip(make_simple_tooltip(ctx, row_tooltip)),
+                        )
+                        .with_text("Height")
+                        .build(ctx),
                 )
                 .with_child({
                     height = NumericUpDownBuilder::new(WidgetBuilder::new().on_column(1).on_row(1))

--- a/editor/src/plugins/inspector/editors/surface.rs
+++ b/editor/src/plugins/inspector/editors/surface.rs
@@ -224,7 +224,8 @@ impl SurfaceDataPropertyEditor {
 
         let select = make_pick_button(1, ctx);
 
-        let text = TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
+        let text = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
             .with_text(surface_data_info(&resource_manager, &surface_resource))
             .build(ctx);
 

--- a/editor/src/plugins/inspector/editors/texture.rs
+++ b/editor/src/plugins/inspector/editors/texture.rs
@@ -218,14 +218,15 @@ impl TextureEditorBuilder {
 
         let select = utils::make_pick_button(2, ctx);
 
-        let path = TextBuilder::new(
-            WidgetBuilder::new()
-                .on_column(1)
-                .with_margin(Thickness::uniform(1.0))
-                .with_vertical_alignment(VerticalAlignment::Center),
-        )
-        .with_text(texture_name(self.texture.as_ref(), &resource_manager))
-        .build(ctx);
+        let path = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .on_column(1)
+                    .with_margin(Thickness::uniform(1.0))
+                    .with_vertical_alignment(VerticalAlignment::Center),
+            )
+            .with_text(texture_name(self.texture.as_ref(), &resource_manager))
+            .build(ctx);
 
         let locate = ImageButtonBuilder::default()
             .on_column(3)

--- a/editor/src/plugins/inspector/editors/triangle_buffer.rs
+++ b/editor/src/plugins/inspector/editors/triangle_buffer.rs
@@ -59,13 +59,14 @@ impl PropertyEditorDefinition for TriangleBufferPropertyEditorDefinition {
     ) -> Result<PropertyEditorInstance, InspectorError> {
         let value = ctx.property_info.cast_value::<TriangleBuffer>()?;
         Ok(PropertyEditorInstance::simple(
-            TextBuilder::new(
-                WidgetBuilder::new()
-                    .with_margin(Thickness::top_bottom(1.0))
-                    .with_vertical_alignment(VerticalAlignment::Center),
-            )
-            .with_text(triangle_buffer_description(value))
-            .build(ctx.build_context),
+            TextBuilder::new()
+                .with_widget_builder(
+                    WidgetBuilder::new()
+                        .with_margin(Thickness::top_bottom(1.0))
+                        .with_vertical_alignment(VerticalAlignment::Center),
+                )
+                .with_text(triangle_buffer_description(value))
+                .build(ctx.build_context),
         ))
     }
 

--- a/editor/src/plugins/inspector/editors/vertex_buffer.rs
+++ b/editor/src/plugins/inspector/editors/vertex_buffer.rs
@@ -59,13 +59,14 @@ impl PropertyEditorDefinition for VertexBufferPropertyEditorDefinition {
     ) -> Result<PropertyEditorInstance, InspectorError> {
         let value = ctx.property_info.cast_value::<VertexBuffer>()?;
         Ok(PropertyEditorInstance::simple(
-            TextBuilder::new(
-                WidgetBuilder::new()
-                    .with_margin(Thickness::top_bottom(1.0))
-                    .with_vertical_alignment(VerticalAlignment::Center),
-            )
-            .with_text(vertex_buffer_description(value))
-            .build(ctx.build_context),
+            TextBuilder::new()
+                .with_widget_builder(
+                    WidgetBuilder::new()
+                        .with_margin(Thickness::top_bottom(1.0))
+                        .with_vertical_alignment(VerticalAlignment::Center),
+                )
+                .with_text(vertex_buffer_description(value))
+                .build(ctx.build_context),
         ))
     }
 

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -234,16 +234,17 @@ impl InspectorPlugin {
                 GridBuilder::new(
                     WidgetBuilder::new()
                         .with_child({
-                            warning_text = TextBuilder::new(
-                                WidgetBuilder::new()
-                                    .with_visibility(false)
-                                    .with_margin(Thickness::left(4.0))
-                                    .with_foreground(ctx.style.property(Style::BRUSH_ERROR))
-                                    .on_row(0),
-                            )
-                            .with_wrap(WrapMode::Word)
-                            .with_text(warning_text_str)
-                            .build(ctx);
+                            warning_text = TextBuilder::new()
+                                .with_widget_builder(
+                                    WidgetBuilder::new()
+                                        .with_visibility(false)
+                                        .with_margin(Thickness::left(4.0))
+                                        .with_foreground(ctx.style.property(Style::BRUSH_ERROR))
+                                        .on_row(0),
+                                )
+                                .with_wrap(WrapMode::Word)
+                                .with_text(warning_text_str)
+                                .build(ctx);
                             warning_text
                         })
                         .with_child(
@@ -251,14 +252,15 @@ impl InspectorPlugin {
                                 WidgetBuilder::new()
                                     .on_row(1)
                                     .with_child({
-                                        type_name_text = TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .with_margin(Thickness::uniform(4.0))
-                                                .on_row(0)
-                                                .on_column(0),
-                                        )
-                                        .with_wrap(WrapMode::NoWrap)
-                                        .build(ctx);
+                                        type_name_text = TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .with_margin(Thickness::uniform(4.0))
+                                                    .on_row(0)
+                                                    .on_column(0),
+                                            )
+                                            .with_wrap(WrapMode::NoWrap)
+                                            .build(ctx);
                                         type_name_text
                                     })
                                     .with_child({

--- a/editor/src/plugins/material/editor.rs
+++ b/editor/src/plugins/material/editor.rs
@@ -318,11 +318,13 @@ impl MaterialFieldEditorBuilder {
             WidgetBuilder::new()
                 .on_column(1)
                 .with_child({
-                    text =
-                        TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
-                            .with_text(make_name(&resource_manager, &material))
-                            .with_vertical_text_alignment(VerticalAlignment::Center)
-                            .build(ctx);
+                    text = TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new().with_margin(Thickness::uniform(1.0)),
+                        )
+                        .with_text(make_name(&resource_manager, &material))
+                        .with_vertical_text_alignment(VerticalAlignment::Center)
+                        .build(ctx);
                     text
                 })
                 .with_child(buttons),

--- a/editor/src/plugins/material/mod.rs
+++ b/editor/src/plugins/material/mod.rs
@@ -130,7 +130,7 @@ fn make_item_container(ctx: &mut BuildContext, name: &str, item: Handle<UiNode>)
         WidgetBuilder::new()
             .with_margin(Thickness::uniform(1.0))
             .with_child(
-                TextBuilder::new(WidgetBuilder::new())
+                TextBuilder::new()
                     .with_text(name)
                     .with_vertical_text_alignment(VerticalAlignment::Center)
                     .build(ctx),
@@ -305,15 +305,16 @@ impl MaterialEditor {
                             WidgetBuilder::new()
                                 .on_row(0)
                                 .with_child(
-                                    TextBuilder::new(
-                                        WidgetBuilder::new()
-                                            .on_row(0)
-                                            .on_column(0)
-                                            .with_margin(Thickness::uniform(3.0)),
-                                    )
-                                    .with_vertical_text_alignment(VerticalAlignment::Center)
-                                    .with_text("Shader")
-                                    .build(ctx),
+                                    TextBuilder::new()
+                                        .with_widget_builder(
+                                            WidgetBuilder::new()
+                                                .on_row(0)
+                                                .on_column(0)
+                                                .with_margin(Thickness::uniform(3.0)),
+                                        )
+                                        .with_vertical_text_alignment(VerticalAlignment::Center)
+                                        .with_text("Shader")
+                                        .build(ctx),
                                 )
                                 .with_child({
                                     shader = ResourceFieldBuilder::<Shader>::new(

--- a/editor/src/plugins/stats.rs
+++ b/editor/src/plugins/stats.rs
@@ -70,9 +70,9 @@ impl EditorPlugin for EditorStatisticsPlugin {
         if let Some(MenuItemMessage::Click) = message.data() {
             if message.destination() == self.open_ui_stats && self.window.is_none() {
                 let ctx = &mut ui.build_ctx();
-                self.text =
-                    TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
-                        .build(ctx);
+                self.text = TextBuilder::new()
+                    .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
+                    .build(ctx);
                 self.window =
                     WindowBuilder::new(WidgetBuilder::new().with_width(200.0).with_height(130.0))
                         .with_title(WindowTitle::text("Editor Statistics"))

--- a/editor/src/plugins/tilemap/autotile.rs
+++ b/editor/src/plugins/tilemap/autotile.rs
@@ -92,7 +92,8 @@ fn make_failure_log_list(
 }
 
 fn make_list_item(text: &str, ctx: &mut BuildContext) -> Handle<UiNode> {
-    let content = TextBuilder::new(WidgetBuilder::new().on_column(1))
+    let content = TextBuilder::new()
+        .with_widget_builder(WidgetBuilder::new().on_column(1))
         .with_vertical_text_alignment(VerticalAlignment::Center)
         .with_horizontal_text_alignment(HorizontalAlignment::Left)
         .with_text(text)
@@ -493,9 +494,7 @@ impl BrushMacro for AutoTileMacro {
             tile_set,
             ctx,
         );
-        let failure_log_label = TextBuilder::new(WidgetBuilder::new())
-            .with_text("Failure Log Level")
-            .build(ctx);
+        let failure_log_label = TextBuilder::new().with_text("Failure Log Level").build(ctx);
         self.failure_log_list = make_failure_log_list(
             WidgetBuilder::new().on_column(1),
             instance.failure_log_kind,
@@ -511,16 +510,16 @@ impl BrushMacro for AutoTileMacro {
         .add_column(Row::strict(PROPERTY_LABEL_WIDTH))
         .add_column(Row::stretch())
         .build(ctx);
-        let pattern_prop_help_text =
-            TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(5.0)))
-                .with_wrap(WrapMode::Word)
-                .with_text(PATTERN_PROP_DESC)
-                .build(ctx);
-        let freq_prop_help_text =
-            TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(5.0)))
-                .with_wrap(WrapMode::Word)
-                .with_text(FREQUENCY_PROP_DESC)
-                .build(ctx);
+        let pattern_prop_help_text = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(5.0)))
+            .with_wrap(WrapMode::Word)
+            .with_text(PATTERN_PROP_DESC)
+            .build(ctx);
+        let freq_prop_help_text = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(5.0)))
+            .with_wrap(WrapMode::Word)
+            .with_text(FREQUENCY_PROP_DESC)
+            .build(ctx);
         let handle = StackPanelBuilder::new(
             WidgetBuilder::new()
                 .with_margin(Thickness::uniform(5.0))
@@ -573,7 +572,8 @@ impl BrushMacro for AutoTileMacro {
         let adjacent_field = GridBuilder::new(
             WidgetBuilder::new()
                 .with_child(
-                    TextBuilder::new(WidgetBuilder::new().on_column(1))
+                    TextBuilder::new()
+                        .with_widget_builder(WidgetBuilder::new().on_column(1))
                         .with_text("Adjacent")
                         .build(ctx),
                 )
@@ -586,7 +586,8 @@ impl BrushMacro for AutoTileMacro {
         let diagonal_field = GridBuilder::new(
             WidgetBuilder::new()
                 .with_child(
-                    TextBuilder::new(WidgetBuilder::new().on_column(1))
+                    TextBuilder::new()
+                        .with_widget_builder(WidgetBuilder::new().on_column(1))
                         .with_text("Diagonal")
                         .build(ctx),
                 )

--- a/editor/src/plugins/tilemap/brush_macro.rs
+++ b/editor/src/plugins/tilemap/brush_macro.rs
@@ -706,9 +706,7 @@ impl MacroPropertyValueField {
         ctx: &mut BuildContext,
     ) -> Self {
         use TileSetPropertyValueElement as Element;
-        let label = TextBuilder::new(WidgetBuilder::new())
-            .with_text(label)
-            .build(ctx);
+        let label = TextBuilder::new().with_text(label).build(ctx);
         let wb = WidgetBuilder::new().on_column(1);
         let textbox = match &value {
             Element::I32(v) => NumericUpDownBuilder::<i32>::new(wb)
@@ -881,11 +879,7 @@ impl MacroPropertyValueField {
 
 fn make_item(text: &str, ctx: &mut BuildContext) -> Handle<UiNode> {
     DecoratorBuilder::new(BorderBuilder::new(
-        WidgetBuilder::new().with_child(
-            TextBuilder::new(WidgetBuilder::new())
-                .with_text(text)
-                .build(ctx),
-        ),
+        WidgetBuilder::new().with_child(TextBuilder::new().with_text(text).build(ctx)),
     ))
     .build(ctx)
     .to_base()
@@ -946,9 +940,7 @@ impl MacroPropertyField {
         tile_set: Option<&TileSet>,
         ctx: &mut BuildContext,
     ) -> Self {
-        let label = TextBuilder::new(WidgetBuilder::new())
-            .with_text(label)
-            .build(ctx);
+        let label = TextBuilder::new().with_text(label).build(ctx);
         let (index, items) = make_index_and_items(prop_type, value, tile_set, ctx);
         let list = DropdownListBuilder::new(WidgetBuilder::new().on_column(1))
             .with_items(items)

--- a/editor/src/plugins/tilemap/collider_editor.rs
+++ b/editor/src/plugins/tilemap/collider_editor.rs
@@ -105,7 +105,7 @@ pub struct TileColliderEditor {
 }
 
 pub fn make_list_option(ctx: &mut BuildContext, name: &str) -> Handle<UiNode> {
-    let text = TextBuilder::new(WidgetBuilder::new())
+    let text = TextBuilder::new()
         .with_vertical_text_alignment(VerticalAlignment::Center)
         .with_horizontal_text_alignment(HorizontalAlignment::Left)
         .with_text(name)
@@ -140,7 +140,8 @@ impl TileColliderEditor {
         .build(ctx);
         let draw_button = make_draw_button(Some(0), ctx);
         let show_button = make_show_button(Some(1), ctx);
-        let name_field = TextBuilder::new(WidgetBuilder::new().on_column(3))
+        let name_field = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().on_column(3))
             .with_text(collider_layer.name.clone())
             .build(ctx);
         let custom_field =
@@ -149,7 +150,8 @@ impl TileColliderEditor {
                 .with_wrap(WrapMode::Word)
                 .with_text_commit_mode(TextCommitMode::Changed)
                 .build(ctx);
-        let error_field = TextBuilder::new(WidgetBuilder::new().with_visibility(false))
+        let error_field = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().with_visibility(false))
             .with_wrap(WrapMode::Word)
             .with_horizontal_text_alignment(HorizontalAlignment::Center)
             .build(ctx);

--- a/editor/src/plugins/tilemap/colliders_tab.rs
+++ b/editor/src/plugins/tilemap/colliders_tab.rs
@@ -112,15 +112,16 @@ pub fn make_list_item(ctx: &mut BuildContext, collider: &TileSetColliderLayer) -
                 .build(ctx),
             )
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::left(5.0))
-                        .on_column(1),
-                )
-                .with_vertical_text_alignment(VerticalAlignment::Center)
-                .with_horizontal_text_alignment(HorizontalAlignment::Left)
-                .with_text(collider.name.clone())
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::left(5.0))
+                            .on_column(1),
+                    )
+                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                    .with_horizontal_text_alignment(HorizontalAlignment::Left)
+                    .with_text(collider.name.clone())
+                    .build(ctx),
             ),
     )
     .add_row(Row::auto())
@@ -172,13 +173,14 @@ impl CollidersTab {
         .add_column(Column::stretch())
         .add_column(Column::stretch())
         .build(ctx);
-        let left_label = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_horizontal_alignment(HorizontalAlignment::Center)
-                .with_margin(Thickness::uniform(2.0)),
-        )
-        .with_text("Colliders:")
-        .build(ctx);
+        let left_label = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_horizontal_alignment(HorizontalAlignment::Center)
+                    .with_margin(Thickness::uniform(2.0)),
+            )
+            .with_text("Colliders:")
+            .build(ctx);
         let left_side = GridBuilder::new(
             WidgetBuilder::new()
                 .with_margin(Thickness::uniform(2.0))
@@ -191,13 +193,14 @@ impl CollidersTab {
         .add_row(Row::strict(30.0))
         .add_column(Column::stretch())
         .build(ctx);
-        let name_text = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_vertical_alignment(VerticalAlignment::Center)
-                .with_margin(Thickness::right(4.0)),
-        )
-        .with_text("Name:")
-        .build(ctx);
+        let name_text = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_vertical_alignment(VerticalAlignment::Center)
+                    .with_margin(Thickness::right(4.0)),
+            )
+            .with_text("Name:")
+            .build(ctx);
         let name_field = TextBoxBuilder::new(WidgetBuilder::new().with_height(20.0).on_column(1))
             .with_text_commit_mode(TextCommitMode::Changed)
             .with_vertical_text_alignment(VerticalAlignment::Center)

--- a/editor/src/plugins/tilemap/handle_field.rs
+++ b/editor/src/plugins/tilemap/handle_field.rs
@@ -75,9 +75,7 @@ fn value_to_string(value: Option<TileDefinitionHandle>) -> String {
 }
 
 fn make_label(name: &str, ctx: &mut BuildContext) -> Handle<Text> {
-    TextBuilder::new(WidgetBuilder::new())
-        .with_text(name)
-        .build(ctx)
+    TextBuilder::new().with_text(name).build(ctx)
 }
 
 impl Control for TileHandleField {

--- a/editor/src/plugins/tilemap/macro_inspector.rs
+++ b/editor/src/plugins/tilemap/macro_inspector.rs
@@ -128,12 +128,13 @@ fn make_remove_button(ctx: &mut BuildContext) -> Handle<Button> {
 
 impl ItemHeader {
     fn new(name: String, has_cell: bool, ctx: &mut BuildContext) -> Self {
-        let label = TextBuilder::new(
-            WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Center),
-        )
-        .with_vertical_text_alignment(VerticalAlignment::Center)
-        .with_text(name)
-        .build(ctx);
+        let label = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Center),
+            )
+            .with_vertical_text_alignment(VerticalAlignment::Center)
+            .with_text(name)
+            .build(ctx);
         let button = if has_cell {
             make_remove_button(ctx)
         } else {

--- a/editor/src/plugins/tilemap/macro_tab.rs
+++ b/editor/src/plugins/tilemap/macro_tab.rs
@@ -108,26 +108,28 @@ pub fn make_list_item(
     let content = GridBuilder::new(
         WidgetBuilder::new()
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::right(5.0))
-                        .on_column(0),
-                )
-                .with_vertical_text_alignment(VerticalAlignment::Center)
-                .with_horizontal_text_alignment(HorizontalAlignment::Right)
-                .with_text(macro_name)
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::right(5.0))
+                            .on_column(0),
+                    )
+                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                    .with_horizontal_text_alignment(HorizontalAlignment::Right)
+                    .with_text(macro_name)
+                    .build(ctx),
             )
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::left(5.0))
-                        .on_column(1),
-                )
-                .with_vertical_text_alignment(VerticalAlignment::Center)
-                .with_horizontal_text_alignment(HorizontalAlignment::Left)
-                .with_text(instance_name)
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::left(5.0))
+                            .on_column(1),
+                    )
+                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                    .with_horizontal_text_alignment(HorizontalAlignment::Left)
+                    .with_text(instance_name)
+                    .build(ctx),
             ),
     )
     .add_row(Row::auto())
@@ -236,13 +238,14 @@ impl MacroTab {
                 .build(ctx),
         )
         .build(ctx);
-        let left_label = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_horizontal_alignment(HorizontalAlignment::Center)
-                .with_margin(Thickness::uniform(2.0)),
-        )
-        .with_text("Macros:")
-        .build(ctx);
+        let left_label = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_horizontal_alignment(HorizontalAlignment::Center)
+                    .with_margin(Thickness::uniform(2.0)),
+            )
+            .with_text("Macros:")
+            .build(ctx);
         let left_side = GridBuilder::new(
             WidgetBuilder::new()
                 .with_margin(Thickness::uniform(2.0))
@@ -257,13 +260,14 @@ impl MacroTab {
         .add_row(Row::auto())
         .add_column(Column::stretch())
         .build(ctx);
-        let name_text = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_vertical_alignment(VerticalAlignment::Center)
-                .with_margin(Thickness::right(4.0)),
-        )
-        .with_text("Name:")
-        .build(ctx);
+        let name_text = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_vertical_alignment(VerticalAlignment::Center)
+                    .with_margin(Thickness::right(4.0)),
+            )
+            .with_text("Name:")
+            .build(ctx);
         let name_field = TextBoxBuilder::new(WidgetBuilder::new().with_height(20.0).on_column(1))
             .with_text_commit_mode(TextCommitMode::Changed)
             .with_vertical_text_alignment(VerticalAlignment::Center)

--- a/editor/src/plugins/tilemap/mod.rs
+++ b/editor/src/plugins/tilemap/mod.rs
@@ -924,7 +924,8 @@ pub fn make_named_value_list_option(
             .with_background(Brush::Solid(color).into()),
     )
     .build(ctx);
-    let text = TextBuilder::new(WidgetBuilder::new().on_column(1))
+    let text = TextBuilder::new()
+        .with_widget_builder(WidgetBuilder::new().on_column(1))
         .with_vertical_text_alignment(VerticalAlignment::Center)
         .with_horizontal_text_alignment(HorizontalAlignment::Left)
         .with_text(name)

--- a/editor/src/plugins/tilemap/panel.rs
+++ b/editor/src/plugins/tilemap/panel.rs
@@ -165,7 +165,9 @@ impl TileMapPanel {
     /// or the current active tool has changed, so the main purpose of the tile map panel is to manipulate
     /// this state.
     pub fn new(ctx: &mut BuildContext, state: TileDrawStateRef, sender: MessageSender) -> Self {
-        let tile_set_name = TextBuilder::new(WidgetBuilder::new().on_row(0)).build(ctx);
+        let tile_set_name = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().on_row(0))
+            .build(ctx);
         let preview = PanelPreviewBuilder::new(
             WidgetBuilder::new()
                 .with_margin(Thickness::uniform(1.0))

--- a/editor/src/plugins/tilemap/properties_tab.rs
+++ b/editor/src/plugins/tilemap/properties_tab.rs
@@ -124,7 +124,10 @@ fn make_type_widget(ctx: &mut BuildContext, prop_type: TileSetPropertyType) -> H
         TileSetPropertyType::String => "STRING",
         TileSetPropertyType::NineSlice => "NINE",
     };
-    TextBuilder::new(WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Center))
+    TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Center),
+        )
         .with_vertical_text_alignment(VerticalAlignment::Center)
         .with_horizontal_text_alignment(HorizontalAlignment::Right)
         .with_font_size((10.0).into())
@@ -137,15 +140,16 @@ fn make_list_item(ctx: &mut BuildContext, property: &TileSetPropertyLayer) -> Ha
         WidgetBuilder::new()
             .with_child(make_type_widget(ctx, property.prop_type))
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::left(10.0))
-                        .on_column(1),
-                )
-                .with_vertical_text_alignment(VerticalAlignment::Center)
-                .with_horizontal_text_alignment(HorizontalAlignment::Left)
-                .with_text(property.name.clone())
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::left(10.0))
+                            .on_column(1),
+                    )
+                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                    .with_horizontal_text_alignment(HorizontalAlignment::Left)
+                    .with_text(property.name.clone())
+                    .build(ctx),
             ),
     )
     .add_row(Row::auto())
@@ -175,7 +179,10 @@ fn make_value_widget(ctx: &mut BuildContext, value: NamableValue) -> Handle<Text
         NamableValue::I32(x) => x.to_string(),
         NamableValue::F32(x) => x.to_string(),
     };
-    TextBuilder::new(WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Center))
+    TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new().with_vertical_alignment(VerticalAlignment::Center),
+        )
         .with_vertical_text_alignment(VerticalAlignment::Center)
         .with_horizontal_text_alignment(HorizontalAlignment::Right)
         .with_text(text)
@@ -199,15 +206,16 @@ fn make_name_list_item(ctx: &mut BuildContext, named_value: &NamedValue) -> Hand
             )
             .with_child(make_value_widget(ctx, named_value.value))
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::left(10.0))
-                        .on_column(2),
-                )
-                .with_vertical_text_alignment(VerticalAlignment::Center)
-                .with_horizontal_text_alignment(HorizontalAlignment::Left)
-                .with_text(&named_value.name)
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::left(10.0))
+                            .on_column(2),
+                    )
+                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                    .with_horizontal_text_alignment(HorizontalAlignment::Left)
+                    .with_text(&named_value.name)
+                    .build(ctx),
             ),
     )
     .add_row(Row::auto())
@@ -292,13 +300,14 @@ impl PropertiesTab {
         .add_column(Column::stretch())
         .add_column(Column::stretch())
         .build(ctx);
-        let left_label = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_horizontal_alignment(HorizontalAlignment::Center)
-                .with_margin(Thickness::uniform(2.0)),
-        )
-        .with_text("Properties:")
-        .build(ctx);
+        let left_label = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_horizontal_alignment(HorizontalAlignment::Center)
+                    .with_margin(Thickness::uniform(2.0)),
+            )
+            .with_text("Properties:")
+            .build(ctx);
         let left_side = GridBuilder::new(
             WidgetBuilder::new()
                 .with_margin(Thickness::uniform(2.0))
@@ -313,20 +322,22 @@ impl PropertiesTab {
         .add_row(Row::auto())
         .add_column(Column::stretch())
         .build(ctx);
-        let name_text_0 = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_vertical_alignment(VerticalAlignment::Center)
-                .with_margin(Thickness::right(4.0)),
-        )
-        .with_text("Name:")
-        .build(ctx);
-        let name_text_1 = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_vertical_alignment(VerticalAlignment::Center)
-                .with_margin(Thickness::right(4.0)),
-        )
-        .with_text("Name:")
-        .build(ctx);
+        let name_text_0 = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_vertical_alignment(VerticalAlignment::Center)
+                    .with_margin(Thickness::right(4.0)),
+            )
+            .with_text("Name:")
+            .build(ctx);
+        let name_text_1 = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_vertical_alignment(VerticalAlignment::Center)
+                    .with_margin(Thickness::right(4.0)),
+            )
+            .with_text("Name:")
+            .build(ctx);
         let name_field = TextBoxBuilder::new(WidgetBuilder::new().with_height(20.0).on_column(1))
             .with_vertical_text_alignment(VerticalAlignment::Center)
             .with_text_commit_mode(TextCommitMode::Changed)

--- a/editor/src/plugins/tilemap/tile_editor.rs
+++ b/editor/src/plugins/tilemap/tile_editor.rs
@@ -109,9 +109,7 @@ pub trait TileEditor: Send {
 }
 
 fn make_label(name: &str, ctx: &mut BuildContext) -> Handle<Text> {
-    TextBuilder::new(WidgetBuilder::new())
-        .with_text(name)
-        .build(ctx)
+    TextBuilder::new().with_text(name).build(ctx)
 }
 
 fn make_draw_button(

--- a/editor/src/plugins/tilemap/tile_inspector.rs
+++ b/editor/src/plugins/tilemap/tile_inspector.rs
@@ -456,9 +456,7 @@ fn make_button(
 }
 
 fn make_label(name: &str, ctx: &mut BuildContext) -> Handle<Text> {
-    TextBuilder::new(WidgetBuilder::new())
-        .with_text(name)
-        .build(ctx)
+    TextBuilder::new().with_text(name).build(ctx)
 }
 
 fn highlight_tool_button(button: Handle<Button>, highlight: bool, ui: &UserInterface) {

--- a/editor/src/plugins/tilemap/tile_prop_editor.rs
+++ b/editor/src/plugins/tilemap/tile_prop_editor.rs
@@ -116,7 +116,7 @@ impl TilePropertyEditor {
         ctx: &mut BuildContext,
     ) -> Self {
         let draw_button = make_draw_button(Some(0), ctx);
-        let name_field = TextBuilder::new(WidgetBuilder::new())
+        let name_field = TextBuilder::new()
             .with_text(prop_layer.name.clone())
             .build(ctx);
         let value_field = match prop_layer.prop_type {

--- a/editor/src/plugins/tilemap/tileset.rs
+++ b/editor/src/plugins/tilemap/tileset.rs
@@ -133,7 +133,8 @@ fn make_tab(
 ) -> TabDefinition {
     TabDefinition {
         uuid,
-        header: TextBuilder::new(WidgetBuilder::new().with_margin(TAB_MARGIN))
+        header: TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().with_margin(TAB_MARGIN))
             .with_text(name)
             .build(ctx)
             .to_base(),
@@ -163,9 +164,7 @@ fn make_button(
 }
 
 fn make_label(name: &str, ctx: &mut BuildContext) -> Handle<Text> {
-    TextBuilder::new(WidgetBuilder::new())
-        .with_text(name)
-        .build(ctx)
+    TextBuilder::new().with_text(name).build(ctx)
 }
 
 fn tile_set_to_title(resource_manager: &ResourceManager, tile_book: &TileBook) -> String {
@@ -239,7 +238,7 @@ impl TileSetEditor {
         let remove;
         let all_pages;
         let all_tiles;
-        let cell_position = TextBuilder::new(WidgetBuilder::new()).build(ctx);
+        let cell_position = TextBuilder::new().build(ctx);
         let pick_button = make_drawing_mode_button(
             ctx,
             20.0,

--- a/editor/src/plugins/tilemap/wfc.rs
+++ b/editor/src/plugins/tilemap/wfc.rs
@@ -163,7 +163,7 @@ fn make_terrain_list_element(
     layer: Option<&TileSetPropertyLayer>,
     ctx: &mut BuildContext,
 ) -> (Handle<UiNode>, TerrainWidgets) {
-    let number = TextBuilder::new(WidgetBuilder::new())
+    let number = TextBuilder::new()
         .with_text(terrain.to_string())
         .with_horizontal_text_alignment(HorizontalAlignment::Right)
         .build(ctx);
@@ -184,7 +184,8 @@ fn make_terrain_list_element(
             .with_background(Brush::Solid(color).into()),
     )
     .build(ctx);
-    let name_text = TextBuilder::new(WidgetBuilder::new().on_column(2))
+    let name_text = TextBuilder::new()
+        .with_widget_builder(WidgetBuilder::new().on_column(2))
         .with_text(name.clone())
         .build(ctx);
     let frequency_field = NumericUpDownBuilder::new(
@@ -528,16 +529,16 @@ impl BrushMacro for WfcMacro {
             tile_set,
             ctx,
         );
-        let pattern_prop_help_text =
-            TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(5.0)))
-                .with_wrap(WrapMode::Word)
-                .with_text(PATTERN_PROP_DESC)
-                .build(ctx);
-        let freq_prop_help_text =
-            TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(5.0)))
-                .with_wrap(WrapMode::Word)
-                .with_text(FREQUENCY_PROP_DESC)
-                .build(ctx);
+        let pattern_prop_help_text = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(5.0)))
+            .with_wrap(WrapMode::Word)
+            .with_text(PATTERN_PROP_DESC)
+            .build(ctx);
+        let freq_prop_help_text = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(5.0)))
+            .with_wrap(WrapMode::Word)
+            .with_text(FREQUENCY_PROP_DESC)
+            .build(ctx);
         let constrain_edges = instance.constrain_edges;
         let attempts = instance.max_attempts;
         self.attempts_field = NumericUpDownBuilder::new(WidgetBuilder::new().on_column(1))
@@ -549,7 +550,8 @@ impl BrushMacro for WfcMacro {
         let edges_field = GridBuilder::new(
             WidgetBuilder::new()
                 .with_child(
-                    TextBuilder::new(WidgetBuilder::new().on_column(1))
+                    TextBuilder::new()
+                        .with_widget_builder(WidgetBuilder::new().on_column(1))
                         .with_text("Constrain Edges")
                         .build(ctx),
                 )
@@ -561,11 +563,7 @@ impl BrushMacro for WfcMacro {
         .build(ctx);
         let attempts_field = GridBuilder::new(
             WidgetBuilder::new()
-                .with_child(
-                    TextBuilder::new(WidgetBuilder::new())
-                        .with_text("Max Attempts")
-                        .build(ctx),
-                )
+                .with_child(TextBuilder::new().with_text("Max Attempts").build(ctx))
                 .with_child(self.attempts_field),
         )
         .add_row(Row::auto())

--- a/editor/src/scene/dialog.rs
+++ b/editor/src/scene/dialog.rs
@@ -72,14 +72,15 @@ impl NodeRemovalDialog {
                 GridBuilder::new(
                     WidgetBuilder::new()
                         .with_child(
-                            TextBuilder::new(
-                                WidgetBuilder::new()
-                                    .on_row(0)
-                                    .with_margin(Thickness::uniform(1.0)),
-                            )
-                            .with_wrap(WrapMode::Word)
-                            .with_text(text)
-                            .build(ctx),
+                            TextBuilder::new()
+                                .with_widget_builder(
+                                    WidgetBuilder::new()
+                                        .on_row(0)
+                                        .with_margin(Thickness::uniform(1.0)),
+                                )
+                                .with_wrap(WrapMode::Word)
+                                .with_text(text)
+                                .build(ctx),
                         )
                         .with_child(
                             ScrollViewerBuilder::new(

--- a/editor/src/scene/property.rs
+++ b/editor/src/scene/property.rs
@@ -149,7 +149,8 @@ impl PropertyDescriptor {
             ))))
             .with_items(items)
             .with_content(
-                TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
+                TextBuilder::new()
+                    .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
                     .with_text(name)
                     .build(ctx),
             )

--- a/editor/src/scene/selector.rs
+++ b/editor/src/scene/selector.rs
@@ -150,7 +150,8 @@ impl HierarchyNode {
                 .collect(),
         )
         .with_content(
-            TextBuilder::new(WidgetBuilder::new().with_foreground(brush))
+            TextBuilder::new()
+                .with_widget_builder(WidgetBuilder::new().with_foreground(brush))
                 .with_text(make_node_name(&self.name, self.handle) + " - " + &self.inner_type_name)
                 .build(ctx),
         )
@@ -577,22 +578,23 @@ impl NodeSelectorWindowBuilder {
         let content = GridBuilder::new(
             WidgetBuilder::new()
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .with_visibility(!self.allowed_types.is_empty())
-                            .with_margin(Thickness::uniform(2.0)),
-                    )
-                    .with_text(
-                        "Select a node of the following type(s):\n".to_string()
-                            + &self
-                                .allowed_types
-                                .iter()
-                                .map(|ty| ty.name.clone())
-                                .collect::<Vec<_>>()
-                                .join("\n"),
-                    )
-                    .with_wrap(WrapMode::Letter)
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .with_visibility(!self.allowed_types.is_empty())
+                                .with_margin(Thickness::uniform(2.0)),
+                        )
+                        .with_text(
+                            "Select a node of the following type(s):\n".to_string()
+                                + &self
+                                    .allowed_types
+                                    .iter()
+                                    .map(|ty| ty.name.clone())
+                                    .collect::<Vec<_>>()
+                                    .join("\n"),
+                        )
+                        .with_wrap(WrapMode::Letter)
+                        .build(ctx),
                 )
                 .with_child({
                     selector = NodeSelectorBuilder::new(WidgetBuilder::new().on_row(1))

--- a/editor/src/scene_viewer/mod.rs
+++ b/editor/src/scene_viewer/mod.rs
@@ -124,7 +124,8 @@ impl GridSnappingMenu {
                     WidgetBuilder::new()
                         .with_margin(Thickness::uniform(2.0))
                         .with_child(
-                            TextBuilder::new(WidgetBuilder::new().on_row(0).on_column(0))
+                            TextBuilder::new()
+                                .with_widget_builder(WidgetBuilder::new().on_row(0).on_column(0))
                                 .with_text("Grid Snapping")
                                 .build(ctx),
                         )
@@ -140,7 +141,8 @@ impl GridSnappingMenu {
                             enabled
                         })
                         .with_child(
-                            TextBuilder::new(WidgetBuilder::new().on_row(1).on_column(0))
+                            TextBuilder::new()
+                                .with_widget_builder(WidgetBuilder::new().on_row(1).on_column(0))
                                 .with_text("X Step")
                                 .build(ctx),
                         )
@@ -156,7 +158,8 @@ impl GridSnappingMenu {
                             x_step
                         })
                         .with_child(
-                            TextBuilder::new(WidgetBuilder::new().on_row(2).on_column(0))
+                            TextBuilder::new()
+                                .with_widget_builder(WidgetBuilder::new().on_row(2).on_column(0))
                                 .with_text("Y Step")
                                 .build(ctx),
                         )
@@ -172,7 +175,8 @@ impl GridSnappingMenu {
                             y_step
                         })
                         .with_child(
-                            TextBuilder::new(WidgetBuilder::new().on_row(3).on_column(0))
+                            TextBuilder::new()
+                                .with_widget_builder(WidgetBuilder::new().on_row(3).on_column(0))
                                 .with_text("Z Step")
                                 .build(ctx),
                         )
@@ -468,7 +472,7 @@ impl SceneViewer {
         .add_row(Row::stretch())
         .build(ctx);
 
-        let no_scene_reminder = TextBuilder::new(
+        let no_scene_reminder = TextBuilder::new().with_widget_builder(
             WidgetBuilder::new()
                 .with_hit_test_visibility(false)
                 .with_foreground(ctx.style.property(Style::BRUSH_DARKEST)),
@@ -901,15 +905,16 @@ impl SceneViewer {
         // Add any missing tabs.
         for entry in scenes.iter() {
             if tabs.iter().all(|tab| tab.uuid != entry.id) {
-                let header = TextBuilder::new(WidgetBuilder::new().with_margin(Thickness {
-                    left: 4.0,
-                    top: 2.0,
-                    right: 4.0,
-                    bottom: 2.0,
-                }))
-                .with_text(entry.name())
-                .build(&mut engine.user_interfaces.first_mut().build_ctx())
-                .to_base();
+                let header = TextBuilder::new()
+                    .with_widget_builder(WidgetBuilder::new().with_margin(Thickness {
+                        left: 4.0,
+                        top: 2.0,
+                        right: 4.0,
+                        bottom: 2.0,
+                    }))
+                    .with_text(entry.name())
+                    .build(&mut engine.user_interfaces.first_mut().build_ctx())
+                    .to_base();
 
                 engine.user_interfaces.first().send_sync(
                     self.tab_control,

--- a/editor/src/stats.rs
+++ b/editor/src/stats.rs
@@ -53,10 +53,11 @@ impl StatisticsWindow {
             .with_content(
                 ScrollViewerBuilder::new(WidgetBuilder::new())
                     .with_content({
-                        text = TextBuilder::new(
-                            WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
-                        )
-                        .build(ctx);
+                        text = TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new().with_margin(Thickness::uniform(2.0)),
+                            )
+                            .build(ctx);
                         text
                     })
                     .build(ctx),

--- a/editor/src/ui_scene/bbcode.rs
+++ b/editor/src/ui_scene/bbcode.rs
@@ -37,11 +37,7 @@ impl BBCodePanel {
         let root_widget = StackPanelBuilder::new(
             WidgetBuilder::new()
                 .with_visibility(false)
-                .with_child(
-                    TextBuilder::new(WidgetBuilder::new())
-                        .with_text("BBCode")
-                        .build(ctx),
-                )
+                .with_child(TextBuilder::new().with_text("BBCode").build(ctx))
                 .with_child(text_box),
         )
         .build(ctx);

--- a/editor/src/world/item.rs
+++ b/editor/src/world/item.rs
@@ -317,23 +317,24 @@ impl SceneItemBuilder {
                     .build(ctx),
                 )
                 .with_child({
-                    text_name = TextBuilder::new(
-                        WidgetBuilder::new()
-                            .with_foreground(
-                                self.text_brush
-                                    .unwrap_or(ctx.style.property(Style::BRUSH_TEXT)),
-                            )
-                            .with_margin(Thickness::left(1.0))
-                            .on_column(1),
-                    )
-                    .with_vertical_text_alignment(VerticalAlignment::Center)
-                    .with_text(format!(
-                        "{} ({}:{})",
-                        self.name,
-                        self.entity_handle.index(),
-                        self.entity_handle.generation()
-                    ))
-                    .build(ctx);
+                    text_name = TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .with_foreground(
+                                    self.text_brush
+                                        .unwrap_or(ctx.style.property(Style::BRUSH_TEXT)),
+                                )
+                                .with_margin(Thickness::left(1.0))
+                                .on_column(1),
+                        )
+                        .with_vertical_text_alignment(VerticalAlignment::Center)
+                        .with_text(format!(
+                            "{} ({}:{})",
+                            self.name,
+                            self.entity_handle.index(),
+                            self.entity_handle.generation()
+                        ))
+                        .build(ctx);
                     text_name
                 }),
         )

--- a/editor/src/world/mod.rs
+++ b/editor/src/world/mod.rs
@@ -413,7 +413,7 @@ impl WorldViewer {
                 .build(ctx),
             )
             .with_content(
-                TextBuilder::new(WidgetBuilder::new())
+                TextBuilder::new()
                     .with_vertical_text_alignment(VerticalAlignment::Center)
                     .with_text(if self.breadcrumbs.is_empty() {
                         name.to_owned()

--- a/fyrox-build-tools/src/build.rs
+++ b/fyrox-build-tools/src/build.rs
@@ -102,20 +102,21 @@ impl BuildWindow {
                             GridBuilder::new(
                                 WidgetBuilder::new()
                                     .with_child(
-                                        TextBuilder::new(
-                                            WidgetBuilder::new()
-                                                .with_margin(Thickness {
-                                                    left: 5.0,
-                                                    top: 1.0,
-                                                    right: 1.0,
-                                                    bottom: 1.0,
-                                                })
-                                                .on_column(0),
-                                        )
-                                        .with_text(format!(
-                                            "Please wait while {project_name} is building..."
-                                        ))
-                                        .build(ctx),
+                                        TextBuilder::new()
+                                            .with_widget_builder(
+                                                WidgetBuilder::new()
+                                                    .with_margin(Thickness {
+                                                        left: 5.0,
+                                                        top: 1.0,
+                                                        right: 1.0,
+                                                        bottom: 1.0,
+                                                    })
+                                                    .on_column(0),
+                                            )
+                                            .with_text(format!(
+                                                "Please wait while {project_name} is building..."
+                                            ))
+                                            .build(ctx),
                                     )
                                     .with_child({
                                         progress_indicator = ImageBuilder::new(
@@ -151,9 +152,7 @@ impl BuildWindow {
                                         scroll_viewer =
                                             ScrollViewerBuilder::new(WidgetBuilder::new())
                                                 .with_content({
-                                                    log_text =
-                                                        TextBuilder::new(WidgetBuilder::new())
-                                                            .build(ctx);
+                                                    log_text = TextBuilder::new().build(ctx);
                                                     log_text
                                                 })
                                                 .build(ctx);

--- a/fyrox-ui/src/button.rs
+++ b/fyrox-ui/src/button.rs
@@ -291,7 +291,7 @@ impl ButtonContent {
 
     fn build(&self, ctx: &mut BuildContext) -> Handle<UiNode> {
         match self {
-            Self::Text { text, font, size } => TextBuilder::new(WidgetBuilder::new())
+            Self::Text { text, font, size } => TextBuilder::new()
                 .with_text(text)
                 .with_horizontal_text_alignment(HorizontalAlignment::Center)
                 .with_vertical_text_alignment(VerticalAlignment::Center)

--- a/fyrox-ui/src/color/mod.rs
+++ b/fyrox-ui/src/color/mod.rs
@@ -963,14 +963,15 @@ pub struct ColorPickerBuilder {
 }
 
 fn make_text_mark(ctx: &mut BuildContext, text: &str, row: usize, column: usize) -> Handle<Text> {
-    TextBuilder::new(
-        WidgetBuilder::new()
-            .with_vertical_alignment(VerticalAlignment::Center)
-            .on_row(row)
-            .on_column(column),
-    )
-    .with_text(text)
-    .build(ctx)
+    TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new()
+                .with_vertical_alignment(VerticalAlignment::Center)
+                .on_row(row)
+                .on_column(column),
+        )
+        .with_text(text)
+        .build(ctx)
 }
 
 fn make_input_field(

--- a/fyrox-ui/src/curve/mod.rs
+++ b/fyrox-ui/src/curve/mod.rs
@@ -1850,17 +1850,18 @@ impl CurveEditorBuilder {
                                         WidgetBuilder::new()
                                             .with_enabled(false)
                                             .with_child(
-                                                TextBuilder::new(
-                                                    WidgetBuilder::new()
-                                                        .with_vertical_alignment(
-                                                            VerticalAlignment::Center,
-                                                        )
-                                                        .with_margin(Thickness::uniform(1.0))
-                                                        .on_row(0)
-                                                        .on_column(0),
-                                                )
-                                                .with_text("Location")
-                                                .build(ctx),
+                                                TextBuilder::new()
+                                                    .with_widget_builder(
+                                                        WidgetBuilder::new()
+                                                            .with_vertical_alignment(
+                                                                VerticalAlignment::Center,
+                                                            )
+                                                            .with_margin(Thickness::uniform(1.0))
+                                                            .on_row(0)
+                                                            .on_column(0),
+                                                    )
+                                                    .with_text("Location")
+                                                    .build(ctx),
                                             )
                                             .with_child({
                                                 key_location = NumericUpDownBuilder::<f32>::new(
@@ -1873,17 +1874,18 @@ impl CurveEditorBuilder {
                                                 key_location
                                             })
                                             .with_child(
-                                                TextBuilder::new(
-                                                    WidgetBuilder::new()
-                                                        .with_vertical_alignment(
-                                                            VerticalAlignment::Center,
-                                                        )
-                                                        .with_margin(Thickness::uniform(1.0))
-                                                        .on_row(1)
-                                                        .on_column(0),
-                                                )
-                                                .with_text("Value")
-                                                .build(ctx),
+                                                TextBuilder::new()
+                                                    .with_widget_builder(
+                                                        WidgetBuilder::new()
+                                                            .with_vertical_alignment(
+                                                                VerticalAlignment::Center,
+                                                            )
+                                                            .with_margin(Thickness::uniform(1.0))
+                                                            .on_row(1)
+                                                            .on_column(0),
+                                                    )
+                                                    .with_text("Value")
+                                                    .build(ctx),
                                             )
                                             .with_child({
                                                 key_value = NumericUpDownBuilder::<f32>::new(

--- a/fyrox-ui/src/dock/tile.rs
+++ b/fyrox-ui/src/dock/tile.rs
@@ -973,14 +973,15 @@ fn create_tab_header(label: String, ctx: &mut BuildContext) -> Handle<UiNode> {
         right: 4.0,
         bottom: 2.0,
     };
-    TextBuilder::new(
-        WidgetBuilder::new()
-            .with_min_size(min_size)
-            .with_margin(margin),
-    )
-    .with_text(label)
-    .build(ctx)
-    .to_base()
+    TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new()
+                .with_min_size(min_size)
+                .with_margin(margin),
+        )
+        .with_text(label)
+        .build(ctx)
+        .to_base()
 }
 
 impl Tile {

--- a/fyrox-ui/src/file_browser/fs_tree.rs
+++ b/fyrox-ui/src/file_browser/fs_tree.rs
@@ -142,19 +142,20 @@ pub fn build_tree_item<P: AsRef<Path>>(
                 Handle::NONE
             })
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::left(4.0))
-                        .on_column(1),
-                )
-                .with_text(
-                    path.as_ref()
-                        .to_string_lossy()
-                        .replace(&parent_path.as_ref().to_string_lossy().to_string(), "")
-                        .replace('\\', ""),
-                )
-                .with_vertical_text_alignment(VerticalAlignment::Center)
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::left(4.0))
+                            .on_column(1),
+                    )
+                    .with_text(
+                        path.as_ref()
+                            .to_string_lossy()
+                            .replace(&parent_path.as_ref().to_string_lossy().to_string(), "")
+                            .replace('\\', ""),
+                    )
+                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                    .build(ctx),
             ),
     )
     .add_row(Row::stretch())

--- a/fyrox-ui/src/file_browser/mod.rs
+++ b/fyrox-ui/src/file_browser/mod.rs
@@ -721,17 +721,18 @@ impl FileBrowserBuilder {
         .add_rows(vec![Row::auto(), Row::stretch()])
         .build(ctx);
 
-        let no_items_message = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_foreground(ctx.style.property(Style::BRUSH_BRIGHT))
-                .with_visibility(items_count == 0)
-                .with_hit_test_visibility(false),
-        )
-        .with_wrap(WrapMode::Word)
-        .with_vertical_text_alignment(VerticalAlignment::Center)
-        .with_horizontal_text_alignment(HorizontalAlignment::Center)
-        .with_text(self.no_items_text)
-        .build(ctx);
+        let no_items_message = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_foreground(ctx.style.property(Style::BRUSH_BRIGHT))
+                    .with_visibility(items_count == 0)
+                    .with_hit_test_visibility(false),
+            )
+            .with_wrap(WrapMode::Word)
+            .with_vertical_text_alignment(VerticalAlignment::Center)
+            .with_horizontal_text_alignment(HorizontalAlignment::Center)
+            .with_text(self.no_items_text)
+            .build(ctx);
 
         let root_container = GridBuilder::new(
             WidgetBuilder::new()

--- a/fyrox-ui/src/file_browser/selector.rs
+++ b/fyrox-ui/src/file_browser/selector.rs
@@ -372,14 +372,15 @@ impl FileSelectorBuilder {
                 .on_row(1)
                 .on_column(0)
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .on_row(0)
-                            .on_column(0)
-                            .with_vertical_alignment(VerticalAlignment::Center),
-                    )
-                    .with_text("File Name:")
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .on_row(0)
+                                .on_column(0)
+                                .with_vertical_alignment(VerticalAlignment::Center),
+                        )
+                        .with_text("File Name:")
+                        .build(ctx),
                 )
                 .with_child({
                     file_name = TextBoxBuilder::new(
@@ -422,14 +423,15 @@ impl FileSelectorBuilder {
                 .on_row(2)
                 .on_column(0)
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .on_row(0)
-                            .on_column(0)
-                            .with_vertical_alignment(VerticalAlignment::Center),
-                    )
-                    .with_text("File Type:")
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .on_row(0)
+                                .on_column(0)
+                                .with_vertical_alignment(VerticalAlignment::Center),
+                        )
+                        .with_text("File Type:")
+                        .build(ctx),
                 )
                 .with_child({
                     extension_selector = DropdownListBuilder::new(

--- a/fyrox-ui/src/input.rs
+++ b/fyrox-ui/src/input.rs
@@ -241,11 +241,13 @@ impl<'b> InputBoxBuilder<'b> {
         let content = GridBuilder::new(
             WidgetBuilder::new()
                 .with_child({
-                    text =
-                        TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(4.0)))
-                            .with_text(self.text)
-                            .with_wrap(WrapMode::Word)
-                            .build(ctx);
+                    text = TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new().with_margin(Thickness::uniform(4.0)),
+                        )
+                        .with_text(self.text)
+                        .with_wrap(WrapMode::Word)
+                        .build(ctx);
                     text
                 })
                 .with_child({

--- a/fyrox-ui/src/inspector/editors/texture_slice.rs
+++ b/fyrox-ui/src/inspector/editors/texture_slice.rs
@@ -599,37 +599,27 @@ impl TextureSliceEditorWindowBuilder {
         parent_editor: Handle<UiNode>,
         ctx: &mut BuildContext,
     ) -> Handle<TextureSliceEditorWindow> {
-        let region_text = TextBuilder::new(WidgetBuilder::new())
-            .with_text("Texture Region")
-            .build(ctx);
+        let region_text = TextBuilder::new().with_text("Texture Region").build(ctx);
         let region =
             RectEditorBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
                 .with_value(*self.texture_slice.texture_region)
                 .build(ctx);
-        let left_margin_text = TextBuilder::new(WidgetBuilder::new())
-            .with_text("Left Margin")
-            .build(ctx);
+        let left_margin_text = TextBuilder::new().with_text("Left Margin").build(ctx);
         let left_margin =
             NumericUpDownBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
                 .with_value(*self.texture_slice.left_margin)
                 .build(ctx);
-        let right_margin_text = TextBuilder::new(WidgetBuilder::new())
-            .with_text("Right Margin")
-            .build(ctx);
+        let right_margin_text = TextBuilder::new().with_text("Right Margin").build(ctx);
         let right_margin =
             NumericUpDownBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
                 .with_value(*self.texture_slice.right_margin)
                 .build(ctx);
-        let top_margin_text = TextBuilder::new(WidgetBuilder::new())
-            .with_text("Top Margin")
-            .build(ctx);
+        let top_margin_text = TextBuilder::new().with_text("Top Margin").build(ctx);
         let top_margin =
             NumericUpDownBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
                 .with_value(*self.texture_slice.top_margin)
                 .build(ctx);
-        let bottom_margin_text = TextBuilder::new(WidgetBuilder::new())
-            .with_text("Bottom Margin")
-            .build(ctx);
+        let bottom_margin_text = TextBuilder::new().with_text("Bottom Margin").build(ctx);
         let bottom_margin =
             NumericUpDownBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
                 .with_value(*self.texture_slice.bottom_margin)

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -906,16 +906,18 @@ fn make_expander_check_box(
         } else {
             format!("{property_name}\n\n{property_description}")
         };
-        TextBuilder::new(
-            WidgetBuilder::new()
-                .with_opt_tooltip(make_tooltip(ctx, &description))
-                .with_height(16.0)
-                .with_margin(Thickness::left(2.0)),
-        )
-        .with_vertical_text_alignment(VerticalAlignment::Center)
-        .with_text(property_name)
-        .build(ctx)
-    })
+        TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_opt_tooltip(make_tooltip(ctx, &description))
+                    .with_height(16.0)
+                    .with_margin(Thickness::left(2.0)),
+            )
+            .with_vertical_text_alignment(VerticalAlignment::Center)
+            .with_text(property_name)
+            .build(ctx),
+        }
+    )
     .checked(Some(true))
     .with_check_mark(make_arrow(ctx, ArrowDirection::Bottom, 8.0))
     .with_uncheck_mark(make_arrow(ctx, ArrowDirection::Right, 8.0))
@@ -965,7 +967,8 @@ pub fn make_expander_container(
 }
 
 fn create_header(ctx: &mut BuildContext, text: &str, layer_index: usize) -> Handle<Text> {
-    TextBuilder::new(WidgetBuilder::new().with_margin(make_property_margin(layer_index)))
+    TextBuilder::new()
+        .with_widget_builder(WidgetBuilder::new().with_margin(make_property_margin(layer_index)))
         .with_text(text)
         .with_vertical_text_alignment(VerticalAlignment::Center)
         .build(ctx)
@@ -1181,7 +1184,10 @@ impl InspectorContext {
                             ));
                             make_simple_property_container(
                                 create_header(ctx, info.display_name, layer_index),
-                                TextBuilder::new(WidgetBuilder::new().on_row(i).on_column(1))
+                                TextBuilder::new()
+                                    .with_widget_builder(
+                                        WidgetBuilder::new().on_row(i).on_column(1),
+                                    )
                                     .with_wrap(WrapMode::Word)
                                     .with_vertical_text_alignment(VerticalAlignment::Center)
                                     .with_text(format!(
@@ -1201,7 +1207,8 @@ impl InspectorContext {
                 } else {
                     editors.push(make_simple_property_container(
                         create_header(ctx, info.display_name, layer_index),
-                        TextBuilder::new(WidgetBuilder::new().on_row(i).on_column(1))
+                        TextBuilder::new()
+                            .with_widget_builder(WidgetBuilder::new().on_row(i).on_column(1))
                             .with_wrap(WrapMode::Word)
                             .with_vertical_text_alignment(VerticalAlignment::Center)
                             .with_text(format!(

--- a/fyrox-ui/src/key.rs
+++ b/fyrox-ui/src/key.rs
@@ -313,7 +313,7 @@ impl HotKeyEditorBuilder {
 
     /// Finishes widget building and adds it to the user interface, returning a handle to the new instance.
     pub fn build(self, ctx: &mut BuildContext) -> Handle<HotKeyEditor> {
-        let text = TextBuilder::new(WidgetBuilder::new())
+        let text = TextBuilder::new()
             .with_text(format!("{}", self.value))
             .build(ctx);
 
@@ -512,7 +512,7 @@ impl KeyBindingEditorBuilder {
 
     /// Finishes widget building and adds the new widget instance to the user interface, returning a handle of it.
     pub fn build(self, ctx: &mut BuildContext) -> Handle<KeyBindingEditor> {
-        let text = TextBuilder::new(WidgetBuilder::new())
+        let text = TextBuilder::new()
             .with_text(format!("{}", self.value))
             .build(ctx);
 

--- a/fyrox-ui/src/log.rs
+++ b/fyrox-ui/src/log.rs
@@ -323,22 +323,25 @@ impl LogPanel {
                         ctx.style.property(Style::BRUSH_DARK)
                     })
                     .with_child(
-                        TextBuilder::new(
-                            WidgetBuilder::new()
-                                .with_margin(Thickness::uniform(2.0))
-                                .with_foreground(match msg.kind {
-                                    MessageKind::Information => {
-                                        ctx.style.property(Style::BRUSH_INFORMATION)
-                                    }
-                                    MessageKind::Warning => {
-                                        ctx.style.property(Style::BRUSH_WARNING)
-                                    }
-                                    MessageKind::Error => ctx.style.property(Style::BRUSH_ERROR),
-                                }),
-                        )
-                        .with_vertical_text_alignment(VerticalAlignment::Center)
-                        .with_text(text)
-                        .build(ctx),
+                        TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new()
+                                    .with_margin(Thickness::uniform(2.0))
+                                    .with_foreground(match msg.kind {
+                                        MessageKind::Information => {
+                                            ctx.style.property(Style::BRUSH_INFORMATION)
+                                        }
+                                        MessageKind::Warning => {
+                                            ctx.style.property(Style::BRUSH_WARNING)
+                                        }
+                                        MessageKind::Error => {
+                                            ctx.style.property(Style::BRUSH_ERROR)
+                                        }
+                                    }),
+                            )
+                            .with_vertical_text_alignment(VerticalAlignment::Center)
+                            .with_text(text)
+                            .build(ctx),
                     ),
             )
             .build(ctx);

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -1011,26 +1011,28 @@ impl MenuItemBuilder {
                     .with_vertical_alignment(VerticalAlignment::Center)
                     .with_child(*icon)
                     .with_child(
-                        TextBuilder::new(
-                            WidgetBuilder::new()
-                                .with_margin(Thickness::left(2.0))
-                                .on_column(1)
-                                .with_vertical_alignment(VerticalAlignment::Center),
-                        )
-                        .with_text(text)
-                        .build(ctx),
+                        TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new()
+                                    .with_margin(Thickness::left(2.0))
+                                    .on_column(1)
+                                    .with_vertical_alignment(VerticalAlignment::Center),
+                            )
+                            .with_text(text)
+                            .build(ctx),
                     )
                     .with_child(
-                        TextBuilder::new(
-                            WidgetBuilder::new()
-                                .with_foreground(ctx.style.property(Style::BRUSH_LIGHTEST))
-                                .with_horizontal_alignment(HorizontalAlignment::Right)
-                                .with_vertical_alignment(VerticalAlignment::Center)
-                                .with_margin(Thickness::uniform(1.0))
-                                .on_column(2),
-                        )
-                        .with_text(shortcut)
-                        .build(ctx),
+                        TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new()
+                                    .with_foreground(ctx.style.property(Style::BRUSH_LIGHTEST))
+                                    .with_horizontal_alignment(HorizontalAlignment::Right)
+                                    .with_vertical_alignment(VerticalAlignment::Center)
+                                    .with_margin(Thickness::uniform(1.0))
+                                    .on_column(2),
+                            )
+                            .with_text(shortcut)
+                            .build(ctx),
                     )
                     .with_child({
                         arrow_widget = if *arrow {
@@ -1060,14 +1062,13 @@ impl MenuItemBuilder {
             .add_column(Column::strict(5.0))
             .build(ctx)
             .to_base(),
-            Some(MenuItemContent::TextCentered(text)) => {
-                TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::left_right(5.0)))
-                    .with_text(text)
-                    .with_horizontal_text_alignment(HorizontalAlignment::Center)
-                    .with_vertical_text_alignment(VerticalAlignment::Center)
-                    .build(ctx)
-                    .to_base()
-            }
+            Some(MenuItemContent::TextCentered(text)) => TextBuilder::new()
+                .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::left_right(5.0)))
+                .with_text(text)
+                .with_horizontal_text_alignment(HorizontalAlignment::Center)
+                .with_vertical_text_alignment(VerticalAlignment::Center)
+                .build(ctx)
+                .to_base(),
             Some(MenuItemContent::Node(node)) => *node,
         };
 

--- a/fyrox-ui/src/messagebox.rs
+++ b/fyrox-ui/src/messagebox.rs
@@ -312,12 +312,13 @@ impl<'b> MessageBoxBuilder<'b> {
             MessageBoxButtons::Ok => GridBuilder::new(
                 WidgetBuilder::new()
                     .with_child({
-                        text = TextBuilder::new(
-                            WidgetBuilder::new().with_margin(Thickness::uniform(4.0)),
-                        )
-                        .with_text(self.text)
-                        .with_wrap(WrapMode::Word)
-                        .build(ctx);
+                        text = TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new().with_margin(Thickness::uniform(4.0)),
+                            )
+                            .with_text(self.text)
+                            .with_wrap(WrapMode::Word)
+                            .build(ctx);
                         text
                     })
                     .with_child({
@@ -341,7 +342,7 @@ impl<'b> MessageBoxBuilder<'b> {
             MessageBoxButtons::YesNo => GridBuilder::new(
                 WidgetBuilder::new()
                     .with_child({
-                        text = TextBuilder::new(WidgetBuilder::new())
+                        text = TextBuilder::new()
                             .with_text(self.text)
                             .with_wrap(WrapMode::Word)
                             .build(ctx);
@@ -385,7 +386,7 @@ impl<'b> MessageBoxBuilder<'b> {
             MessageBoxButtons::YesNoCancel => GridBuilder::new(
                 WidgetBuilder::new()
                     .with_child({
-                        text = TextBuilder::new(WidgetBuilder::new())
+                        text = TextBuilder::new()
                             .with_text(self.text)
                             .with_wrap(WrapMode::Word)
                             .build(ctx);

--- a/fyrox-ui/src/range.rs
+++ b/fyrox-ui/src/range.rs
@@ -275,14 +275,15 @@ where
                         WidgetBuilder::new()
                             .with_child(start)
                             .with_child(
-                                TextBuilder::new(
-                                    WidgetBuilder::new()
-                                        .on_column(1)
-                                        .with_margin(Thickness::uniform(1.0)),
-                                )
-                                .with_vertical_text_alignment(VerticalAlignment::Center)
-                                .with_text("..")
-                                .build(ctx),
+                                TextBuilder::new()
+                                    .with_widget_builder(
+                                        WidgetBuilder::new()
+                                            .on_column(1)
+                                            .with_margin(Thickness::uniform(1.0)),
+                                    )
+                                    .with_vertical_text_alignment(VerticalAlignment::Center)
+                                    .with_text("..")
+                                    .build(ctx),
                             )
                             .with_child(end),
                     )

--- a/fyrox-ui/src/rect.rs
+++ b/fyrox-ui/src/rect.rs
@@ -237,7 +237,7 @@ fn create_field<T: NumericType>(
             .with_margin(Thickness::left(10.0))
             .on_row(row)
             .with_child(
-                TextBuilder::new(WidgetBuilder::new())
+                TextBuilder::new()
                     .with_text(name)
                     .with_vertical_text_alignment(VerticalAlignment::Center)
                     .build(ctx),

--- a/fyrox-ui/src/scroll_bar.rs
+++ b/fyrox-ui/src/scroll_bar.rs
@@ -575,29 +575,30 @@ impl ScrollBarBuilder {
         let value = self.value.unwrap_or(0.0).clamp(min, max);
 
         let value_text = if self.show_value {
-            let value_text = TextBuilder::new(
-                WidgetBuilder::new()
-                    .with_visibility(self.show_value)
-                    .with_horizontal_alignment(HorizontalAlignment::Center)
-                    .with_vertical_alignment(VerticalAlignment::Center)
-                    .with_hit_test_visibility(false)
-                    .with_margin(Thickness::uniform(3.0))
-                    .on_column(match orientation {
-                        Orientation::Horizontal => 1,
-                        Orientation::Vertical => 0,
-                    })
-                    .on_row(match orientation {
-                        Orientation::Horizontal => 0,
-                        Orientation::Vertical => 1,
-                    }),
-            )
-            .with_font(self.font.unwrap_or_else(|| ctx.default_font()))
-            .with_font_size(
-                self.font_size
-                    .unwrap_or_else(|| ctx.style.property(Style::FONT_SIZE)),
-            )
-            .with_text(format!("{:.1$}", value, self.value_precision))
-            .build(ctx);
+            let value_text = TextBuilder::new()
+                .with_widget_builder(
+                    WidgetBuilder::new()
+                        .with_visibility(self.show_value)
+                        .with_horizontal_alignment(HorizontalAlignment::Center)
+                        .with_vertical_alignment(VerticalAlignment::Center)
+                        .with_hit_test_visibility(false)
+                        .with_margin(Thickness::uniform(3.0))
+                        .on_column(match orientation {
+                            Orientation::Horizontal => 1,
+                            Orientation::Vertical => 0,
+                        })
+                        .on_row(match orientation {
+                            Orientation::Horizontal => 0,
+                            Orientation::Vertical => 1,
+                        }),
+                )
+                .with_font(self.font.unwrap_or_else(|| ctx.default_font()))
+                .with_font_size(
+                    self.font_size
+                        .unwrap_or_else(|| ctx.style.property(Style::FONT_SIZE)),
+                )
+                .with_text(format!("{:.1$}", value, self.value_precision))
+                .build(ctx);
 
             ctx.link(value_text, indicator);
 

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -346,7 +346,8 @@ impl ConstructorProvider<UiNode, UserInterface> for Text {
     fn constructor() -> GraphNodeConstructor<UiNode, UserInterface> {
         GraphNodeConstructor::new::<Self>()
             .with_variant("Text", |ui| {
-                TextBuilder::new(WidgetBuilder::new().with_name("Text"))
+                TextBuilder::new()
+                    .with_widget_builder(WidgetBuilder::new().with_name("Text"))
                     .with_text("Text")
                     .build(&mut ui.build_ctx())
                     .to_base()
@@ -539,7 +540,7 @@ impl Text {
 
 /// TextBuilder is used to create instances of [`Text`] widget and register them in the user interface.
 pub struct TextBuilder {
-    widget_builder: WidgetBuilder,
+    widget_builder: Option<WidgetBuilder>,
     bbcode: Option<String>,
     text: Option<String>,
     font: Option<FontResource>,
@@ -556,10 +557,10 @@ pub struct TextBuilder {
 }
 
 impl TextBuilder {
-    /// Creates new [`TextBuilder`] instance using the provided base widget builder.
-    pub fn new(widget_builder: WidgetBuilder) -> Self {
+    /// Creates new [`TextBuilder`] instance.
+    pub fn new() -> Self {
         Self {
-            widget_builder,
+            widget_builder: None,
             bbcode: None,
             text: None,
             font: None,
@@ -574,6 +575,12 @@ impl TextBuilder {
             runs: Vec::default(),
             trim_text: true,
         }
+    }
+
+    /// Sets the base widget builder used to build the widget.
+    pub fn with_widget_builder(mut self, widget_builder: WidgetBuilder) -> Self {
+        self.widget_builder = Some(widget_builder);
+        self
     }
 
     /// Sets the desired text of the widget, with BBcode tags that will
@@ -675,15 +682,16 @@ impl TextBuilder {
     }
 
     /// Finishes text widget creation and registers it in the user interface, returning its handle to you.
-    pub fn build(mut self, ctx: &mut BuildContext) -> Handle<Text> {
+    pub fn build(self, ctx: &mut BuildContext) -> Handle<Text> {
+        let mut widget_builder = self.widget_builder.unwrap_or_default();
         let font = if let Some(font) = self.font {
             font
         } else {
             ctx.default_font()
         };
 
-        if self.widget_builder.foreground.is_none() {
-            self.widget_builder.foreground = Some(ctx.style.property(Style::BRUSH_TEXT));
+        if widget_builder.foreground.is_none() {
+            widget_builder.foreground = Some(ctx.style.property(Style::BRUSH_TEXT));
         }
 
         let text_builder = if let Some(bbcode) = &self.bbcode {
@@ -710,7 +718,7 @@ impl TextBuilder {
             .build();
 
         let text = Text {
-            widget: self.widget_builder.build(ctx),
+            widget: widget_builder.build(ctx),
             bbcode: self.bbcode.unwrap_or_default().into(),
             formatted_text: RefCell::new(formatted_text),
         };
@@ -720,11 +728,11 @@ impl TextBuilder {
 
 #[cfg(test)]
 mod test {
+    use crate::test::test_widget_deletion;
     use crate::text::TextBuilder;
-    use crate::{test::test_widget_deletion, widget::WidgetBuilder};
 
     #[test]
     fn test_deletion() {
-        test_widget_deletion(|ctx| TextBuilder::new(WidgetBuilder::new()).build(ctx));
+        test_widget_deletion(|ctx| TextBuilder::new().build(ctx));
     }
 }

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -1506,15 +1506,16 @@ impl<'a> EmptyTextPlaceholder<'a> {
     fn build(self, main_text: &str, ctx: &mut BuildContext) -> Handle<UiNode> {
         match self {
             EmptyTextPlaceholder::None => Handle::NONE,
-            EmptyTextPlaceholder::Text(text) => TextBuilder::new(
-                WidgetBuilder::new()
-                    .with_visibility(main_text.is_empty())
-                    .with_foreground(ctx.style.property(Style::BRUSH_LIGHTER)),
-            )
-            .with_text(text)
-            .with_vertical_text_alignment(VerticalAlignment::Center)
-            .build(ctx)
-            .to_base(),
+            EmptyTextPlaceholder::Text(text) => TextBuilder::new()
+                .with_widget_builder(
+                    WidgetBuilder::new()
+                        .with_visibility(main_text.is_empty())
+                        .with_foreground(ctx.style.property(Style::BRUSH_LIGHTER)),
+                )
+                .with_text(text)
+                .with_vertical_text_alignment(VerticalAlignment::Center)
+                .build(ctx)
+                .to_base(),
             EmptyTextPlaceholder::Widget(widget) => widget,
         }
     }

--- a/fyrox-ui/src/utils.rs
+++ b/fyrox-ui/src/utils.rs
@@ -155,14 +155,15 @@ pub fn make_simple_tooltip(ctx: &mut BuildContext, text: &str) -> RcUiNodeHandle
             .with_background(Brush::Solid(Color::opaque(230, 230, 230)).into())
             .with_width(300.0)
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .with_margin(Thickness::uniform(2.0))
-                        .with_foreground(ctx.style.property(Style::BRUSH_DARKER)),
-                )
-                .with_wrap(WrapMode::Word)
-                .with_text(text)
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .with_margin(Thickness::uniform(2.0))
+                            .with_foreground(ctx.style.property(Style::BRUSH_DARKER)),
+                    )
+                    .with_wrap(WrapMode::Word)
+                    .with_text(text)
+                    .build(ctx),
             ),
     )
     .build(ctx);
@@ -235,7 +236,8 @@ pub fn make_dropdown_list_option_universal<T: Send + 'static>(
                     .with_height(height)
                     .with_user_data(Arc::new(Mutex::new(user_data)))
                     .with_child(
-                        TextBuilder::new(WidgetBuilder::new().with_margin(text_margin()))
+                        TextBuilder::new()
+                            .with_widget_builder(WidgetBuilder::new().with_margin(text_margin()))
                             .with_vertical_text_alignment(VerticalAlignment::Center)
                             .with_horizontal_text_alignment(HorizontalAlignment::Left)
                             .with_text(name)
@@ -256,15 +258,16 @@ pub fn make_dropdown_list_option(ctx: &mut BuildContext, name: &str) -> Handle<U
         DecoratorBuilder::new(
             BorderBuilder::new(
                 WidgetBuilder::new().with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .with_margin(text_margin())
-                            .with_vertical_alignment(VerticalAlignment::Center),
-                    )
-                    .with_vertical_text_alignment(VerticalAlignment::Center)
-                    .with_horizontal_text_alignment(HorizontalAlignment::Left)
-                    .with_text(name)
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .with_margin(text_margin())
+                                .with_vertical_alignment(VerticalAlignment::Center),
+                        )
+                        .with_vertical_text_alignment(VerticalAlignment::Center)
+                        .with_horizontal_text_alignment(HorizontalAlignment::Left)
+                        .with_text(name)
+                        .build(ctx),
                 ),
             )
             .with_corner_radius(4.0f32.into())
@@ -285,7 +288,8 @@ pub fn make_dropdown_list_option_with_height(
         DecoratorBuilder::new(
             BorderBuilder::new(
                 WidgetBuilder::new().with_height(height).with_child(
-                    TextBuilder::new(WidgetBuilder::new().with_margin(text_margin()))
+                    TextBuilder::new()
+                        .with_widget_builder(WidgetBuilder::new().with_margin(text_margin()))
                         .with_vertical_text_alignment(VerticalAlignment::Center)
                         .with_horizontal_text_alignment(HorizontalAlignment::Left)
                         .with_text(name)
@@ -535,22 +539,23 @@ pub fn make_text_and_image_button_with_tooltip(
                     .build(ctx),
                 )
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .on_row(0)
-                            .on_column(1)
-                            .with_vertical_alignment(VerticalAlignment::Center)
-                            .with_horizontal_alignment(HorizontalAlignment::Center)
-                            .with_margin(Thickness {
-                                left: 4.0,
-                                top: margin,
-                                right: 8.0,
-                                bottom: margin,
-                            }),
-                    )
-                    .with_font_size(font_size.into())
-                    .with_text(text)
-                    .build(ctx),
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .on_row(0)
+                                .on_column(1)
+                                .with_vertical_alignment(VerticalAlignment::Center)
+                                .with_horizontal_alignment(HorizontalAlignment::Center)
+                                .with_margin(Thickness {
+                                    left: 4.0,
+                                    top: margin,
+                                    right: 8.0,
+                                    bottom: margin,
+                                }),
+                        )
+                        .with_font_size(font_size.into())
+                        .with_text(text)
+                        .build(ctx),
                 ),
         )
         .add_column(Column::auto())

--- a/fyrox-ui/src/uuid.rs
+++ b/fyrox-ui/src/uuid.rs
@@ -137,15 +137,16 @@ impl UuidEditorBuilder {
         let grid = GridBuilder::new(
             WidgetBuilder::new()
                 .with_child({
-                    text = TextBuilder::new(
-                        WidgetBuilder::new()
-                            .on_column(0)
-                            .on_row(0)
-                            .with_margin(Thickness::uniform(1.0))
-                            .with_vertical_alignment(VerticalAlignment::Center),
-                    )
-                    .with_text(self.value.to_string())
-                    .build(ctx);
+                    text = TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .on_column(0)
+                                .on_row(0)
+                                .with_margin(Thickness::uniform(1.0))
+                                .with_vertical_alignment(VerticalAlignment::Center),
+                        )
+                        .with_text(self.value.to_string())
+                        .build(ctx);
                     text
                 })
                 .with_child({

--- a/fyrox-ui/src/window.rs
+++ b/fyrox-ui/src/window.rs
@@ -992,18 +992,19 @@ fn make_text_title(
     font: FontResource,
     size: StyledProperty<f32>,
 ) -> Handle<Text> {
-    TextBuilder::new(
-        WidgetBuilder::new()
-            .with_margin(Thickness::left(5.0))
-            .on_row(0)
-            .on_column(0),
-    )
-    .with_font_size(size)
-    .with_font(font)
-    .with_vertical_text_alignment(VerticalAlignment::Center)
-    .with_horizontal_text_alignment(HorizontalAlignment::Left)
-    .with_text(text)
-    .build(ctx)
+    TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new()
+                .with_margin(Thickness::left(5.0))
+                .on_row(0)
+                .on_column(0),
+        )
+        .with_font_size(size)
+        .with_font(font)
+        .with_vertical_text_alignment(VerticalAlignment::Center)
+        .with_horizontal_text_alignment(HorizontalAlignment::Left)
+        .with_text(text)
+        .build(ctx)
 }
 
 enum HeaderButton {

--- a/project-manager/src/manager.rs
+++ b/project-manager/src/manager.rs
@@ -199,33 +199,35 @@ fn make_project_item(
     .with_opt_texture(load_image(include_bytes!("../resources/flame.png")))
     .build(ctx);
 
-    let engine_version = TextBuilder::new(
-        WidgetBuilder::new()
-            .with_foreground(ctx.style.property(Style::BRUSH_BRIGHTEST))
-            .with_margin(Thickness {
-                left: 0.0,
-                top: 6.0,
-                right: 3.0,
-                bottom: 0.0,
-            }),
-    )
-    .with_font_size(13.0.into())
-    .with_text(engine_version)
-    .build(ctx);
+    let engine_version = TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new()
+                .with_foreground(ctx.style.property(Style::BRUSH_BRIGHTEST))
+                .with_margin(Thickness {
+                    left: 0.0,
+                    top: 6.0,
+                    right: 3.0,
+                    bottom: 0.0,
+                }),
+        )
+        .with_font_size(13.0.into())
+        .with_text(engine_version)
+        .build(ctx);
 
-    let size_text = TextBuilder::new(
-        WidgetBuilder::new()
-            .with_foreground(ctx.style.property(Style::BRUSH_BRIGHTEST))
-            .with_margin(Thickness {
-                left: 0.0,
-                top: 6.0,
-                right: 8.0,
-                bottom: 0.0,
-            }),
-    )
-    .with_font_size(13.0.into())
-    .with_text("Size: N/A")
-    .build(ctx);
+    let size_text = TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new()
+                .with_foreground(ctx.style.property(Style::BRUSH_BRIGHTEST))
+                .with_margin(Thickness {
+                    left: 0.0,
+                    top: 6.0,
+                    right: 8.0,
+                    bottom: 0.0,
+                }),
+        )
+        .with_font_size(13.0.into())
+        .with_text("Size: N/A")
+        .build(ctx);
 
     if let Some(project_dir) = Path::new(path).parent().map(|p| p.to_path_buf()) {
         std::thread::spawn(move || {
@@ -253,27 +255,29 @@ fn make_project_item(
             .on_column(1)
             .with_child(info)
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .on_row(0)
-                        .with_margin(Thickness::uniform(2.0))
-                        .with_vertical_alignment(VerticalAlignment::Center),
-                )
-                .with_font_size(18.0.into())
-                .with_text(name)
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .on_row(0)
+                            .with_margin(Thickness::uniform(2.0))
+                            .with_vertical_alignment(VerticalAlignment::Center),
+                    )
+                    .with_font_size(18.0.into())
+                    .with_text(name)
+                    .build(ctx),
             )
             .with_child(
-                TextBuilder::new(
-                    WidgetBuilder::new()
-                        .on_row(1)
-                        .with_foreground(ctx.style.property(Style::BRUSH_BRIGHTEST))
-                        .with_margin(Thickness::uniform(2.0))
-                        .with_vertical_alignment(VerticalAlignment::Center),
-                )
-                .with_font_size(13.0.into())
-                .with_text(path.to_string_lossy())
-                .build(ctx),
+                TextBuilder::new()
+                    .with_widget_builder(
+                        WidgetBuilder::new()
+                            .on_row(1)
+                            .with_foreground(ctx.style.property(Style::BRUSH_BRIGHTEST))
+                            .with_margin(Thickness::uniform(2.0))
+                            .with_vertical_alignment(VerticalAlignment::Center),
+                    )
+                    .with_font_size(13.0.into())
+                    .with_text(path.to_string_lossy())
+                    .build(ctx),
             ),
     )
     .add_column(Column::stretch())
@@ -359,20 +363,21 @@ impl ProjectManager {
             WidgetBuilder::new()
                 .with_visibility(!is_ready)
                 .with_child(
-                    TextBuilder::new(
-                        WidgetBuilder::new()
-                            .on_column(0)
-                            .with_margin(Thickness::uniform(2.0))
-                            .with_foreground(Brush::Solid(Color::RED).into()),
-                    )
-                    .with_text(
-                        "Rust is not installed, please click the button at the right \
+                    TextBuilder::new()
+                        .with_widget_builder(
+                            WidgetBuilder::new()
+                                .on_column(0)
+                                .with_margin(Thickness::uniform(2.0))
+                                .with_foreground(Brush::Solid(Color::RED).into()),
+                        )
+                        .with_text(
+                            "Rust is not installed, please click the button at the right \
                         and follow build instructions for your platform. Also make sure that cargo \
                         is added to PATH environment variable!",
-                    )
-                    .with_font_size(18.0.into())
-                    .with_wrap(WrapMode::Word)
-                    .build(ctx),
+                        )
+                        .with_font_size(18.0.into())
+                        .with_wrap(WrapMode::Word)
+                        .build(ctx),
                 )
                 .with_child(download),
         )
@@ -460,15 +465,16 @@ impl ProjectManager {
                         .build(ctx),
                     )
                     .with_child({
-                        message_count = TextBuilder::new(
-                            WidgetBuilder::new()
-                                .on_column(1)
-                                .with_margin(Thickness::uniform(1.0))
-                                .with_vertical_alignment(VerticalAlignment::Center)
-                                .with_foreground(Brush::Solid(Color::GOLD).into()),
-                        )
-                        .with_text("0")
-                        .build(ctx);
+                        message_count = TextBuilder::new()
+                            .with_widget_builder(
+                                WidgetBuilder::new()
+                                    .on_column(1)
+                                    .with_margin(Thickness::uniform(1.0))
+                                    .with_vertical_alignment(VerticalAlignment::Center)
+                                    .with_foreground(Brush::Solid(Color::GOLD).into()),
+                            )
+                            .with_text("0")
+                            .build(ctx);
                         message_count
                     }),
             )
@@ -644,7 +650,8 @@ impl ProjectManager {
                 .with_tooltip(make_simple_tooltip(ctx, hot_reload_tooltip)),
         )
         .with_content(
-            TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::left(2.0)))
+            TextBuilder::new()
+                .with_widget_builder(WidgetBuilder::new().with_margin(Thickness::left(2.0)))
                 .with_text("Hot Reloading")
                 .with_vertical_text_alignment(VerticalAlignment::Center)
                 .build(ctx),
@@ -689,17 +696,17 @@ impl ProjectManager {
         .with_items(make_project_items(&settings, "", &project_size_sender, ctx).to_base())
         .build(ctx);
 
-        let no_projects_warning =
-            TextBuilder::new(WidgetBuilder::new().with_visibility(settings.projects.is_empty()))
-                .with_text(
-                    "At this moment you don't have any existing projects.\n\
+        let no_projects_warning = TextBuilder::new()
+            .with_widget_builder(WidgetBuilder::new().with_visibility(settings.projects.is_empty()))
+            .with_text(
+                "At this moment you don't have any existing projects.\n\
                         Click \"+Create\" button to create a new project or \"Import\" an \
                         existing one.",
-                )
-                .with_font_size(16.0f32.into())
-                .with_horizontal_text_alignment(HorizontalAlignment::Center)
-                .with_vertical_text_alignment(VerticalAlignment::Center)
-                .build(ctx);
+            )
+            .with_font_size(16.0f32.into())
+            .with_horizontal_text_alignment(HorizontalAlignment::Center)
+            .with_vertical_text_alignment(VerticalAlignment::Center)
+            .build(ctx);
 
         let border = BorderBuilder::new(
             WidgetBuilder::new()

--- a/project-manager/src/project.rs
+++ b/project-manager/src/project.rs
@@ -116,19 +116,20 @@ pub struct ProjectWizard {
 }
 
 fn make_text(text: &str, row: usize, ctx: &mut BuildContext) -> Handle<Text> {
-    TextBuilder::new(
-        WidgetBuilder::new()
-            .with_vertical_alignment(VerticalAlignment::Center)
-            .with_margin(Thickness {
-                left: 5.0,
-                top: 1.0,
-                right: 1.0,
-                bottom: 1.0,
-            })
-            .on_row(row),
-    )
-    .with_text(text)
-    .build(ctx)
+    TextBuilder::new()
+        .with_widget_builder(
+            WidgetBuilder::new()
+                .with_vertical_alignment(VerticalAlignment::Center)
+                .with_margin(Thickness {
+                    left: 5.0,
+                    top: 1.0,
+                    right: 1.0,
+                    bottom: 1.0,
+                })
+                .on_row(row),
+        )
+        .with_text(text)
+        .build(ctx)
 }
 
 fn full_project_path(folder: &Path, name: &str) -> String {
@@ -205,14 +206,15 @@ impl ProjectWizard {
         .with_orientation(Orientation::Horizontal)
         .build(ctx);
 
-        let full_project_path = TextBuilder::new(
-            WidgetBuilder::new()
-                .with_margin(Thickness::uniform(1.0))
-                .on_row(4)
-                .on_column(1),
-        )
-        .with_text(full_project_path(&path, &name))
-        .build(ctx);
+        let full_project_path = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .with_margin(Thickness::uniform(1.0))
+                    .on_row(4)
+                    .on_column(1),
+            )
+            .with_text(full_project_path(&path, &name))
+            .build(ctx);
 
         let grid = GridBuilder::new(
             WidgetBuilder::new()
@@ -238,14 +240,15 @@ impl ProjectWizard {
         .add_column(Column::stretch())
         .build(ctx);
 
-        let validation_text = TextBuilder::new(
-            WidgetBuilder::new()
-                .on_row(1)
-                .with_foreground(ctx.style.property(style::Style::BRUSH_ERROR)),
-        )
-        .with_font_size(12.0.into())
-        .with_wrap(WrapMode::Word)
-        .build(ctx);
+        let validation_text = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .on_row(1)
+                    .with_foreground(ctx.style.property(style::Style::BRUSH_ERROR)),
+            )
+            .with_font_size(12.0.into())
+            .with_wrap(WrapMode::Word)
+            .build(ctx);
 
         let outer_grid = GridBuilder::new(
             WidgetBuilder::new()

--- a/project-manager/src/upgrade.rs
+++ b/project-manager/src/upgrade.rs
@@ -78,22 +78,23 @@ impl UpgradeTool {
     pub fn new(project: &Project, ctx: &mut BuildContext) -> Self {
         let dependency = utils::fyrox_dependency_from_path(&project.manifest_path).unwrap();
 
-        let version = TextBuilder::new(
-            WidgetBuilder::new()
-                .on_row(0)
-                .with_margin(Thickness::uniform(1.0)),
-        )
-        .with_text(format!(
-            "Current Engine Version: {}\nSource: {}",
-            dependency.req,
-            dependency
-                .source
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| dependency.path.as_ref().map(|s| s.to_string()))
-                .unwrap_or_default()
-        ))
-        .build(ctx);
+        let version = TextBuilder::new()
+            .with_widget_builder(
+                WidgetBuilder::new()
+                    .on_row(0)
+                    .with_margin(Thickness::uniform(1.0)),
+            )
+            .with_text(format!(
+                "Current Engine Version: {}\nSource: {}",
+                dependency.req,
+                dependency
+                    .source
+                    .as_ref()
+                    .map(|s| s.to_string())
+                    .or_else(|| dependency.path.as_ref().map(|s| s.to_string()))
+                    .unwrap_or_default()
+            ))
+            .build(ctx);
 
         let is_local = dependency.path.is_some();
 

--- a/project-manager/src/utils.rs
+++ b/project-manager/src/utils.rs
@@ -70,7 +70,7 @@ pub fn make_button(
 
     ButtonBuilder::new(widget_builder)
         .with_content(
-            TextBuilder::new(WidgetBuilder::new())
+            TextBuilder::new()
                 .with_text(text)
                 .with_font_size(16.0.into())
                 .with_vertical_text_alignment(VerticalAlignment::Center)


### PR DESCRIPTION
TextBuilder can now be initialized without `widget_builder`, which means calls like:
```rust
TextBuilder::new()
    .with_font(font)
    .with_font_size(font_size)
```
are now possible.

## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Scaffolding for #911 .

Instead carrying fields/methods that do nothing but pass data down to internal `TextBuilder`s, builders that require a `TextBuilder` instance should take them as parameters instead (like `WidgetBuilder`), this allows caller to customize values of `TextBuilder`, and parent `Builder` to override values if necessary. For example:

### Problem 1
```rust
MenuItemBuilder::new(widget_builder)
    .with_font(font)
    .with_font_size(font_size)
    // What if caller wants to change Text::WrapMode?
    // MenuItemBuilder must now implement with_wrap()
    .build(ctx)

MenuItemBuilder {
    // ...
    pub font: FontResource, // Only exists to be passed down to TextBuilder
    pub font_size: StyledProperty<f32>, // Only exists to be passed down to TextBuilder
    // Need to implement wrap_mode: WrapMode
}
```

### Problem 2
```rust
MenuItemBuilder::new(widget_builder)
    // What if caller does not want to define WidgetBuilder values?
    .with_text_builder(
        TextBuilder::new(widget_builder)
    )
    .build(ctx)

impl MenuItemBuilder {
    pub fn build(self, ctx: &mut BuildContext) -> Handle<MenuItem> {
        // No way to override WidgetBuilder
        self.text_builder
            .with_font(self.font)
            .with_font_size(self.font_size)
            .build()
    }    
}
```

### Solution
```rust
MenuItemBuilder::new(widget_builder)
    .with_text_builder(
        // Anything a TextBuilder can have, the caller can add
        TextBuilder::new()
            .with_font(self.font)
            .with_font_size(self.font_size)
    )
    .build(ctx)

MenuItemBuilder {
    // ...
    // No need to carry transient data
   pub text_builder: Option<TextBuilder>,
}

impl MenuItemBuilder {
    pub fn build(self, ctx: &mut BuildContext) -> Handle<MenuItem> {
        self.text_builder.unwrap_or_default()
            // Builders can inject WidgetBuilder of their own
            .with_widget_builder(
                WidgetBuilder::new().with_thickness::left(2.0)
            )
            .build()
    }
}
```

This allows a higher degree of flexibility between caller and implementation.

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
- No change in project functionality.
- All instances of `TextBuilder::new(widget_builder)` are now `TextBuilder::new().with_widget_builder(widget_builder)`
- All instances of `TextBuilder::new(WidgetBuilder::new())` are now `TextBuilder::new()`
- `TextBuilder::widget_builder` is now an `Option<WidgetBuilder>` type (default: `None`)
- In `TextBuilder::build()`, if `widget_builder` is `None`, use `WidgetBuilder::new()` instead.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
N/A

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
