### PR TITLE
Reflection refactoring

### DIFF
--- a/editor/src/audio/mod.rs
+++ b/editor/src/audio/mod.rs
@@ -97,7 +97,7 @@ impl SelectionContainer for AudioBusSelection {
             .first()
             .and_then(|handle| state.bus_graph_ref().try_get_bus_ref(*handle).ok())
         {
-            (callback)(EntityInfo::with_no_parent(effect as &dyn Reflect));
+            (callback)(EntityInfo::with_no_parent(effect));
         }
     }
 

--- a/editor/src/command/mod.rs
+++ b/editor/src/command/mod.rs
@@ -544,38 +544,34 @@ impl<F: EntityGetter> CommandTrait for AddCollectionItemCommand<F> {
     fn execute(&mut self, ctx: &mut dyn CommandContext) {
         let entity = some_or_return!((self.entity_getter)(ctx));
         try_modify_property(entity, &self.path, |field| {
-            field.as_list_mut(&mut |result| {
-                if let Some(list) = result {
-                    if let Err(item) = list.reflect_push(self.item.take().unwrap()) {
-                        err!(
-                            "Failed to push item to {} collection. Type mismatch {} and {}!",
-                            self.path,
-                            item.type_info_ref().type_name,
-                            list.type_info_ref().type_name
-                        );
-                        self.item = Some(item);
-                    }
-                } else {
-                    err!("Property {} is not a collection!", self.path)
+            if let Some(list) = field.as_list_mut() {
+                if let Err(item) = list.reflect_push(self.item.take().unwrap()) {
+                    err!(
+                        "Failed to push item to {} collection. Type mismatch {} and {}!",
+                        self.path,
+                        item.type_info_ref().type_name,
+                        list.type_info_ref().type_name
+                    );
+                    self.item = Some(item);
                 }
-            });
+            } else {
+                err!("Property {} is not a collection!", self.path)
+            }
         })
     }
 
     fn revert(&mut self, ctx: &mut dyn CommandContext) {
         let entity = some_or_return!((self.entity_getter)(ctx));
         try_modify_property(entity, &self.path, |field| {
-            field.as_list_mut(&mut |result| {
-                if let Some(list) = result {
-                    if let Some(item) = list.reflect_pop() {
-                        self.item = Some(item);
-                    } else {
-                        err!("Failed to pop item from {} collection!", self.path)
-                    }
+            if let Some(list) = field.as_list_mut() {
+                if let Some(item) = list.reflect_pop() {
+                    self.item = Some(item);
                 } else {
-                    err!("Property {} is not a collection!", self.path)
+                    err!("Failed to pop item from {} collection!", self.path)
                 }
-            });
+            } else {
+                err!("Property {} is not a collection!", self.path)
+            }
         })
     }
 }
@@ -612,32 +608,28 @@ impl<F: EntityGetter> CommandTrait for RemoveCollectionItemCommand<F> {
     fn execute(&mut self, ctx: &mut dyn CommandContext) {
         let entity = some_or_return!((self.entity_getter)(ctx));
         try_modify_property(entity, &self.path, |field| {
-            field.as_list_mut(&mut |result| {
-                if let Some(list) = result {
-                    self.value = list.reflect_remove(self.index);
-                } else {
-                    err!("Property {} is not a collection!", self.path)
-                }
-            })
+            if let Some(list) = field.as_list_mut() {
+                self.value = list.reflect_remove(self.index);
+            } else {
+                err!("Property {} is not a collection!", self.path)
+            }
         })
     }
 
     fn revert(&mut self, ctx: &mut dyn CommandContext) {
         let entity = some_or_return!((self.entity_getter)(ctx));
         try_modify_property(entity, &self.path, |field| {
-            field.as_list_mut(&mut |result| {
-                if let Some(list) = result {
-                    if let Err(item) = list.reflect_insert(self.index, self.value.take().unwrap()) {
-                        self.value = Some(item);
-                        err!(
-                            "Failed to insert item to {} collection. Type mismatch!",
-                            self.path
-                        )
-                    }
-                } else {
-                    err!("Property {} is not a collection!", self.path)
+            if let Some(list) = field.as_list_mut() {
+                if let Err(item) = list.reflect_insert(self.index, self.value.take().unwrap()) {
+                    self.value = Some(item);
+                    err!(
+                        "Failed to insert item to {} collection. Type mismatch!",
+                        self.path
+                    )
                 }
-            });
+            } else {
+                err!("Property {} is not a collection!", self.path)
+            }
         })
     }
 }

--- a/editor/src/export/mod.rs
+++ b/editor/src/export/mod.rs
@@ -209,6 +209,7 @@ impl ExportWindow {
                             generate_property_string_values: true,
                             filter: Default::default(),
                             name_column_width: 150.0,
+                            hide_name_column: false,
                             base_path: Default::default(),
                             has_parent_object: false,
                         });

--- a/editor/src/interaction/navmesh/selection.rs
+++ b/editor/src/interaction/navmesh/selection.rs
@@ -67,7 +67,7 @@ impl SelectionContainer for NavmeshSelection {
         let scene = &scenes[game_scene.scene];
         let node = scene.graph.try_get_node(self.navmesh_node).unwrap();
         (callback)(EntityInfo {
-            entity: node as &dyn Reflect,
+            entity: node,
             has_inheritance_parent: node.has_inheritance_parent(),
             read_only: false,
         });

--- a/editor/src/interaction/terrain.rs
+++ b/editor/src/interaction/terrain.rs
@@ -640,6 +640,7 @@ impl BrushPanel {
             generate_property_string_values: true,
             filter: Default::default(),
             name_column_width: 150.0,
+            hide_name_column: false,
             base_path: Default::default(),
             has_parent_object: false,
         });

--- a/editor/src/light.rs
+++ b/editor/src/light.rs
@@ -268,6 +268,7 @@ impl LightPanel {
                                 generate_property_string_values: true,
                                 filter: Default::default(),
                                 name_column_width: 150.0,
+                                hide_name_column: false,
                                 base_path: Default::default(),
                                 has_parent_object: false,
                             }))

--- a/editor/src/plugins/absm/mod.rs
+++ b/editor/src/plugins/absm/mod.rs
@@ -148,7 +148,8 @@ where
         .try_get_node_mut(absm_handle)
         .ok()
         .and_then(|n| {
-            (n as &mut dyn Reflect).first_field_mut::<InheritableVariable<Machine<Handle<N>>>>()
+            n.inner_mut()
+                .first_field_mut::<InheritableVariable<Machine<Handle<N>>>>()
         })
         .map(|v| v.get_value_mut_silent())
 }
@@ -165,7 +166,8 @@ where
 {
     let absm = graph.try_get_node(absm_handle).ok()?;
 
-    let animation_player_handle = **(absm as &dyn Reflect)
+    let animation_player_handle = **absm
+        .inner_ref()
         .first_field_ref::<InheritableVariable<Handle<AnimationPlayer>>>()?;
 
     let animation_player = graph.try_get_mut(animation_player_handle).ok()?;
@@ -185,7 +187,8 @@ where
         .try_get_node(absm_handle)
         .ok()
         .and_then(|n| {
-            (n as &dyn Reflect).first_field_ref::<InheritableVariable<Machine<Handle<N>>>>()
+            n.inner_ref()
+                .first_field_ref::<InheritableVariable<Machine<Handle<N>>>>()
         })
         .map(|v| v.get_value_ref())
 }
@@ -202,7 +205,8 @@ where
 {
     let absm = graph.try_get_node(absm_handle).ok()?;
 
-    let animation_player_handle = **(absm as &dyn Reflect)
+    let animation_player_handle = **absm
+        .inner_ref()
         .first_field_ref::<InheritableVariable<Handle<AnimationPlayer>>>()?;
 
     let animation_player = graph.try_get(animation_player_handle).ok()?;

--- a/editor/src/plugins/absm/mod.rs
+++ b/editor/src/plugins/absm/mod.rs
@@ -148,8 +148,7 @@ where
         .try_get_node_mut(absm_handle)
         .ok()
         .and_then(|n| {
-            n.inner_mut_direct()
-                .first_field_mut::<InheritableVariable<Machine<Handle<N>>>>()
+            (n as &mut dyn Reflect).first_field_mut::<InheritableVariable<Machine<Handle<N>>>>()
         })
         .map(|v| v.get_value_mut_silent())
 }
@@ -166,14 +165,12 @@ where
 {
     let absm = graph.try_get_node(absm_handle).ok()?;
 
-    let animation_player_handle = **absm
-        .inner_ref_direct()
+    let animation_player_handle = **(absm as &dyn Reflect)
         .first_field_ref::<InheritableVariable<Handle<AnimationPlayer>>>()?;
 
     let animation_player = graph.try_get_mut(animation_player_handle).ok()?;
 
-    let container = animation_player
-        .inner_mut_direct()
+    let container = (animation_player as &mut dyn Reflect)
         .first_field_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>()?;
 
     Some((animation_player_handle, container.get_value_mut_silent()))
@@ -188,8 +185,7 @@ where
         .try_get_node(absm_handle)
         .ok()
         .and_then(|n| {
-            n.inner_ref_direct()
-                .first_field_ref::<InheritableVariable<Machine<Handle<N>>>>()
+            (n as &dyn Reflect).first_field_ref::<InheritableVariable<Machine<Handle<N>>>>()
         })
         .map(|v| v.get_value_ref())
 }
@@ -206,14 +202,12 @@ where
 {
     let absm = graph.try_get_node(absm_handle).ok()?;
 
-    let animation_player_handle = **absm
-        .inner_ref_direct()
+    let animation_player_handle = **(absm as &dyn Reflect)
         .first_field_ref::<InheritableVariable<Handle<AnimationPlayer>>>()?;
 
     let animation_player = graph.try_get(animation_player_handle).ok()?;
 
-    let container = animation_player
-        .inner_ref_direct()
+    let container = (animation_player as &dyn Reflect)
         .first_field_ref::<InheritableVariable<AnimationContainer<Handle<N>>>>()?;
 
     Some((animation_player_handle, &**container))

--- a/editor/src/plugins/absm/parameter.rs
+++ b/editor/src/plugins/absm/parameter.rs
@@ -110,6 +110,7 @@ impl ParameterPanel {
                     generate_property_string_values: true,
                     filter: Default::default(),
                     name_column_width: 150.0,
+                    hide_name_column: false,
                     base_path: Default::default(),
                     has_parent_object: false,
                 })

--- a/editor/src/plugins/animation/mod.rs
+++ b/editor/src/plugins/animation/mod.rs
@@ -213,7 +213,10 @@ where
     graph
         .try_get_node_mut(handle)
         .ok()
-        .and_then(|n| n.self_or_field_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>())
+        .and_then(|n| {
+            n.inner_mut()
+                .self_or_field_mut::<InheritableVariable<AnimationContainer<Handle<N>>>>()
+        })
         .map(|v| v.get_value_mut_silent())
 }
 
@@ -229,7 +232,7 @@ where
         .try_get_node(handle)
         .ok()
         .and_then(|n| {
-            (n as &dyn Reflect)
+            n.inner_ref()
                 .first_field_ref::<InheritableVariable<AnimationContainer<Handle<N>>>>()
         })
         .map(|v| v.get_value_ref())

--- a/editor/src/plugins/animation/selection.rs
+++ b/editor/src/plugins/animation/selection.rs
@@ -135,7 +135,7 @@ where
                     self.entities.first()
                 {
                     if let Some(signal) = animation.signals().iter().find(|s| s.id == *id) {
-                        (callback)(EntityInfo::with_no_parent(signal as &dyn Reflect));
+                        (callback)(EntityInfo::with_no_parent(signal));
                     }
                 }
             }

--- a/editor/src/plugins/animation/track.rs
+++ b/editor/src/plugins/animation/track.rs
@@ -869,38 +869,36 @@ impl TrackList {
                         }
                         ValueBinding::Property { name, .. } => node_ref.find_field(name, &mut |value| {
                             if let Some(value) = value {
-                                value.inner_ref(&mut |reflect| {
-                                    let curves = track.data_container().curves_ref();
-                                    if curves.len() == 1 {
-                                        if let Some(scalar) = any_scalar_to_f32(reflect) {
-                                            adder.add(&[scalar]);
-                                        } else {
-                                            err!("Unable to set {name} scalar property!");
-                                        }
-                                    } else if curves.len() == 2 {
-                                        if let Some(vec2) = any_vec_to_f32::<2>(reflect) {
-                                            adder.add(vec2.as_slice())
-                                        } else {
-                                            err!("Unable to set {name} Vector2 property!");
-                                        }
-                                    } else if curves.len() == 3 {
-                                        if let Some(vec3) = any_vec_to_f32::<3>(reflect) {
-                                            adder.add(vec3.as_slice())
-                                        } else {
-                                            err!("Unable to set {name} Vector3 property!");
-                                        }
-                                    } else if curves.len() == 4 {
-                                        if let Some(vec4) = any_vec_to_f32::<4>(reflect) {
-                                            adder.add(vec4.as_slice())
-                                        } else if let Some(quat) = any_quat_to_f32(reflect) {
-                                            adder.add(quat.coords.as_slice())
-                                        } else {
-                                            err!(
+                                let curves = track.data_container().curves_ref();
+                                if curves.len() == 1 {
+                                    if let Some(scalar) = any_scalar_to_f32(value) {
+                                        adder.add(&[scalar]);
+                                    } else {
+                                        err!("Unable to set {name} scalar property!");
+                                    }
+                                } else if curves.len() == 2 {
+                                    if let Some(vec2) = any_vec_to_f32::<2>(value) {
+                                        adder.add(vec2.as_slice())
+                                    } else {
+                                        err!("Unable to set {name} Vector2 property!");
+                                    }
+                                } else if curves.len() == 3 {
+                                    if let Some(vec3) = any_vec_to_f32::<3>(value) {
+                                        adder.add(vec3.as_slice())
+                                    } else {
+                                        err!("Unable to set {name} Vector3 property!");
+                                    }
+                                } else if curves.len() == 4 {
+                                    if let Some(vec4) = any_vec_to_f32::<4>(value) {
+                                        adder.add(vec4.as_slice())
+                                    } else if let Some(quat) = any_quat_to_f32(value) {
+                                        adder.add(quat.coords.as_slice())
+                                    } else {
+                                        err!(
                                                 "Unable to set {name} Vector4/Quaternion property!"
                                             );
-                                        }
                                     }
-                                })
+                                }
                             } else {
                                 err!("Unable to resolve property {name} when adding animation key!")
                             }
@@ -1103,9 +1101,7 @@ impl TrackList {
                     for property_path in selected_properties {
                         node.resolve_path(&property_path.path, &mut |result| match result {
                             Ok(property) => {
-                                let mut property_type = TypeId::of::<u32>();
-                                property
-                                    .inner_ref(&mut |reflect| property_type = reflect.type_id());
+                                let property_type = property.type_id();
 
                                 let types = type_id_to_supported_type(property_type);
 
@@ -1279,10 +1275,9 @@ impl TrackList {
     {
         let mut descriptors = Vec::new();
         if let Ok(node) = graph.try_get_node(node) {
-            node.inner_ref(&mut |node| {
-                descriptors = object_to_property_tree("", node, &mut |field: &FieldRef| {
-                    let type_id = field.value.field_value_as_reflect().type_id();
-                    type_id != TypeId::of::<TextureBytes>()
+            descriptors = object_to_property_tree("", node, &mut |field: &FieldRef| {
+                let type_id = field.value.type_id();
+                type_id != TypeId::of::<TextureBytes>()
                         // Vertex buffer cannot be animated (mainly because it contains untyped data).
                         && type_id != TypeId::of::<VertexBuffer>()
                         // Mesh topology cannot be animated.
@@ -1293,7 +1288,6 @@ impl TrackList {
                         // Do not allow animating prefab's content.
                         && type_id != TypeId::of::<ModelResource>()
                         && type_id != TypeId::of::<Resource<UserInterface>>()
-                });
             });
         }
 
@@ -1410,8 +1404,7 @@ impl TrackList {
 
         node.resolve_path(&desc.path, &mut |result| match result {
             Ok(property) => {
-                let mut property_type = TypeId::of::<u32>();
-                property.inner_ref(&mut |reflect| property_type = reflect.type_id());
+                let property_type = property.type_id();
 
                 let types = type_id_to_supported_type(property_type);
 
@@ -1713,8 +1706,7 @@ impl TrackList {
                     {
                         target.resolve_path(name, &mut |result| match result {
                             Ok(value) => {
-                                let mut property_type = TypeId::of::<u32>();
-                                value.inner_ref(&mut |reflect| property_type = reflect.type_id());
+                                let property_type= value.type_id();
 
                                 if let Some((_, type_)) = type_id_to_supported_type(property_type) {
                                     if *value_type != type_ {

--- a/editor/src/plugins/inspector/editors/dyntype.rs
+++ b/editor/src/plugins/inspector/editors/dyntype.rs
@@ -163,6 +163,7 @@ impl DynTypePropertyEditorBuilder {
                 generate_property_string_values,
                 filter,
                 name_column_width,
+                hide_name_column: false,
                 base_path: Default::default(),
                 has_parent_object,
             })
@@ -279,6 +280,7 @@ impl PropertyEditorDefinition for DynTypePropertyEditorDefinition {
                 editor
             },
             ctx.name_column_width,
+            ctx.hide_name_column,
             ctx.build_context,
         );
 
@@ -355,6 +357,7 @@ impl PropertyEditorDefinition for DynTypePropertyEditorDefinition {
                         generate_property_string_values: ctx.generate_property_string_values,
                         filter: ctx.filter,
                         name_column_width: ctx.name_column_width,
+                        hide_name_column: false,
                         base_path: Default::default(),
                         has_parent_object: ctx.has_parent_object,
                     })

--- a/editor/src/plugins/inspector/editors/mod.rs
+++ b/editor/src/plugins/inspector/editors/mod.rs
@@ -405,7 +405,7 @@ pub fn make_property_editors_container(
     container.insert(InheritablePropertyEditorDefinition::<
         Option<Resource<UserInterface>>,
     >::new());
-    container.register_inheritable_vec_collection::<Option<UserInterface>>();
+    container.register_vec_collection::<Option<UserInterface>>();
 
     container.insert(ResourceFieldPropertyEditorDefinition::<TileSet>::new(
         sender.clone(),
@@ -413,7 +413,7 @@ pub fn make_property_editors_container(
     container.insert(InheritablePropertyEditorDefinition::<
         Option<Resource<TileSet>>,
     >::new());
-    container.register_inheritable_vec_collection::<Option<TileSet>>();
+    container.register_vec_collection::<Option<TileSet>>();
 
     container.insert(ResourceFieldPropertyEditorDefinition::<Shader>::new(
         sender.clone(),
@@ -428,7 +428,7 @@ pub fn make_property_editors_container(
         Option<TileMapBrushResource>,
     >::new());
     container.register_inheritable_vec_collection::<Option<TileMapBrushResource>>();
-    container.register_inheritable_inspectable::<TileMapBrush>();
+    container.register_inspectable::<TileMapBrush>();
 
     container.register_inheritable_inspectable::<ColorGradingLut>();
     container.register_inheritable_inspectable::<InteractionGroups>();
@@ -444,8 +444,8 @@ pub fn make_property_editors_container(
     container.register_inheritable_inspectable::<PrismaticJoint>();
     container.register_inheritable_inspectable::<dim2::joint::PrismaticJoint>();
 
-    container.register_inheritable_inspectable::<Base>();
-    container.register_inheritable_inspectable::<BaseLight>();
+    container.register_inspectable::<Base>();
+    container.register_inspectable::<BaseLight>();
 
     container.insert(EnumPropertyEditorDefinition::<Effect>::new());
     container.insert(VecCollectionPropertyEditorDefinition::<Effect>::new());
@@ -462,14 +462,14 @@ pub fn make_property_editors_container(
     container.register_inheritable_enum::<Emitter, _>();
 
     container.register_inheritable_inspectable::<Biquad>();
-    container.register_inheritable_inspectable::<AudioBus>();
+    container.register_inspectable::<AudioBus>();
     container.register_inheritable_inspectable::<BaseEmitter>();
     container.register_inheritable_inspectable::<SphereEmitter>();
     container.register_inheritable_inspectable::<CylinderEmitter>();
     container.register_inheritable_inspectable::<CuboidEmitter>();
     container.register_inheritable_inspectable::<PerspectiveProjection>();
     container.register_inheritable_inspectable::<OrthographicProjection>();
-    container.register_inheritable_inspectable::<Transform>();
+    container.register_inspectable::<Transform>();
     container.register_inheritable_inspectable::<CsmOptions>();
     container.register_inheritable_inspectable::<HdrSettings>();
 
@@ -499,7 +499,7 @@ pub fn make_property_editors_container(
     container.register_inheritable_enum::<FrustumSplitOptions, _>();
     container.register_inheritable_enum::<MaterialSearchOptions, _>();
     container.register_inheritable_enum::<DistanceModel, _>();
-    container.register_inheritable_enum::<sound::Renderer, _>();
+    container.register_enum::<sound::Renderer, _>();
     container.register_inheritable_enum::<RenderPath, _>();
     container.register_inheritable_enum::<TexturePixelKind, _>();
     container.register_inheritable_enum::<EnvironmentLightingSource, _>();
@@ -763,6 +763,7 @@ pub fn make_property_editors_container(
         Terrain,
         TileMap
     );
+    container.register_inspectable::<scene::animation::AnimationPlayer>();
 
     container
 }

--- a/editor/src/plugins/inspector/editors/mod.rs
+++ b/editor/src/plugins/inspector/editors/mod.rs
@@ -199,6 +199,9 @@ use crate::{
         selection::SelectionSettings,
     },
 };
+use fyrox::gui::dock::DockingManager;
+use fyrox::gui::input::InputBox;
+use fyrox::gui::inspector::Inspector;
 use fyrox::scene::dim2::rectangle::Rectangle;
 use fyrox::scene::probe::ReflectionProbe;
 use fyrox_build_tools::{BuildProfile, CommandDescriptor, EnvironmentVariable};
@@ -801,6 +804,38 @@ pub fn make_property_editors_container(
         TileMap,
         Listener,
         Sprite
+    );
+
+    reg_node_editors!(
+        container,
+        Canvas,
+        Border,
+        Button,
+        CheckBox,
+        Decorator,
+        DropdownList,
+        DropdownMenu,
+        Expander,
+        Image,
+        NinePatch,
+        Popup,
+        ProgressBar,
+        Screen,
+        ScrollBar,
+        ScrollPanel,
+        ScrollViewer,
+        SearchBar,
+        Tile,
+        DockingManager,
+        Grid,
+        InputBox,
+        Inspector,
+        Menu,
+        MenuItem,
+        Window,
+        TabControl,
+        VectorImage,
+        WrapPanel
     );
 
     container

--- a/editor/src/plugins/inspector/editors/mod.rs
+++ b/editor/src/plugins/inspector/editors/mod.rs
@@ -199,11 +199,6 @@ use crate::{
         selection::SelectionSettings,
     },
 };
-use fyrox::gui::dock::DockingManager;
-use fyrox::gui::input::InputBox;
-use fyrox::gui::inspector::Inspector;
-use fyrox::scene::dim2::rectangle::Rectangle;
-use fyrox::scene::probe::ReflectionProbe;
 use fyrox_build_tools::{BuildProfile, CommandDescriptor, EnvironmentVariable};
 
 pub mod animation;
@@ -310,14 +305,6 @@ macro_rules! reg_node_handle_editors {
             $container.insert(NodeHandlePropertyEditorDefinition::<$ty>::new($sender.clone()));
             $container.insert(InheritablePropertyEditorDefinition::<Handle<$ty>>::new());
             $container.register_inheritable_vec_collection::<Handle<$ty>>();
-        )*
-    };
-}
-
-macro_rules! reg_node_editors {
-    ($container:ident, $($ty:ty),*) => {
-        $(
-            $container.insert(InspectablePropertyEditorDefinition::<$ty>::new());
         )*
     };
 }
@@ -775,67 +762,6 @@ pub fn make_property_editors_container(
         Listener,
         Terrain,
         TileMap
-    );
-
-    reg_node_editors!(
-        container,
-        scene::animation::AnimationPlayer,
-        scene::animation::absm::AnimationBlendingStateMachine,
-        Decal,
-        dim2::collider::Collider,
-        dim2::joint::Joint,
-        dim2::rigidbody::RigidBody,
-        DirectionalLight,
-        PointLight,
-        SpotLight,
-        Pivot,
-        Rectangle,
-        Camera,
-        Collider,
-        RigidBody,
-        Joint,
-        Mesh,
-        NavigationalMesh,
-        ParticleSystem,
-        ReflectionProbe,
-        Ragdoll,
-        Sound,
-        Terrain,
-        TileMap,
-        Listener,
-        Sprite
-    );
-
-    reg_node_editors!(
-        container,
-        Canvas,
-        Border,
-        Button,
-        CheckBox,
-        Decorator,
-        DropdownList,
-        DropdownMenu,
-        Expander,
-        Image,
-        NinePatch,
-        Popup,
-        ProgressBar,
-        Screen,
-        ScrollBar,
-        ScrollPanel,
-        ScrollViewer,
-        SearchBar,
-        Tile,
-        DockingManager,
-        Grid,
-        InputBox,
-        Inspector,
-        Menu,
-        MenuItem,
-        Window,
-        TabControl,
-        VectorImage,
-        WrapPanel
     );
 
     container

--- a/editor/src/plugins/inspector/editors/mod.rs
+++ b/editor/src/plugins/inspector/editors/mod.rs
@@ -199,6 +199,8 @@ use crate::{
         selection::SelectionSettings,
     },
 };
+use fyrox::scene::dim2::rectangle::Rectangle;
+use fyrox::scene::probe::ReflectionProbe;
 use fyrox_build_tools::{BuildProfile, CommandDescriptor, EnvironmentVariable};
 
 pub mod animation;
@@ -305,6 +307,14 @@ macro_rules! reg_node_handle_editors {
             $container.insert(NodeHandlePropertyEditorDefinition::<$ty>::new($sender.clone()));
             $container.insert(InheritablePropertyEditorDefinition::<Handle<$ty>>::new());
             $container.register_inheritable_vec_collection::<Handle<$ty>>();
+        )*
+    };
+}
+
+macro_rules! reg_node_editors {
+    ($container:ident, $($ty:ty),*) => {
+        $(
+            $container.insert(InspectablePropertyEditorDefinition::<$ty>::new());
         )*
     };
 }
@@ -763,7 +773,35 @@ pub fn make_property_editors_container(
         Terrain,
         TileMap
     );
-    container.register_inspectable::<scene::animation::AnimationPlayer>();
+
+    reg_node_editors!(
+        container,
+        scene::animation::AnimationPlayer,
+        scene::animation::absm::AnimationBlendingStateMachine,
+        Decal,
+        dim2::collider::Collider,
+        dim2::joint::Joint,
+        dim2::rigidbody::RigidBody,
+        DirectionalLight,
+        PointLight,
+        SpotLight,
+        Pivot,
+        Rectangle,
+        Camera,
+        Collider,
+        RigidBody,
+        Joint,
+        Mesh,
+        NavigationalMesh,
+        ParticleSystem,
+        ReflectionProbe,
+        Ragdoll,
+        Sound,
+        Terrain,
+        TileMap,
+        Listener,
+        Sprite
+    );
 
     container
 }

--- a/editor/src/plugins/inspector/editors/script.rs
+++ b/editor/src/plugins/inspector/editors/script.rs
@@ -238,6 +238,7 @@ impl ScriptPropertyEditorBuilder {
                 generate_property_string_values,
                 filter,
                 name_column_width,
+                hide_name_column: false,
                 base_path: Default::default(),
                 has_parent_object,
             })
@@ -383,6 +384,7 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
                 editor
             },
             ctx.name_column_width,
+            ctx.hide_name_column,
             ctx.build_context,
         );
 
@@ -460,6 +462,7 @@ impl PropertyEditorDefinition for ScriptPropertyEditorDefinition {
                         generate_property_string_values: ctx.generate_property_string_values,
                         filter: ctx.filter,
                         name_column_width: ctx.name_column_width,
+                        hide_name_column: false,
                         base_path: Default::default(),
                         has_parent_object: ctx.has_parent_object,
                     })

--- a/editor/src/plugins/inspector/handlers/node/mod.rs
+++ b/editor/src/plugins/inspector/handlers/node/mod.rs
@@ -18,19 +18,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crate::command::make_command;
-use crate::fyrox::core::reflect::Reflect;
-use crate::fyrox::{
-    core::pool::Handle,
-    gui::inspector::{CollectionAction, FieldAction, PropertyChanged},
-    scene::{node::Node, terrain::Terrain},
-};
-use crate::scene::commands::{GameSceneContext, RevertSceneNodePropertyCommand};
 use crate::{
-    scene::commands::terrain::{AddTerrainLayerCommand, DeleteTerrainLayerCommand},
+    command::make_command,
+    fyrox::{
+        core::pool::Handle,
+        graph::{SceneGraph, SceneGraphNode},
+        gui::inspector::{CollectionAction, FieldAction, PropertyChanged},
+        scene::{node::Node, terrain::Terrain},
+    },
+    scene::commands::{
+        terrain::{AddTerrainLayerCommand, DeleteTerrainLayerCommand},
+        GameSceneContext, RevertSceneNodePropertyCommand,
+    },
     Command,
 };
-use fyrox::graph::SceneGraph;
 
 pub struct SceneNodePropertyChangedHandler;
 
@@ -87,7 +88,7 @@ impl SceneNodePropertyChangedHandler {
                         .graph
                         .try_get_node_mut(handle)
                         .ok()
-                        .map(|n| n as &mut dyn Reflect)
+                        .map(|n| n.inner_mut())
                 })
             }
         })

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -494,12 +494,8 @@ impl EditorPlugin for InspectorPlugin {
                                             can_clone = property.try_clone_box().is_some();
 
                                             if let Some(value) = self.clipboard.as_ref() {
-                                                value.inner_ref(&mut |reflect| {
-                                                    property.inner_ref(&mut |property| {
-                                                        can_paste =
-                                                            property.type_id() == reflect.type_id();
-                                                    })
-                                                })
+                                                can_paste =
+                                                    property.type_id() == (**value).type_id();
                                             }
                                         }
                                         Err(err) => {

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -348,6 +348,7 @@ impl InspectorPlugin {
             generate_property_string_values: true,
             filter: Default::default(),
             name_column_width: 150.0,
+            hide_name_column: false,
             base_path: Default::default(),
             has_parent_object,
         });

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -195,9 +195,15 @@ fn print_errors(sync_errors: &[InspectorError]) {
 }
 
 fn is_out_of_sync(sync_errors: &[InspectorError]) -> bool {
-    sync_errors
-        .iter()
-        .any(|err| matches!(err, &InspectorError::OutOfSync))
+    sync_errors.iter().any(|err| {
+        if matches!(err, &InspectorError::OutOfSync) {
+            true
+        } else if let InspectorError::Group(group) = err {
+            is_out_of_sync(group)
+        } else {
+            false
+        }
+    })
 }
 
 impl InspectorPlugin {

--- a/editor/src/plugins/ragdoll.rs
+++ b/editor/src/plugins/ragdoll.rs
@@ -1058,6 +1058,7 @@ impl RagdollWizard {
                                 generate_property_string_values: true,
                                 filter: Default::default(),
                                 name_column_width: 150.0,
+                                hide_name_column: false,
                                 base_path: Default::default(),
                                 has_parent_object: false,
                             }))

--- a/editor/src/plugins/settings.rs
+++ b/editor/src/plugins/settings.rs
@@ -219,6 +219,7 @@ impl SettingsWindow {
             generate_property_string_values: true,
             filter: Default::default(),
             name_column_width: 250.0,
+            hide_name_column: false,
             base_path: Default::default(),
             has_parent_object: false,
         });

--- a/editor/src/scene/commands/mod.rs
+++ b/editor/src/scene/commands/mod.rs
@@ -338,16 +338,19 @@ impl CommandTrait for RevertSceneNodePropertyCommand {
         // If the property was modified, then simply set it to previous value to make it modified again.
         if let Some(old_value) = self.value.take() {
             let mut old_value = Some(old_value);
-            context.scene.graph[self.handle].inner_mut(&mut |node| {
-                node.set_field_by_path(&self.path, old_value.take().unwrap(), &mut |result| {
+            let node = &mut context.scene.graph[self.handle];
+            (node as &mut dyn Reflect).set_field_by_path(
+                &self.path,
+                old_value.take().unwrap(),
+                &mut |result| {
                     if result.is_err() {
                         Log::err(format!(
                             "Failed to revert property {}. Reason: no such property!",
                             self.path
                         ))
                     }
-                });
-            })
+                },
+            );
         }
     }
 }

--- a/editor/src/scene/property.rs
+++ b/editor/src/scene/property.rs
@@ -176,7 +176,7 @@ where
                 continue;
             }
 
-            let field_ref = field_info.value.field_value_as_reflect();
+            let field_ref = field_info.value;
 
             let path = if parent_path.is_empty() {
                 field_info.name.to_owned()
@@ -191,7 +191,7 @@ where
                     let mut descriptor = PropertyDescriptor {
                         path: path.clone(),
                         display_name: field_info.display_name.to_owned(),
-                        type_name: field_info.value.type_name().to_owned(),
+                        type_name: field_info.value.type_info_ref().type_name.to_owned(),
                         type_id: field_info.value.type_id(),
                         children_properties: Default::default(),
                         read_only: field_info.read_only,
@@ -226,7 +226,7 @@ where
                         let mut descriptor = PropertyDescriptor {
                             path: path.clone(),
                             display_name: field_info.display_name.to_owned(),
-                            type_name: field_info.value.type_name().to_owned(),
+                            type_name: field_info.value.type_info_ref().type_name.to_owned(),
                             type_id: field_info.value.type_id(),
                             children_properties: Default::default(),
                             read_only: field_info.read_only,
@@ -239,13 +239,8 @@ where
                             // fine for most cases in the engine.
                             let mut key_str = format!("{key:?}");
 
-                            let mut is_key_string = false;
-                            key.downcast_ref::<String>(&mut |string| {
-                                is_key_string |= string.is_some()
-                            });
-                            key.downcast_ref::<ImmutableString>(&mut |string| {
-                                is_key_string |= string.is_some()
-                            });
+                            let is_key_string = key.downcast_ref::<String>().is_some()
+                                || key.downcast_ref::<ImmutableString>().is_some();
 
                             if is_key_string {
                                 // Strip quotes at the beginning and the end, because Debug impl for String adds
@@ -282,7 +277,7 @@ where
             if !processed {
                 descriptors.push(PropertyDescriptor {
                     display_name: field_info.display_name.to_owned(),
-                    type_name: field_info.value.type_name().to_owned(),
+                    type_name: field_info.value.type_info_ref().type_name.to_owned(),
                     type_id: field_info.value.type_id(),
                     read_only: field_info.read_only,
                     children_properties: object_to_property_tree(&path, field_ref, filter),

--- a/editor/src/scene/property.rs
+++ b/editor/src/scene/property.rs
@@ -186,7 +186,7 @@ where
 
             let mut processed = true;
 
-            field_ref.as_array(&mut |array| match array {
+            match field_ref.as_array() {
                 Some(array) => {
                     let mut descriptor = PropertyDescriptor {
                         path: path.clone(),
@@ -218,10 +218,10 @@ where
                 None => {
                     processed = false;
                 }
-            });
+            }
 
             if !processed {
-                field_ref.as_hash_map(&mut |result| match result {
+                match field_ref.as_hash_map() {
                     Some(hash_map) => {
                         let mut descriptor = PropertyDescriptor {
                             path: path.clone(),
@@ -271,7 +271,7 @@ where
                     None => {
                         processed = false;
                     }
-                })
+                }
             }
 
             if !processed {

--- a/editor/src/scene/settings/mod.rs
+++ b/editor/src/scene/settings/mod.rs
@@ -55,6 +55,7 @@ use crate::{
     ui_scene::UiScene,
     GameScene, Message,
 };
+use fyrox::gui::inspector::editors::inspectable::InspectablePropertyEditorDefinition;
 use fyrox::gui::inspector::Inspector;
 use std::sync::{mpsc::Sender, Arc};
 
@@ -89,10 +90,12 @@ impl SceneSettingsWindow {
         .with_title(WindowTitle::text("Scene Settings"))
         .build(ctx);
 
-        property_definitions.register_inheritable_inspectable::<Graph>();
+        property_definitions.insert(InspectablePropertyEditorDefinition::<Graph>::new());
         property_definitions.register_inheritable_inspectable::<IntegrationParameters>();
-        property_definitions.register_inheritable_inspectable::<PhysicsWorld>();
-        property_definitions.register_inheritable_inspectable::<dim2::physics::PhysicsWorld>();
+        property_definitions.insert(InspectablePropertyEditorDefinition::<PhysicsWorld>::new());
+        property_definitions.insert(InspectablePropertyEditorDefinition::<
+            dim2::physics::PhysicsWorld,
+        >::new());
         property_definitions.register_inheritable_inspectable::<SceneRenderingOptions>();
         property_definitions.insert(EnumPropertyEditorDefinition::<Color>::new_optional());
 
@@ -161,27 +164,9 @@ impl SceneSettingsWindow {
             layer_index: 0,
             generate_property_string_values: false,
             filter: PropertyFilter::new(|property| {
-                let mut pass = true;
-
-                property.downcast_ref::<NodePool>(&mut |v| {
-                    if v.is_some() {
-                        pass = false;
-                    }
-                });
-
-                property.downcast_ref::<WidgetPool>(&mut |v| {
-                    if v.is_some() {
-                        pass = false;
-                    }
-                });
-
-                property.downcast_ref::<Option<Lightmap>>(&mut |v| {
-                    if v.is_some() {
-                        pass = false;
-                    }
-                });
-
-                pass
+                property.downcast_ref::<NodePool>().is_none()
+                    && property.downcast_ref::<WidgetPool>().is_none()
+                    && property.downcast_ref::<Option<Lightmap>>().is_none()
             }),
             name_column_width: 150.0,
             base_path: Default::default(),

--- a/editor/src/scene/settings/mod.rs
+++ b/editor/src/scene/settings/mod.rs
@@ -169,6 +169,7 @@ impl SceneSettingsWindow {
                     && property.downcast_ref::<Option<Lightmap>>().is_none()
             }),
             name_column_width: 150.0,
+            hide_name_column: false,
             base_path: Default::default(),
             has_parent_object: false,
         });

--- a/editor/src/ui_scene/commands/mod.rs
+++ b/editor/src/ui_scene/commands/mod.rs
@@ -26,6 +26,9 @@ use crate::{
     command::CommandContext, message::MessageSender, scene::Selection,
     ui_scene::clipboard::Clipboard,
 };
+use fyrox::core::pool::Handle;
+use fyrox::graph::SceneGraphNode;
+use fyrox::gui::UiNode;
 
 #[derive(Reflect, Debug)]
 #[reflect(non_cloneable)]
@@ -57,6 +60,13 @@ impl UiSceneContext {
                 clipboard: std::mem::transmute::<&'a mut _, &'static mut _>(clipboard),
             }
         });
+    }
+
+    pub fn widget_mut(&mut self, handle: Handle<UiNode>) -> Option<&mut dyn Reflect> {
+        self.ui
+            .try_get_node_mut(handle)
+            .ok()
+            .map(|widget| widget.inner_mut())
     }
 }
 

--- a/editor/src/ui_scene/commands/widget.rs
+++ b/editor/src/ui_scene/commands/widget.rs
@@ -104,20 +104,19 @@ impl CommandTrait for RevertWidgetPropertyCommand {
         // If the property was modified, then simply set it to previous value to make it modified again.
         if let Some(old_value) = self.value.take() {
             let mut old_value = Some(old_value);
-            context
-                .get_mut::<UiSceneContext>()
-                .ui
-                .node_mut(self.handle)
-                .inner_mut(&mut |node| {
-                    node.set_field_by_path(&self.path, old_value.take().unwrap(), &mut |result| {
-                        if result.is_err() {
-                            Log::err(format!(
-                                "Failed to revert property {}. Reason: no such property!",
-                                self.path
-                            ))
-                        }
-                    });
-                })
+            let node = context.get_mut::<UiSceneContext>().ui.node_mut(self.handle);
+            (node as &mut dyn Reflect).set_field_by_path(
+                &self.path,
+                old_value.take().unwrap(),
+                &mut |result| {
+                    if result.is_err() {
+                        Log::err(format!(
+                            "Failed to revert property {}. Reason: no such property!",
+                            self.path
+                        ))
+                    }
+                },
+            );
         }
     }
 }

--- a/editor/src/ui_scene/selection.rs
+++ b/editor/src/ui_scene/selection.rs
@@ -59,7 +59,7 @@ impl SelectionContainer for UiSelection {
         if let Some(first) = self.widgets.first() {
             if let Ok(node) = ui_scene.ui.try_get_node(*first) {
                 (callback)(EntityInfo {
-                    entity: node as &dyn Reflect,
+                    entity: node,
                     has_inheritance_parent: node.has_inheritance_parent(),
                     read_only: false,
                 })

--- a/editor/src/ui_scene/selection.rs
+++ b/editor/src/ui_scene/selection.rs
@@ -57,10 +57,10 @@ impl SelectionContainer for UiSelection {
     ) {
         let ui_scene = some_or_return!(controller.downcast_ref::<UiScene>());
         if let Some(first) = self.widgets.first() {
-            if let Ok(node) = ui_scene.ui.try_get_node(*first) {
+            if let Ok(widget) = ui_scene.ui.try_get_node(*first) {
                 (callback)(EntityInfo {
-                    entity: node,
-                    has_inheritance_parent: node.has_inheritance_parent(),
+                    entity: widget.inner_ref(),
+                    has_inheritance_parent: widget.has_inheritance_parent(),
                     read_only: false,
                 })
             }
@@ -79,10 +79,10 @@ impl SelectionContainer for UiSelection {
             .widgets
             .iter()
             .filter_map(|&node_handle| {
-                let node = ui_scene.ui.try_get_node(node_handle).ok()?;
+                let widget = ui_scene.ui.try_get_node(node_handle).ok()?;
                 if args.is_inheritable() {
                     // Prevent reverting property value if there's no parent resource.
-                    if node.resource().is_some() {
+                    if widget.resource().is_some() {
                         Some(Command::new(RevertWidgetPropertyCommand::new(
                             args.path(),
                             node_handle,
@@ -92,11 +92,7 @@ impl SelectionContainer for UiSelection {
                     }
                 } else {
                     make_command(args, move |ctx| {
-                        ctx.get_mut::<UiSceneContext>()
-                            .ui
-                            .try_get_node_mut(node_handle)
-                            .ok()
-                            .map(|n| n as &mut dyn Reflect)
+                        ctx.get_mut::<UiSceneContext>().widget_mut(node_handle)
                     })
                 }
             })
@@ -114,13 +110,7 @@ impl SelectionContainer for UiSelection {
                     Command::new(SetPropertyCommand::new(
                         path.to_string(),
                         value,
-                        move |ctx| {
-                            ctx.get_mut::<UiSceneContext>()
-                                .ui
-                                .try_get_node_mut(node_handle)
-                                .ok()
-                                .map(|n| n as &mut dyn Reflect)
-                        },
+                        move |ctx| ctx.get_mut::<UiSceneContext>().widget_mut(node_handle),
                     ))
                 })
             })
@@ -131,13 +121,8 @@ impl SelectionContainer for UiSelection {
 
     fn provide_docs(&self, controller: &dyn SceneController, _engine: &Engine) -> Option<String> {
         let ui_scene = controller.downcast_ref::<UiScene>()?;
-        self.widgets.first().and_then(|h| {
-            ui_scene
-                .ui
-                .try_get_node(*h)
-                .ok()
-                .map(|n| n.type_info_ref().doc_comment.to_string())
-        })
+        let widget = ui_scene.ui.try_get_node(*self.widgets.first()?).ok()?;
+        Some(widget.inner_ref().type_info_ref().doc_comment.to_string())
     }
 }
 

--- a/editor/src/ui_scene/utils.rs
+++ b/editor/src/ui_scene/utils.rs
@@ -23,7 +23,7 @@ use crate::fyrox::{
     asset::manager::ResourceManager,
     core::{
         futures::executor::block_on, make_pretty_type_name, make_relative_path, pool::ErasedHandle,
-        pool::Handle, reflect::Reflect,
+        pool::Handle,
     },
     graph::SceneGraph,
     gui::{
@@ -110,7 +110,7 @@ impl WorldViewerDataProvider for UiSceneWorldViewerDataProvider<'_> {
             Cow::Owned(format!(
                 "{} [{}]",
                 n.name(),
-                make_pretty_type_name(n.type_info_ref().type_name)
+                make_pretty_type_name(n.inner_ref().type_info_ref().type_name)
             ))
         })
     }

--- a/editor/src/world/menu.rs
+++ b/editor/src/world/menu.rs
@@ -461,16 +461,14 @@ impl SceneNodeContextMenu {
                             if let Ok(node) = scene.graph.try_get_node(*node_handle) {
                                 (node as &dyn Reflect).enumerate_fields_recursively(
                                     &mut |path, _, val| {
-                                        val.as_inheritable_variable(&mut |inheritable| {
-                                            if inheritable.is_some() {
-                                                commands.push(Command::new(
-                                                    RevertSceneNodePropertyCommand::new(
-                                                        path.to_string(),
-                                                        *node_handle,
-                                                    ),
-                                                ));
-                                            }
-                                        });
+                                        if val.as_inheritable_variable().is_some() {
+                                            commands.push(Command::new(
+                                                RevertSceneNodePropertyCommand::new(
+                                                    path.to_string(),
+                                                    *node_handle,
+                                                ),
+                                            ));
+                                        }
                                     },
                                     &[TypeId::of::<UntypedResource>()],
                                 )

--- a/editor/src/world/selection.rs
+++ b/editor/src/world/selection.rs
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use crate::scene::EntityInfo;
 use crate::{
     command::{Command, SetPropertyCommand},
     fyrox::{
@@ -28,13 +27,14 @@ use crate::{
             some_or_return,
         },
         engine::Engine,
-        graph::SceneGraph,
+        graph::{SceneGraph, SceneGraphNode},
         gui::inspector::PropertyChanged,
         scene::{graph::Graph, node::Node, SceneContainer},
     },
     message::MessageSender,
     scene::{
-        commands::GameSceneContext, controller::SceneController, GameScene, SelectionContainer,
+        commands::GameSceneContext, controller::SceneController, EntityInfo, GameScene,
+        SelectionContainer,
     },
     utils,
 };
@@ -63,7 +63,7 @@ impl SelectionContainer for GraphSelection {
             .and_then(|handle| scene.graph.try_get_node(*handle).ok())
         {
             (callback)(EntityInfo {
-                entity: node,
+                entity: node.inner_ref(),
                 has_inheritance_parent: node.has_inheritance_parent(),
                 read_only: false,
             });
@@ -110,7 +110,7 @@ impl SelectionContainer for GraphSelection {
                                 .graph
                                 .try_get_node_mut(node_handle)
                                 .ok()
-                                .map(|n| n as &mut dyn Reflect)
+                                .map(|n| n.inner_mut())
                         },
                     ))
                 })
@@ -123,9 +123,8 @@ impl SelectionContainer for GraphSelection {
     fn provide_docs(&self, controller: &dyn SceneController, engine: &Engine) -> Option<String> {
         let game_scene = controller.downcast_ref::<GameScene>()?;
         let scene = &engine.scenes[game_scene.scene];
-        self.nodes
-            .first()
-            .map(|h| scene.graph[*h].type_info_ref().doc_comment.to_string())
+        let node = scene.graph.try_get(*self.nodes.first()?).ok()?;
+        Some(node.inner_ref().type_info_ref().doc_comment.to_string())
     }
 }
 

--- a/editor/src/world/selection.rs
+++ b/editor/src/world/selection.rs
@@ -63,7 +63,7 @@ impl SelectionContainer for GraphSelection {
             .and_then(|handle| scene.graph.try_get_node(*handle).ok())
         {
             (callback)(EntityInfo {
-                entity: node as &dyn Reflect,
+                entity: node,
                 has_inheritance_parent: node.has_inheritance_parent(),
                 read_only: false,
             });

--- a/fyrox-animation/src/value.rs
+++ b/fyrox-animation/src/value.rs
@@ -405,28 +405,23 @@ impl BoundValue {
         property_path: &str,
         value_type: ValueType,
     ) {
-        object.inner_mut(&mut |object_ref| {
-            object_ref.resolve_path_mut(property_path, &mut |result| match result {
-                Ok(property) => {
-                    let mut applied = false;
-                    property.inner_mut(&mut |reflect| {
-                        applied = self.value.apply_to_any(reflect, value_type);
+        object.resolve_path_mut(property_path, &mut |result| match result {
+            Ok(property) => {
+                let applied = self.value.apply_to_any(property, value_type);
+                if applied {
+                    property.as_inheritable_variable_mut(&mut |var| {
+                        if let Some(var) = var {
+                            var.mark_modified();
+                        }
                     });
-                    if applied {
-                        property.as_inheritable_variable_mut(&mut |var| {
-                            if let Some(var) = var {
-                                var.mark_modified();
-                            }
-                        });
-                    }
                 }
-                Err(err) => {
-                    Log::err(format!(
-                        "Failed to set property {property_path}! Reason: {err:?}"
-                    ));
-                }
-            });
-        })
+            }
+            Err(err) => {
+                Log::err(format!(
+                    "Failed to set property {property_path}! Reason: {err:?}"
+                ));
+            }
+        });
     }
 }
 
@@ -538,7 +533,7 @@ mod test {
         assert!(!object.other_struct.inheritable_variable.is_modified());
         inheritable_variable_value.apply_to_object(
             &mut object,
-            "other_struct.inheritable_variable",
+            "other_struct.inheritable_variable.Content",
             ValueType::U32,
         );
         assert_eq!(object.other_struct.field, 123);

--- a/fyrox-animation/src/value.rs
+++ b/fyrox-animation/src/value.rs
@@ -409,11 +409,9 @@ impl BoundValue {
             Ok(property) => {
                 let applied = self.value.apply_to_any(property, value_type);
                 if applied {
-                    property.as_inheritable_variable_mut(&mut |var| {
-                        if let Some(var) = var {
-                            var.mark_modified();
-                        }
-                    });
+                    if let Some(var) = property.as_inheritable_variable_mut() {
+                        var.mark_modified();
+                    }
                 }
             }
             Err(err) => {

--- a/fyrox-core-derive/src/reflect.rs
+++ b/fyrox-core-derive/src/reflect.rs
@@ -429,6 +429,12 @@ fn gen_impl(
                 None
             }
         }
+    } else if let Some(ref clone_fn) = ty_args.clone_fn {
+        quote! {
+            fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
+                Some(Box::new(#clone_fn(self)))
+            }
+        }
     } else {
         quote! {
             fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {

--- a/fyrox-core-derive/src/reflect.rs
+++ b/fyrox-core-derive/src/reflect.rs
@@ -477,10 +477,6 @@ fn gen_impl(
                 #metadata_mut
             }
 
-            fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-                self
-            }
-
             fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
                 let value = match value.take() {
                     Ok(x) => x,
@@ -503,22 +499,6 @@ fn gen_impl(
             }
 
             #set_field
-
-            fn inner_ref_direct(&self) -> &dyn Reflect {
-                self
-            }
-
-            fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-                func(self as &dyn Reflect)
-            }
-
-            fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-                self
-            }
-
-            fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-                func(self as &mut dyn Reflect)
-            }
 
             #as_array_impl
 

--- a/fyrox-core-derive/src/reflect/args.rs
+++ b/fyrox-core-derive/src/reflect/args.rs
@@ -62,6 +62,9 @@ pub struct TypeArgs {
 
     #[darling(default)]
     pub non_cloneable: bool,
+
+    #[darling(default)]
+    pub clone_fn: Option<Path>,
 }
 
 impl TypeArgs {

--- a/fyrox-core-derive/src/reflect/args.rs
+++ b/fyrox-core-derive/src/reflect/args.rs
@@ -104,12 +104,12 @@ impl TypeArgs {
         }
 
         quote! {
-            fn as_list(&self, func: &mut dyn FnMut(Option<&dyn ReflectList>)) {
-                func(Some(self))
+            fn as_list(&self) -> Option<&dyn ReflectList> {
+                Some(self)
             }
 
-            fn as_list_mut(&mut self,  func: &mut dyn FnMut(Option<&mut dyn ReflectList>)) {
-                func(Some(self))
+            fn as_list_mut(&mut self) -> Option<&mut dyn ReflectList> {
+                Some(self)
             }
         }
     }
@@ -120,12 +120,12 @@ impl TypeArgs {
         }
 
         quote! {
-            fn as_array(&self, func: &mut dyn FnMut(Option<&dyn ReflectArray>)) {
-                func(Some(self))
+            fn as_array(&self) -> Option<&dyn ReflectArray> {
+                Some(self)
             }
 
-            fn as_array_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectArray>)) {
-                func(Some(self))
+            fn as_array_mut(&mut self) -> Option<&mut dyn ReflectArray> {
+                Some(self)
             }
         }
     }

--- a/fyrox-core-derive/tests/it/reflect.rs
+++ b/fyrox-core-derive/tests/it/reflect.rs
@@ -290,18 +290,13 @@ fn reflect_fields_list_of_struct() {
 
     foo.fields_ref(&mut |fields| assert_eq!(fields.len(), 2));
     foo.fields_ref(&mut |fields| {
-        fields[0]
-            .value
-            .field_value_as_reflect()
-            .downcast_ref::<f32>(&mut |result| assert_eq!(result.cloned(), Some(1.23)))
+        assert_eq!(fields[0].value.downcast_ref::<f32>().cloned(), Some(1.23))
     });
     foo.fields_ref(&mut |fields| {
-        fields[1]
-            .value
-            .field_value_as_reflect()
-            .downcast_ref::<String>(&mut |result| {
-                assert_eq!(result.cloned(), Some("Foobar".to_string()))
-            })
+        assert_eq!(
+            fields[1].value.downcast_ref::<String>().cloned(),
+            Some("Foobar".to_string())
+        )
     });
 }
 
@@ -317,10 +312,7 @@ fn reflect_fields_list_of_enum() {
 
     bar_variant.fields_ref(&mut |fields| assert_eq!(fields.len(), 1));
     bar_variant.fields_ref(&mut |fields| {
-        fields[0]
-            .value
-            .field_value_as_reflect()
-            .downcast_ref::<f32>(&mut |result| assert_eq!(result.cloned(), Some(1.23)))
+        assert_eq!(fields[0].value.downcast_ref::<f32>().cloned(), Some(1.23))
     });
 
     let baz_variant = Foo::Baz {
@@ -330,18 +322,13 @@ fn reflect_fields_list_of_enum() {
 
     baz_variant.fields_ref(&mut |fields| assert_eq!(fields.len(), 2));
     baz_variant.fields_ref(&mut |fields| {
-        fields[0]
-            .value
-            .field_value_as_reflect()
-            .downcast_ref::<u32>(&mut |result| assert_eq!(result.cloned(), Some(321)))
+        assert_eq!(fields[0].value.downcast_ref::<u32>().cloned(), Some(321))
     });
     baz_variant.fields_ref(&mut |fields| {
-        fields[1]
-            .value
-            .field_value_as_reflect()
-            .downcast_ref::<String>(&mut |result| {
-                assert_eq!(result.cloned(), Some("Foobar".to_string()))
-            })
+        assert_eq!(
+            fields[1].value.downcast_ref::<String>().cloned(),
+            Some("Foobar".to_string())
+        )
     });
 }
 
@@ -636,7 +623,7 @@ fn test_reflect_mutex() {
         hidden: 0,
     });
 
-    foo.get_resolve_path::<usize>("field", &mut |result| {
+    foo.get_resolve_path::<usize>("Content.field", &mut |result| {
         assert_eq!(result, Ok(&123));
     });
 
@@ -672,18 +659,14 @@ fn test_hash_map() {
         assert_eq!(hash_map.reflect_len(), 2);
 
         hash_map.reflect_get(&foo_key, &mut |result| {
-            result
-                .unwrap()
-                .downcast_ref::<Struct>(&mut |result| assert_eq!(result.unwrap().field, 123))
+            assert_eq!(result.unwrap().downcast_ref::<Struct>().unwrap().field, 123)
         })
     });
 
     hash_map.as_hash_map_mut(&mut |result| {
         let hash_map = result.unwrap();
         hash_map.reflect_get_mut(&bar_key, &mut |result| {
-            result
-                .unwrap()
-                .downcast_mut::<Struct>(&mut |result| result.unwrap().field = 555)
+            result.unwrap().downcast_mut::<Struct>().unwrap().field = 555
         })
     });
 

--- a/fyrox-core-derive/tests/it/reflect.rs
+++ b/fyrox-core-derive/tests/it/reflect.rs
@@ -207,14 +207,12 @@ fn reflect_list() {
     let mut data = vec![10usize, 11usize];
 
     let data = &mut data as &mut dyn Reflect;
-    data.as_list_mut(&mut |data| {
-        let data = data.unwrap();
-        data.get_reflect_index(0, &mut |result| assert_eq!(result, Some(&10usize)));
-        data.get_reflect_index::<usize>(2, &mut |result| assert_eq!(result, None));
+    let data = data.as_list_mut().unwrap();
+    data.get_reflect_index(0, &mut |result| assert_eq!(result, Some(&10usize)));
+    data.get_reflect_index::<usize>(2, &mut |result| assert_eq!(result, None));
 
-        data.reflect_push(Box::new(12usize)).unwrap();
-        data.get_reflect_index(2, &mut |result| assert_eq!(result, Some(&12usize)));
-    });
+    data.reflect_push(Box::new(12usize)).unwrap();
+    data.get_reflect_index(2, &mut |result| assert_eq!(result, Some(&12usize)));
 }
 
 #[test]
@@ -654,21 +652,20 @@ fn test_hash_map() {
         },
     );
 
-    hash_map.as_hash_map(&mut |result| {
-        let hash_map = result.unwrap();
+    {
+        let hash_map = hash_map.as_hash_map().unwrap();
         assert_eq!(hash_map.reflect_len(), 2);
-
         hash_map.reflect_get(&foo_key, &mut |result| {
             assert_eq!(result.unwrap().downcast_ref::<Struct>().unwrap().field, 123)
-        })
-    });
+        });
+    }
 
-    hash_map.as_hash_map_mut(&mut |result| {
-        let hash_map = result.unwrap();
+    {
+        let hash_map = hash_map.as_hash_map_mut().unwrap();
         hash_map.reflect_get_mut(&bar_key, &mut |result| {
             result.unwrap().downcast_mut::<Struct>().unwrap().field = 555
-        })
-    });
+        });
+    }
 
     // Check path resolution.
     #[derive(Reflect, Clone, Debug)]

--- a/fyrox-core/src/dyntype.rs
+++ b/fyrox-core/src/dyntype.rs
@@ -30,6 +30,7 @@ use parking_lot::{Mutex, MutexGuard};
 use std::{
     any::{type_name, Any, TypeId},
     fmt::{Debug, Display, Formatter},
+    ops::{Deref, DerefMut},
 };
 use uuid::Uuid;
 
@@ -145,91 +146,13 @@ impl dyn DynType {
 }
 
 /// A container for a boxed dyntype.
-#[derive(Debug, TypeUuidProvider)]
+#[derive(Debug, TypeUuidProvider, Reflect)]
 #[type_uuid(id = "87d9ef74-09a9-4228-a2d1-df270b50fddb")]
-pub struct DynTypeWrapper(pub Box<dyn DynType>);
+pub struct DynTypeWrapper(#[reflect(deref, display_name = "Data")] pub Box<dyn DynType>);
 
 impl Clone for DynTypeWrapper {
     fn clone(&self) -> Self {
         Self(self.0.clone_box())
-    }
-}
-
-static CONTENT_METADATA: FieldMetadata = FieldMetadata {
-    name: "Content",
-    display_name: "Content",
-    tag: "",
-    read_only: false,
-    immutable_collection: false,
-    min_value: None,
-    max_value: None,
-    step: None,
-    precision: None,
-    doc: "",
-};
-
-impl Reflect for DynTypeWrapper {
-    fn type_info() -> TypeInfo {
-        TypeInfo {
-            source_path: file!(),
-            type_name: type_name::<Self>(),
-            assembly_name: env!("CARGO_PKG_NAME"),
-            doc_comment: "",
-            derived_types: &[],
-        }
-    }
-
-    fn type_info_ref(&self) -> TypeInfo {
-        Self::type_info()
-    }
-
-    fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        func(&[{
-            FieldRef {
-                metadata: &CONTENT_METADATA,
-                value: &*self.0,
-            }
-        }])
-    }
-
-    fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        func(&mut [{
-            FieldMut {
-                metadata: &CONTENT_METADATA,
-                value: &mut *self.0,
-            }
-        }])
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-        let this = std::mem::replace(self, value.take()?);
-        Ok(Box::new(this))
-    }
-
-    fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-        Some(Box::new(self.clone()))
-    }
-
-    fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
-        if index == 0 {
-            Some(FieldRef {
-                metadata: &CONTENT_METADATA,
-                value: &*self.0,
-            })
-        } else {
-            None
-        }
-    }
-
-    fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
-        if index == 0 {
-            Some(FieldMut {
-                metadata: &CONTENT_METADATA,
-                value: &mut *self.0,
-            })
-        } else {
-            None
-        }
     }
 }
 

--- a/fyrox-core/src/dyntype.rs
+++ b/fyrox-core/src/dyntype.rs
@@ -101,7 +101,7 @@ impl std::error::Error for DynTypeError {}
 
 /// Dynamic type (dyntype for short) is a user-defined data structure that supports additional
 /// features which makes it available from the editor and serializable to the standard asset format.
-pub trait DynType: Reflect + Visit + Debug + FieldValue + Send {
+pub trait DynType: Reflect + Visit + Debug + Send {
     /// Returns the type uuid of the value.
     fn type_uuid(&self) -> Uuid;
     /// Creates a boxed copy of the value.
@@ -110,7 +110,7 @@ pub trait DynType: Reflect + Visit + Debug + FieldValue + Send {
 
 impl<T> DynType for T
 where
-    T: TypeUuidProvider + Clone + Visit + Reflect + FieldValue + Send,
+    T: TypeUuidProvider + Clone + Visit + Reflect + Send,
 {
     fn type_uuid(&self) -> Uuid {
         <T as TypeUuidProvider>::type_uuid()
@@ -201,18 +201,6 @@ impl Reflect for DynTypeWrapper {
         }])
     }
 
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-        func(self)
-    }
-
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-        func(self)
-    }
-
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
         let this = std::mem::replace(self, value.take()?);
         Ok(Box::new(this))
@@ -242,14 +230,6 @@ impl Reflect for DynTypeWrapper {
         } else {
             None
         }
-    }
-
-    fn inner_ref_direct(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-        self
     }
 }
 

--- a/fyrox-core/src/pool/handle.rs
+++ b/fyrox-core/src/pool/handle.rs
@@ -163,18 +163,6 @@ impl<T: Reflect> Reflect for Handle<T> {
         ])
     }
 
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-        func(self)
-    }
-
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-        func(self)
-    }
-
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
         let this = std::mem::replace(self, value.take()?);
         Ok(Box::new(this))
@@ -218,14 +206,6 @@ impl<T: Reflect> Reflect for Handle<T> {
         } else {
             None
         }
-    }
-
-    fn inner_ref_direct(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-        self
     }
 }
 

--- a/fyrox-core/src/pool/handle.rs
+++ b/fyrox-core/src/pool/handle.rs
@@ -168,12 +168,12 @@ impl<T: Reflect> Reflect for Handle<T> {
         Ok(Box::new(this))
     }
 
-    fn as_handle(&self, func: &mut dyn FnMut(Option<&dyn ReflectHandle>)) {
-        func(Some(self))
+    fn as_handle(&self) -> Option<&dyn ReflectHandle> {
+        Some(self)
     }
 
-    fn as_handle_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectHandle>)) {
-        func(Some(self))
+    fn as_handle_mut(&mut self) -> Option<&mut dyn ReflectHandle> {
+        Some(self)
     }
 
     fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {

--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -191,13 +191,13 @@ where
     }
 
     #[inline]
-    fn as_array(&self, func: &mut dyn FnMut(Option<&dyn ReflectArray>)) {
-        func(Some(self))
+    fn as_array(&self) -> Option<&dyn ReflectArray> {
+        Some(self)
     }
 
     #[inline]
-    fn as_array_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectArray>)) {
-        func(Some(self))
+    fn as_array_mut(&mut self) -> Option<&mut dyn ReflectArray> {
+        Some(self)
     }
 }
 

--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -177,29 +177,6 @@ where
     }
 
     #[inline]
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn inner_ref_direct(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    #[inline]
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-        func(self)
-    }
-
-    #[inline]
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-        func(self)
-    }
-
-    #[inline]
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
         let this = std::mem::replace(self, value.take()?);
         Ok(Box::new(this))

--- a/fyrox-core/src/reflect/array.rs
+++ b/fyrox-core/src/reflect/array.rs
@@ -67,12 +67,12 @@ impl<const N: usize, T: Reflect + Clone> ReflectArray for [T; N] {
 impl<const N: usize, T: Reflect + Clone> Reflect for [T; N] {
     blank_reflect!();
 
-    fn as_array(&self, func: &mut dyn FnMut(Option<&dyn ReflectArray>)) {
-        func(Some(self))
+    fn as_array(&self) -> Option<&dyn ReflectArray> {
+        Some(self)
     }
 
-    fn as_array_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectArray>)) {
-        func(Some(self))
+    fn as_array_mut(&mut self) -> Option<&mut dyn ReflectArray> {
+        Some(self)
     }
 }
 

--- a/fyrox-core/src/reflect/field.rs
+++ b/fyrox-core/src/reflect/field.rs
@@ -19,45 +19,9 @@
 // SOFTWARE.
 
 use crate::reflect::{CastError, Reflect};
-use std::any::{Any, TypeId};
+use std::any::TypeId;
 use std::fmt;
 use std::ops::Deref;
-
-/// A value of a field..
-pub trait FieldValue: Any + 'static {
-    /// Casts `self` to a `&dyn Any`
-    fn field_value_as_any_ref(&self) -> &dyn Any;
-
-    /// Casts `self` to a `&mut dyn Any`
-    fn field_value_as_any_mut(&mut self) -> &mut dyn Any;
-
-    fn field_value_as_reflect(&self) -> &dyn Reflect;
-    fn field_value_as_reflect_mut(&mut self) -> &mut dyn Reflect;
-
-    fn type_name(&self) -> &'static str;
-}
-
-impl<T: Reflect> FieldValue for T {
-    fn field_value_as_any_ref(&self) -> &dyn Any {
-        self
-    }
-
-    fn field_value_as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn field_value_as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn field_value_as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn type_name(&self) -> &'static str {
-        std::any::type_name::<T>()
-    }
-}
 
 #[derive(Debug)]
 pub struct FieldMetadata<'s> {
@@ -98,10 +62,8 @@ pub struct FieldRef<'a, 'b> {
     /// A reference to field's metadata.
     pub metadata: &'a FieldMetadata<'b>,
 
-    /// An reference to the actual value of the property. This is "non-mangled" reference, which
-    /// means that while `field/fields/field_mut/fields_mut` might return a reference to other value,
-    /// than the actual field, the `value` is guaranteed to be a reference to the real value.
-    pub value: &'a dyn FieldValue,
+    /// An reference to the actual value of the property.
+    pub value: &'a dyn Reflect,
 }
 
 impl<'b> Deref for FieldRef<'_, 'b> {
@@ -114,8 +76,8 @@ impl<'b> Deref for FieldRef<'_, 'b> {
 
 impl FieldRef<'_, '_> {
     /// Tries to cast a value to a given type.
-    pub fn cast_value<T: 'static>(&self) -> Result<&T, CastError> {
-        match self.value.field_value_as_any_ref().downcast_ref::<T>() {
+    pub fn cast_value<T: Reflect>(&self) -> Result<&T, CastError> {
+        match self.value.downcast_ref::<T>() {
             Some(value) => Ok(value),
             None => Err(CastError::TypeMismatch {
                 property_name: self.metadata.name.to_string(),
@@ -151,7 +113,7 @@ pub struct FieldMut<'a, 'b> {
     /// An reference to the actual value of the property. This is "non-mangled" reference, which
     /// means that while `field/fields/field_mut/fields_mut` might return a reference to other value,
     /// than the actual field, the `value` is guaranteed to be a reference to the real value.
-    pub value: &'a mut dyn FieldValue,
+    pub value: &'a mut dyn Reflect,
 }
 
 impl<'b> Deref for FieldMut<'_, 'b> {

--- a/fyrox-core/src/reflect/impls.rs
+++ b/fyrox-core/src/reflect/impls.rs
@@ -21,7 +21,6 @@
 //! `Reflect` implementations
 
 use crate::{
-    delegate_reflect,
     reflect::{blank_reflect, prelude::*},
     sstorage::ImmutableString,
     uuid::Uuid,
@@ -29,6 +28,7 @@ use crate::{
 };
 use fyrox_core_derive::impl_reflect;
 use nalgebra::*;
+use std::any::type_name;
 use std::{
     cell::{Cell, RefCell},
     fmt::Debug,
@@ -39,7 +39,7 @@ use std::{
 };
 
 impl_reflect! {
-    pub struct Matrix<T: Copy + 'static, R: Dim + 'static, C: Dim + 'static, S: Copy + Debug + FieldValue + 'static> {
+    pub struct Matrix<T: Copy + 'static, R: Dim + 'static, C: Dim + 'static, S: Copy + Debug + Reflect + 'static> {
         pub data: S,
         // _phantoms: PhantomData<(T, R, C)>,
     }
@@ -129,11 +129,85 @@ impl_reflect! {
 }
 
 impl<T: Reflect + Clone> Reflect for Box<T> {
-    delegate_reflect!();
+    fn type_info() -> TypeInfo {
+        TypeInfo {
+            source_path: file!(),
+            type_name: type_name::<Self>(),
+            assembly_name: env!("CARGO_PKG_NAME"),
+            doc_comment: "",
+            derived_types: &[],
+        }
+    }
+
+    fn type_info_ref(&self) -> TypeInfo {
+        Self::type_info()
+    }
+
+    fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
+        func(&[{
+            FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: self.deref(),
+            }
+        }])
+    }
+
+    fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
+        func(&mut [{
+            FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: self.deref_mut(),
+            }
+        }])
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
+        let this = std::mem::replace(self, value.take()?);
+        Ok(Box::new(this))
+    }
+
+    fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
+        Some(Box::new(self.clone()))
+    }
+
+    fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
+        if index == 0 {
+            Some(FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: self.deref(),
+            })
+        } else {
+            None
+        }
+    }
+
+    fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
+        if index == 0 {
+            Some(FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: self.deref_mut(),
+            })
+        } else {
+            None
+        }
+    }
 }
 
+static CONTENT_METADATA: FieldMetadata = FieldMetadata {
+    name: "Content",
+    display_name: "Content",
+    tag: "",
+    read_only: false,
+    immutable_collection: false,
+    min_value: None,
+    max_value: None,
+    step: None,
+    precision: None,
+    doc: "",
+};
+
 macro_rules! impl_reflect_inner_mutability {
-    ($self:ident, $acquire_lock_guard:block, $into_inner:block) => {
+    ($self:ident, $acquire_lock_guard:block, $clone:block) => {
         fn type_info() -> TypeInfo {
             TypeInfo {
                 source_path: file!(),
@@ -149,48 +223,32 @@ macro_rules! impl_reflect_inner_mutability {
         }
 
         fn try_clone_box(&$self) -> Option<Box<dyn Reflect>> {
-            let guard = $acquire_lock_guard;
-            Some(Box::new(guard.clone()))
+            Some(Box::new($clone))
         }
 
         fn fields_ref(&$self, func: &mut dyn FnMut(&[FieldRef])) {
             let guard = $acquire_lock_guard;
-            guard.fields_ref(func)
+            func(&[{
+                FieldRef {
+                    metadata: &CONTENT_METADATA,
+                    value: &*guard,
+                }
+            }])
         }
 
         fn fields_mut(&mut $self, func: &mut dyn FnMut(&mut [FieldMut])) {
             let mut guard = $acquire_lock_guard;
-            guard.fields_mut(func)
-        }
-
-        fn into_inner($self: Box<Self>) -> Box<dyn Reflect> {
-            let inner = $into_inner;
-            Box::new(inner)
-        }
-
-        fn inner_ref(&$self, func: &mut dyn FnMut(&dyn Reflect)) {
-            let guard = $acquire_lock_guard;
-            (*guard).inner_ref(func)
-        }
-
-        fn inner_mut(&mut $self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-            let mut guard = $acquire_lock_guard;
-            (*guard).inner_mut(func)
-        }
-
-        fn inner_ref_direct(&self) -> &dyn $crate::reflect::Reflect {
-            // xxx_direct methods cannot hold the lock, so return self here.
-            self
-        }
-
-        fn inner_mut_direct(&mut self) -> &mut dyn $crate::reflect::Reflect {
-            // xxx_direct methods cannot hold the lock, so return self here.
-            self
+            func(&mut [{
+                FieldMut {
+                    metadata: &CONTENT_METADATA,
+                    value: &mut *guard,
+                }
+            }])
         }
 
         fn set(&mut $self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-            let mut guard = $acquire_lock_guard;
-            guard.set(value)
+            let this = std::mem::replace($self, value.take()?);
+            Ok(Box::new(this))
         }
 
         fn field_direct_ref(&self, _index: usize) -> Option<FieldRef> {
@@ -200,142 +258,66 @@ macro_rules! impl_reflect_inner_mutability {
         fn field_direct_mut(&mut self, _index: usize) -> Option<FieldMut> {
             None
         }
-
-        fn set_field(
-            &mut $self,
-            field: &str,
-            value: Box<dyn Reflect>,
-            func: &mut dyn FnMut(Result<Box<dyn Reflect>, SetFieldError>),
-        ) {
-            let mut guard = $acquire_lock_guard;
-            guard.set_field(field, value, func)
-        }
-
-        fn find_field(&$self, name: &str, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
-            let guard = $acquire_lock_guard;
-            guard.find_field(name, func)
-        }
-
-        fn find_field_mut(&mut $self, name: &str, func: &mut dyn FnMut(Option<&mut dyn Reflect>)) {
-            let mut guard = $acquire_lock_guard;
-            guard.find_field_mut(name, func)
-        }
-
-        fn as_array(&$self, func: &mut dyn FnMut(Option<&dyn ReflectArray>)) {
-            let guard = $acquire_lock_guard;
-            guard.as_array(func)
-        }
-
-        fn as_array_mut(&mut $self, func: &mut dyn FnMut(Option<&mut dyn ReflectArray>)) {
-            let mut guard = $acquire_lock_guard;
-            guard.as_array_mut(func)
-        }
-
-        fn as_list(&$self, func: &mut dyn FnMut(Option<&dyn ReflectList>)) {
-            let guard = $acquire_lock_guard;
-            guard.as_list(func)
-        }
-
-        fn as_list_mut(&mut $self, func: &mut dyn FnMut(Option<&mut dyn ReflectList>)) {
-            let mut guard = $acquire_lock_guard;
-            guard.as_list_mut(func)
-        }
-
-        fn as_inheritable_variable(
-            &$self,
-            func: &mut dyn FnMut(Option<&dyn ReflectInheritableVariable>),
-        ) {
-            let guard = $acquire_lock_guard;
-            guard.as_inheritable_variable(func)
-        }
-
-        fn as_inheritable_variable_mut(
-            &mut $self,
-            func: &mut dyn FnMut(Option<&mut dyn ReflectInheritableVariable>),
-        ) {
-            let mut guard = $acquire_lock_guard;
-            guard.as_inheritable_variable_mut(func)
-        }
-
-        fn as_hash_map(&$self, func: &mut dyn FnMut(Option<&dyn ReflectHashMap>)) {
-            let guard = $acquire_lock_guard;
-            guard.as_hash_map(func)
-        }
-
-        fn as_hash_map_mut(&mut $self, func: &mut dyn FnMut(Option<&mut dyn ReflectHashMap>)) {
-            let mut guard = $acquire_lock_guard;
-            guard.as_hash_map_mut(func)
-        }
     };
 }
 
 impl<T: Reflect + Clone> Reflect for parking_lot::Mutex<T> {
     impl_reflect_inner_mutability!(self, { self.safe_lock() }, {
-        parking_lot::Mutex::into_inner(*self)
+        parking_lot::Mutex::new(self.safe_lock().clone())
     });
 }
 
 impl<T: Reflect + Clone> Reflect for parking_lot::RwLock<T> {
     impl_reflect_inner_mutability!(self, { self.write() }, {
-        parking_lot::RwLock::into_inner(*self)
+        parking_lot::RwLock::new(self.read().clone())
     });
 }
 
 #[allow(clippy::mut_mutex_lock)]
 impl<T: Reflect + Clone> Reflect for std::sync::Mutex<T> {
     impl_reflect_inner_mutability!(self, { self.safe_lock().unwrap() }, {
-        std::sync::Mutex::into_inner(*self).unwrap()
+        std::sync::Mutex::new(self.safe_lock().unwrap().clone())
     });
 }
 
 impl<T: Reflect + Clone> Reflect for std::sync::RwLock<T> {
     impl_reflect_inner_mutability!(self, { self.write().unwrap() }, {
-        std::sync::RwLock::into_inner(*self).unwrap()
+        std::sync::RwLock::new(self.read().unwrap().clone())
     });
 }
 
 impl<T: Reflect + Clone> Reflect for Arc<parking_lot::Mutex<T>> {
     impl_reflect_inner_mutability!(self, { self.safe_lock() }, {
-        Arc::into_inner(*self)
-            .expect("Value cannot be shared!")
-            .into_inner()
+        Arc::new(parking_lot::Mutex::new(self.safe_lock().clone()))
     });
 }
 
 impl<T: Reflect + Clone> Reflect for Arc<std::sync::Mutex<T>> {
     impl_reflect_inner_mutability!(self, { self.lock().unwrap() }, {
-        Arc::into_inner(*self)
-            .expect("Value cannot be shared!")
-            .into_inner()
-            .unwrap()
+        Arc::new(std::sync::Mutex::new(self.safe_lock().unwrap().clone()))
     });
 }
 
 impl<T: Reflect + Clone> Reflect for Arc<std::sync::RwLock<T>> {
     impl_reflect_inner_mutability!(self, { self.write().unwrap() }, {
-        Arc::into_inner(*self)
-            .expect("Value cannot be shared!")
-            .into_inner()
-            .unwrap()
+        Arc::new(std::sync::RwLock::new(self.read().unwrap().clone()))
     });
 }
 
 impl<T: Reflect + Clone> Reflect for Arc<parking_lot::RwLock<T>> {
     impl_reflect_inner_mutability!(self, { self.write() }, {
-        Arc::into_inner(*self)
-            .expect("Value cannot be shared!")
-            .into_inner()
+        Arc::new(parking_lot::RwLock::new(self.read().clone()))
     });
 }
 
 impl<T: Reflect + Clone> Reflect for RefCell<T> {
-    impl_reflect_inner_mutability!(self, { self.borrow_mut() }, { RefCell::into_inner(*self) });
+    impl_reflect_inner_mutability!(self, { self.borrow_mut() }, {
+        RefCell::new(self.borrow().clone())
+    });
 }
 
 impl<T: Reflect + Clone> Reflect for Rc<RefCell<T>> {
     impl_reflect_inner_mutability!(self, { self.borrow_mut() }, {
-        Rc::into_inner(*self)
-            .expect("Value cannot be shared!")
-            .into_inner()
+        Rc::new(RefCell::new(self.borrow().clone()))
     });
 }

--- a/fyrox-core/src/reflect/macros.rs
+++ b/fyrox-core/src/reflect/macros.rs
@@ -166,22 +166,6 @@ macro_rules! blank_reflect {
             func(&mut [])
         }
 
-        fn find_field(
-            &self,
-            name: &str,
-            func: &mut dyn FnMut(Option<&dyn $crate::reflect::Reflect>),
-        ) {
-            func(if name == "self" { Some(self) } else { None })
-        }
-
-        fn find_field_mut(
-            &mut self,
-            name: &str,
-            func: &mut dyn FnMut(Option<&mut dyn $crate::reflect::Reflect>),
-        ) {
-            func(if name == "self" { Some(self) } else { None })
-        }
-
         fn field_direct_ref(&self, _index: usize) -> Option<$crate::reflect::FieldRef> {
             None
         }

--- a/fyrox-core/src/reflect/macros.rs
+++ b/fyrox-core/src/reflect/macros.rs
@@ -137,158 +137,6 @@ macro_rules! newtype_reflect {
 }
 
 #[macro_export]
-macro_rules! delegate_reflect {
-    () => {
-        fn type_info() -> $crate::reflect::TypeInfo {
-            $crate::reflect::TypeInfo {
-                source_path: file!(),
-                type_name: std::any::type_name::<Self>(),
-                assembly_name: env!("CARGO_PKG_NAME"),
-                doc_comment: "",
-                derived_types: &[],
-            }
-        }
-
-        fn type_info_ref(&self) -> TypeInfo {
-            let inner_type_info = self.deref().type_info_ref();
-
-            $crate::reflect::TypeInfo {
-                source_path: inner_type_info.source_path,
-                type_name: inner_type_info.type_name,
-                assembly_name: inner_type_info.assembly_name,
-                doc_comment: inner_type_info.doc_comment,
-                derived_types: inner_type_info.derived_types,
-            }
-        }
-
-        fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-            Some(Box::new(self.clone()))
-        }
-
-        fn fields_ref(&self, func: &mut dyn FnMut(&[$crate::reflect::FieldRef])) {
-            self.deref().fields_ref(func)
-        }
-
-        fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [$crate::reflect::FieldMut])) {
-            self.deref_mut().fields_mut(func)
-        }
-
-        fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-            (*self).into_inner()
-        }
-
-        fn inner_ref(&self, func: &mut dyn FnMut(&dyn $crate::reflect::Reflect)) {
-            self.deref().inner_ref(func)
-        }
-
-        fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn $crate::reflect::Reflect)) {
-            self.deref_mut().inner_mut(func)
-        }
-
-        fn inner_ref_direct(&self) -> &dyn $crate::reflect::Reflect {
-            self.deref().inner_ref_direct()
-        }
-
-        fn inner_mut_direct(&mut self) -> &mut dyn $crate::reflect::Reflect {
-            self.deref_mut().inner_mut_direct()
-        }
-
-        fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
-            self.deref().field_direct_ref(index)
-        }
-
-        fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
-            self.deref_mut().field_direct_mut(index)
-        }
-
-        fn set(
-            &mut self,
-            value: Box<dyn Reflect>,
-        ) -> Result<Box<dyn $crate::reflect::Reflect>, Box<dyn $crate::reflect::Reflect>> {
-            self.deref_mut().set(value)
-        }
-
-        fn find_field(
-            &self,
-            name: &str,
-            func: &mut dyn FnMut(Option<&dyn $crate::reflect::Reflect>),
-        ) {
-            self.deref().find_field(name, func)
-        }
-
-        fn find_field_mut(
-            &mut self,
-            name: &str,
-            func: &mut dyn FnMut(Option<&mut dyn $crate::reflect::Reflect>),
-        ) {
-            self.deref_mut().find_field_mut(name, func)
-        }
-
-        fn as_array(&self, func: &mut dyn FnMut(Option<&dyn $crate::reflect::ReflectArray>)) {
-            self.deref().as_array(func)
-        }
-
-        fn as_array_mut(
-            &mut self,
-            func: &mut dyn FnMut(Option<&mut dyn $crate::reflect::ReflectArray>),
-        ) {
-            self.deref_mut().as_array_mut(func)
-        }
-
-        fn as_list(&self, func: &mut dyn FnMut(Option<&dyn $crate::reflect::ReflectList>)) {
-            self.deref().as_list(func)
-        }
-
-        fn as_list_mut(
-            &mut self,
-            func: &mut dyn FnMut(Option<&mut dyn $crate::reflect::ReflectList>),
-        ) {
-            self.deref_mut().as_list_mut(func)
-        }
-
-        fn as_inheritable_variable(
-            &self,
-            func: &mut dyn FnMut(Option<&dyn $crate::reflect::ReflectInheritableVariable>),
-        ) {
-            self.deref().as_inheritable_variable(func)
-        }
-
-        fn as_inheritable_variable_mut(
-            &mut self,
-            func: &mut dyn FnMut(Option<&mut dyn $crate::reflect::ReflectInheritableVariable>),
-        ) {
-            self.deref_mut().as_inheritable_variable_mut(func)
-        }
-
-        fn as_handle(&self, func: &mut dyn FnMut(Option<&dyn $crate::reflect::ReflectHandle>)) {
-            self.deref().as_handle(func)
-        }
-
-        fn as_handle_mut(
-            &mut self,
-            func: &mut dyn FnMut(Option<&mut dyn $crate::reflect::ReflectHandle>),
-        ) {
-            self.deref_mut().as_handle_mut(func)
-        }
-
-        fn as_hash_map(&self, func: &mut dyn FnMut(Option<&dyn $crate::reflect::ReflectHashMap>)) {
-            self.deref().as_hash_map(func)
-        }
-
-        fn as_hash_map_mut(
-            &mut self,
-            func: &mut dyn FnMut(Option<&mut dyn $crate::reflect::ReflectHashMap>),
-        ) {
-            self.deref_mut().as_hash_map_mut(func)
-        }
-
-        fn fields_count(&self) -> usize {
-            self.deref().fields_count()
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! blank_reflect {
     () => {
         fn type_info() -> $crate::reflect::TypeInfo {
@@ -316,26 +164,6 @@ macro_rules! blank_reflect {
         #[inline]
         fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [$crate::reflect::FieldMut])) {
             func(&mut [])
-        }
-
-        fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-            self
-        }
-
-        fn inner_ref(&self, func: &mut dyn FnMut(&dyn $crate::reflect::Reflect)) {
-            func(self)
-        }
-
-        fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn $crate::reflect::Reflect)) {
-            func(self)
-        }
-
-        fn inner_ref_direct(&self) -> &dyn $crate::reflect::Reflect {
-            self
-        }
-
-        fn inner_mut_direct(&mut self) -> &mut dyn $crate::reflect::Reflect {
-            self
         }
 
         fn find_field(
@@ -402,18 +230,6 @@ macro_rules! blank_reflect_ref {
             func(&mut [])
         }
 
-        fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-            self
-        }
-
-        fn inner_ref(&self, func: &mut dyn FnMut(&dyn $crate::reflect::Reflect)) {
-            func(self)
-        }
-
-        fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn $crate::reflect::Reflect)) {
-            func(self)
-        }
-
         fn find_field(
             &self,
             name: &str,
@@ -445,17 +261,8 @@ macro_rules! blank_reflect_ref {
             let this = std::mem::replace(self, value.take()?);
             Ok(Box::new(this))
         }
-
-        fn inner_ref_direct(&self) -> &dyn $crate::reflect::Reflect {
-            self
-        }
-
-        fn inner_mut_direct(&mut self) -> &mut dyn $crate::reflect::Reflect {
-            self
-        }
     };
 }
 
 pub use blank_reflect;
-pub use delegate_reflect;
 pub use newtype_reflect;

--- a/fyrox-core/src/reflect/map.rs
+++ b/fyrox-core/src/reflect/map.rs
@@ -51,12 +51,12 @@ where
 {
     blank_reflect!();
 
-    fn as_hash_map(&self, func: &mut dyn FnMut(Option<&dyn ReflectHashMap>)) {
-        func(Some(self))
+    fn as_hash_map(&self) -> Option<&dyn ReflectHashMap> {
+        Some(self)
     }
 
-    fn as_hash_map_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectHashMap>)) {
-        func(Some(self))
+    fn as_hash_map_mut(&mut self) -> Option<&mut dyn ReflectHashMap> {
+        Some(self)
     }
 }
 

--- a/fyrox-core/src/reflect/map.rs
+++ b/fyrox-core/src/reflect/map.rs
@@ -89,7 +89,7 @@ where
     fn reflect_get(&self, key: &dyn Reflect, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
         match key.downcast_ref::<K>() {
             Some(key) => match self.get(key) {
-                Some(value) => func(Some(value as &dyn Reflect)),
+                Some(value) => func(Some(value)),
                 None => func(None),
             },
             None => func(None),
@@ -103,7 +103,7 @@ where
     ) {
         match key.downcast_ref::<K>() {
             Some(key) => match self.get_mut(key) {
-                Some(value) => func(Some(value as &mut dyn Reflect)),
+                Some(value) => func(Some(value)),
                 None => func(None),
             },
             None => func(None),

--- a/fyrox-core/src/reflect/map.rs
+++ b/fyrox-core/src/reflect/map.rs
@@ -87,13 +87,13 @@ where
     }
 
     fn reflect_get(&self, key: &dyn Reflect, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
-        key.downcast_ref::<K>(&mut |result| match result {
+        match key.downcast_ref::<K>() {
             Some(key) => match self.get(key) {
                 Some(value) => func(Some(value as &dyn Reflect)),
                 None => func(None),
             },
             None => func(None),
-        })
+        }
     }
 
     fn reflect_get_mut(
@@ -101,13 +101,13 @@ where
         key: &dyn Reflect,
         func: &mut dyn FnMut(Option<&mut dyn Reflect>),
     ) {
-        key.downcast_ref::<K>(&mut |result| match result {
+        match key.downcast_ref::<K>() {
             Some(key) => match self.get_mut(key) {
                 Some(value) => func(Some(value as &mut dyn Reflect)),
                 None => func(None),
             },
             None => func(None),
-        })
+        }
     }
 
     fn reflect_get_nth_value_ref(&self, index: usize) -> Option<&dyn Reflect> {
@@ -135,12 +135,12 @@ where
         key: &dyn Reflect,
         func: &mut dyn FnMut(Option<Box<dyn Reflect>>),
     ) {
-        key.downcast_ref::<K>(&mut |result| match result {
+        match key.downcast_ref::<K>() {
             Some(key) => func(
                 self.remove(key)
                     .map(|value| Box::new(value) as Box<dyn Reflect>),
             ),
             None => func(None),
-        })
+        }
     }
 }

--- a/fyrox-core/src/reflect/mod.rs
+++ b/fyrox-core/src/reflect/mod.rs
@@ -247,50 +247,44 @@ pub trait Reflect: Any + Debug {
         });
     }
 
-    fn as_array(&self, func: &mut dyn FnMut(Option<&dyn ReflectArray>)) {
-        func(None)
+    fn as_array(&self) -> Option<&dyn ReflectArray> {
+        None
     }
 
-    fn as_array_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectArray>)) {
-        func(None)
+    fn as_array_mut(&mut self) -> Option<&mut dyn ReflectArray> {
+        None
     }
 
-    fn as_list(&self, func: &mut dyn FnMut(Option<&dyn ReflectList>)) {
-        func(None)
+    fn as_list(&self) -> Option<&dyn ReflectList> {
+        None
     }
 
-    fn as_list_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectList>)) {
-        func(None)
+    fn as_list_mut(&mut self) -> Option<&mut dyn ReflectList> {
+        None
     }
 
-    fn as_inheritable_variable(
-        &self,
-        func: &mut dyn FnMut(Option<&dyn ReflectInheritableVariable>),
-    ) {
-        func(None)
+    fn as_inheritable_variable(&self) -> Option<&dyn ReflectInheritableVariable> {
+        None
     }
 
-    fn as_inheritable_variable_mut(
-        &mut self,
-        func: &mut dyn FnMut(Option<&mut dyn ReflectInheritableVariable>),
-    ) {
-        func(None)
+    fn as_inheritable_variable_mut(&mut self) -> Option<&mut dyn ReflectInheritableVariable> {
+        None
     }
 
-    fn as_hash_map(&self, func: &mut dyn FnMut(Option<&dyn ReflectHashMap>)) {
-        func(None)
+    fn as_hash_map(&self) -> Option<&dyn ReflectHashMap> {
+        None
     }
 
-    fn as_hash_map_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectHashMap>)) {
-        func(None)
+    fn as_hash_map_mut(&mut self) -> Option<&mut dyn ReflectHashMap> {
+        None
     }
 
-    fn as_handle(&self, func: &mut dyn FnMut(Option<&dyn ReflectHandle>)) {
-        func(None)
+    fn as_handle(&self) -> Option<&dyn ReflectHandle> {
+        None
     }
 
-    fn as_handle_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectHandle>)) {
-        func(None)
+    fn as_handle_mut(&mut self) -> Option<&mut dyn ReflectHandle> {
+        None
     }
 }
 
@@ -443,16 +437,14 @@ impl dyn Reflect {
 
         let mut done = false;
 
-        self.as_inheritable_variable(&mut |variable| {
-            if let Some(variable) = variable {
-                // Inner variable might also contain inheritable variables, so continue iterating.
-                variable
-                    .inner_value_ref()
-                    .enumerate_fields_recursively_internal(path, field_info, func, ignored_types);
+        if let Some(variable) = self.as_inheritable_variable() {
+            // Inner variable might also contain inheritable variables, so continue iterating.
+            variable
+                .inner_value_ref()
+                .enumerate_fields_recursively_internal(path, field_info, func, ignored_types);
 
-                done = true;
-            }
-        });
+            done = true;
+        }
 
         if done {
             return;
@@ -460,62 +452,58 @@ impl dyn Reflect {
 
         func(path, field_info, self);
 
-        self.as_array(&mut |array| {
-            if let Some(array) = array {
-                for i in 0..array.reflect_len() {
-                    if let Some(item) = array.reflect_index(i) {
-                        let item_path = format!("{path}[{i}]");
+        if let Some(array) = self.as_array() {
+            for i in 0..array.reflect_len() {
+                if let Some(item) = array.reflect_index(i) {
+                    let item_path = format!("{path}[{i}]");
 
-                        item.enumerate_fields_recursively_internal(
-                            &item_path,
-                            field_info,
-                            func,
-                            ignored_types,
-                        );
-                    }
+                    item.enumerate_fields_recursively_internal(
+                        &item_path,
+                        field_info,
+                        func,
+                        ignored_types,
+                    );
                 }
-
-                done = true;
             }
-        });
+
+            done = true;
+        }
 
         if done {
             return;
         }
 
-        self.as_hash_map(&mut |hash_map| {
-            if let Some(hash_map) = hash_map {
-                for i in 0..hash_map.reflect_len() {
-                    if let Some((key, value)) = hash_map.reflect_get_at(i) {
-                        // TODO: Here we just using `Debug` impl to obtain string representation for keys. This is
-                        // fine for most cases in the engine.
-                        let mut key_str = format!("{key:?}");
+        if let Some(hash_map) = self.as_hash_map() {
+            for i in 0..hash_map.reflect_len() {
+                if let Some((key, value)) = hash_map.reflect_get_at(i) {
+                    // TODO: Here we just using `Debug` impl to obtain string representation for keys. This is
+                    // fine for most cases in the engine.
+                    let mut key_str = format!("{key:?}");
 
-                        let is_key_string = key.downcast_ref::<String>().is_some()
-                            || key.downcast_ref::<ImmutableString>().is_some();
+                    let is_key_string = key.downcast_ref::<String>().is_some()
+                        || key.downcast_ref::<ImmutableString>().is_some();
 
-                        if is_key_string {
-                            // Strip quotes at the beginning and the end, because Debug impl for String adds
-                            // quotes at the beginning and the end, but we want raw value.
-                            // TODO: This is unreliable mechanism.
-                            key_str.remove(0);
-                            key_str.pop();
-                        }
-
-                        let item_path = format!("{path}[{key_str}]");
-
-                        value.enumerate_fields_recursively_internal(
-                            &item_path,
-                            field_info,
-                            func,
-                            ignored_types,
-                        );
+                    if is_key_string {
+                        // Strip quotes at the beginning and the end, because Debug impl for String adds
+                        // quotes at the beginning and the end, but we want raw value.
+                        // TODO: This is unreliable mechanism.
+                        key_str.remove(0);
+                        key_str.pop();
                     }
-                }
 
-                done = true;
+                    let item_path = format!("{path}[{key_str}]");
+
+                    value.enumerate_fields_recursively_internal(
+                        &item_path,
+                        field_info,
+                        func,
+                        ignored_types,
+                    );
+                }
             }
-        });
+
+            done = true;
+        }
 
         if done {
             return;
@@ -553,48 +541,42 @@ impl dyn Reflect {
 
         let mut done = false;
 
-        self.as_inheritable_variable(&mut |variable| {
-            if let Some(variable) = variable {
-                // Inner variable might also contain inheritable variables, so continue iterating.
-                variable
-                    .inner_value_ref()
-                    .apply_recursively(func, ignored_types);
+        if let Some(variable) = self.as_inheritable_variable() {
+            // Inner variable might also contain inheritable variables, so continue iterating.
+            variable
+                .inner_value_ref()
+                .apply_recursively(func, ignored_types);
 
-                done = true;
-            }
-        });
+            done = true;
+        }
 
         if done {
             return;
         }
 
-        self.as_array(&mut |array| {
-            if let Some(array) = array {
-                for i in 0..array.reflect_len() {
-                    if let Some(item) = array.reflect_index(i) {
-                        item.apply_recursively(func, ignored_types);
-                    }
+        if let Some(array) = self.as_array() {
+            for i in 0..array.reflect_len() {
+                if let Some(item) = array.reflect_index(i) {
+                    item.apply_recursively(func, ignored_types);
                 }
-
-                done = true;
             }
-        });
+
+            done = true;
+        }
 
         if done {
             return;
         }
 
-        self.as_hash_map(&mut |hash_map| {
-            if let Some(hash_map) = hash_map {
-                for i in 0..hash_map.reflect_len() {
-                    if let Some(item) = hash_map.reflect_get_nth_value_ref(i) {
-                        item.apply_recursively(func, ignored_types);
-                    }
+        if let Some(hash_map) = self.as_hash_map() {
+            for i in 0..hash_map.reflect_len() {
+                if let Some(item) = hash_map.reflect_get_nth_value_ref(i) {
+                    item.apply_recursively(func, ignored_types);
                 }
-
-                done = true;
             }
-        });
+
+            done = true;
+        }
 
         if done {
             return;
@@ -619,48 +601,42 @@ impl dyn Reflect {
 
         let mut done = false;
 
-        self.as_inheritable_variable_mut(&mut |variable| {
-            if let Some(variable) = variable {
-                // Inner variable might also contain inheritable variables, so continue iterating.
-                variable
-                    .inner_value_mut()
-                    .apply_recursively_mut(func, ignored_types);
+        if let Some(variable) = self.as_inheritable_variable_mut() {
+            // Inner variable might also contain inheritable variables, so continue iterating.
+            variable
+                .inner_value_mut()
+                .apply_recursively_mut(func, ignored_types);
 
-                done = true;
-            }
-        });
+            done = true;
+        }
 
         if done {
             return;
         }
 
-        self.as_array_mut(&mut |array| {
-            if let Some(array) = array {
-                for i in 0..array.reflect_len() {
-                    if let Some(item) = array.reflect_index_mut(i) {
-                        item.apply_recursively_mut(func, ignored_types);
-                    }
+        if let Some(array) = self.as_array_mut() {
+            for i in 0..array.reflect_len() {
+                if let Some(item) = array.reflect_index_mut(i) {
+                    item.apply_recursively_mut(func, ignored_types);
                 }
-
-                done = true;
             }
-        });
+
+            done = true;
+        }
 
         if done {
             return;
         }
 
-        self.as_hash_map_mut(&mut |hash_map| {
-            if let Some(hash_map) = hash_map {
-                for i in 0..hash_map.reflect_len() {
-                    if let Some(item) = hash_map.reflect_get_nth_value_mut(i) {
-                        item.apply_recursively_mut(func, ignored_types);
-                    }
+        if let Some(hash_map) = self.as_hash_map_mut() {
+            for i in 0..hash_map.reflect_len() {
+                if let Some(item) = hash_map.reflect_get_nth_value_mut(i) {
+                    item.apply_recursively_mut(func, ignored_types);
                 }
-
-                done = true;
             }
-        });
+
+            done = true;
+        }
 
         if done {
             return;
@@ -884,25 +860,21 @@ impl<'p> Component<'p> {
             Self::Field(path) => reflect.find_field(path, &mut |field| {
                 func(field.ok_or(ReflectPathError::UnknownField { s: path }))
             }),
-            Self::Index(path) => {
-                reflect.as_array(&mut |result| match result {
-                    Some(array) => match path.parse::<usize>() {
-                        Ok(index) => match array.reflect_index(index) {
-                            None => func(Err(ReflectPathError::NoItemForIndex { s: path })),
-                            Some(value) => func(Ok(value)),
-                        },
-                        Err(_) => func(Err(ReflectPathError::InvalidIndexSyntax { s: path })),
+            Self::Index(path) => match reflect.as_array() {
+                Some(array) => match path.parse::<usize>() {
+                    Ok(index) => match array.reflect_index(index) {
+                        None => func(Err(ReflectPathError::NoItemForIndex { s: path })),
+                        Some(value) => func(Ok(value)),
                     },
-                    None => reflect.as_hash_map(&mut |result| match result {
-                        Some(hash_map) => {
-                            try_fetch_by_str_path_ref(hash_map, path, &mut |result| {
-                                func(result.ok_or(ReflectPathError::NoItemForIndex { s: path }))
-                            })
-                        }
-                        None => func(Err(ReflectPathError::NotAnArray)),
+                    Err(_) => func(Err(ReflectPathError::InvalidIndexSyntax { s: path })),
+                },
+                None => match reflect.as_hash_map() {
+                    Some(hash_map) => try_fetch_by_str_path_ref(hash_map, path, &mut |result| {
+                        func(result.ok_or(ReflectPathError::NoItemForIndex { s: path }))
                     }),
-                });
-            }
+                    None => func(Err(ReflectPathError::NotAnArray)),
+                },
+            },
         }
     }
 
@@ -917,7 +889,7 @@ impl<'p> Component<'p> {
             }),
             Self::Index(path) => {
                 let mut succeeded = true;
-                reflect.as_array_mut(&mut |array| match array {
+                match reflect.as_array_mut() {
                     Some(list) => match path.parse::<usize>() {
                         Ok(index) => match list.reflect_index_mut(index) {
                             None => func(Err(ReflectPathError::NoItemForIndex { s: path })),
@@ -926,17 +898,17 @@ impl<'p> Component<'p> {
                         Err(_) => func(Err(ReflectPathError::InvalidIndexSyntax { s: path })),
                     },
                     None => succeeded = false,
-                });
+                }
 
                 if !succeeded {
-                    reflect.as_hash_map_mut(&mut |result| match result {
+                    match reflect.as_hash_map_mut() {
                         Some(hash_map) => {
                             try_fetch_by_str_path_mut(hash_map, path, &mut |result| {
                                 func(result.ok_or(ReflectPathError::NoItemForIndex { s: path }))
                             })
                         }
                         None => func(Err(ReflectPathError::NotAnArray)),
-                    })
+                    }
                 }
             }
         }

--- a/fyrox-core/src/reflect/mod.rs
+++ b/fyrox-core/src/reflect/mod.rs
@@ -48,7 +48,7 @@ pub use map::*;
 
 pub mod prelude {
     pub use super::{
-        FieldMetadata, FieldMut, FieldRef, FieldValue, Reflect, ReflectArray, ReflectHashMap,
+        FieldMetadata, FieldMut, FieldRef, Reflect, ReflectArray, ReflectHashMap,
         ReflectInheritableVariable, ReflectList, ResolvePath, SetFieldByPathError, SetFieldError,
         TypeInfo,
     };
@@ -171,19 +171,6 @@ pub trait Reflect: Any + Debug {
     /// fields in the object.
     fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut]));
 
-    /// Extracts the wrapped value as `Box<dyn Reflect>` and returns it to the caller. This method
-    /// is intended to be used for wrapper structures only. Any other type should return `self` as
-    /// usual.
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect>;
-
-    fn inner_ref_direct(&self) -> &dyn Reflect;
-
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect;
-
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect));
-
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect));
-
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>>;
 
     /// Tries to get a shared reference to a field at the specified index. Returns [`None`] in two cases:
@@ -244,7 +231,7 @@ pub trait Reflect: Any + Debug {
                 fields
                     .iter()
                     .find(|field| field.name == name)
-                    .map(|field| field.value.field_value_as_reflect()),
+                    .map(|field| field.value),
             )
         });
     }
@@ -255,7 +242,7 @@ pub trait Reflect: Any + Debug {
                 fields
                     .iter_mut()
                     .find(|field| field.name == name)
-                    .map(|field| field.value.field_value_as_reflect_mut()),
+                    .map(|field| &mut *field.value),
             )
         });
     }
@@ -311,7 +298,7 @@ pub trait Reflect: Any + Debug {
 impl dyn Reflect {
     pub fn downcast<T: Reflect>(self: Box<dyn Reflect>) -> Result<Box<T>, Box<dyn Reflect>> {
         if self.is::<T>() {
-            Ok((self.into_inner() as Box<dyn Any>).downcast().unwrap())
+            Ok((self as Box<dyn Any>).downcast().unwrap())
         } else {
             Err(self)
         }
@@ -327,23 +314,23 @@ impl dyn Reflect {
     }
 
     #[inline]
-    pub fn downcast_ref<T: Reflect>(&self, func: &mut dyn FnMut(Option<&T>)) {
-        self.inner_ref(&mut |reflect| func((reflect as &dyn Any).downcast_ref::<T>()))
+    pub fn downcast_ref<T: Reflect>(&self) -> Option<&T> {
+        (self as &dyn Any).downcast_ref::<T>()
     }
 
     #[inline]
-    pub fn downcast_mut<T: Reflect>(&mut self, func: &mut dyn FnMut(Option<&mut T>)) {
-        self.inner_mut(&mut |reflect| func((reflect as &mut dyn Any).downcast_mut::<T>()))
+    pub fn downcast_mut<T: Reflect>(&mut self) -> Option<&mut T> {
+        (self as &mut dyn Any).downcast_mut::<T>()
     }
 
     /// Tries to find the first field of the given type. This method internally uses
     /// [`Reflect::field_direct_ref`] with all of its limitations.
     #[inline]
     pub fn first_field_ref<T: Reflect>(&self) -> Option<&T> {
-        let count = self.inner_ref_direct().fields_count();
+        let count = self.fields_count();
 
         for i in 0..count {
-            if let Some(field) = self.inner_ref_direct().field_direct_ref(i) {
+            if let Some(field) = self.field_direct_ref(i) {
                 if let Some(typed_field) = (field.value as &dyn Any).downcast_ref::<T>() {
                     return Some(typed_field);
                 }
@@ -357,7 +344,7 @@ impl dyn Reflect {
     /// [`Reflect::field_direct_ref`] with all of its limitations.
     #[inline]
     pub fn first_field_mut<T: Reflect>(&mut self) -> Option<&mut T> {
-        let count = self.inner_ref_direct().fields_count();
+        let count = self.fields_count();
 
         for i in 0..count {
             // SAFETY: Current implementation of borrow checker is just dumb. When a reborrow of self
@@ -365,7 +352,7 @@ impl dyn Reflect {
             // This way the returned reference has a different lifetime than in the method definition.
             // The following unsafe block reborrows self with the correct lifetime, while the initial
             // reference is not used so this is absolutely safe.
-            let this = unsafe { &mut *(self as *mut Self) }.inner_mut_direct();
+            let this = unsafe { &mut *(self as *mut Self) };
             if let Some(field) = this.field_direct_mut(i) {
                 if let Some(typed_field) = (field.value as &mut dyn Any).downcast_mut::<T>() {
                     return Some(typed_field);
@@ -379,7 +366,7 @@ impl dyn Reflect {
     /// Tries to downcast self to the specified type, or if it is not possible, tries to find a
     /// field of the specified type.
     pub fn self_or_field_ref<T: Reflect>(&self) -> Option<&T> {
-        if let Some(value) = (self.inner_ref_direct() as &dyn Any).downcast_ref::<T>() {
+        if let Some(value) = (self as &dyn Any).downcast_ref::<T>() {
             Some(value)
         } else {
             self.first_field_ref()
@@ -391,7 +378,7 @@ impl dyn Reflect {
     pub fn self_or_field_mut<T: Reflect>(&mut self) -> Option<&mut T> {
         // SAFETY: See the comment in `first_field_mut_of_type` method.
         let this = unsafe { &mut *(self as *mut Self) };
-        if let Some(value) = (self.inner_mut_direct() as &mut dyn Any).downcast_mut::<T>() {
+        if let Some(value) = (self as &mut dyn Any).downcast_mut::<T>() {
             Some(value)
         } else {
             this.first_field_mut()
@@ -504,11 +491,8 @@ impl dyn Reflect {
                         // fine for most cases in the engine.
                         let mut key_str = format!("{key:?}");
 
-                        let mut is_key_string = false;
-                        key.downcast_ref::<String>(&mut |string| is_key_string |= string.is_some());
-                        key.downcast_ref::<ImmutableString>(&mut |string| {
-                            is_key_string |= string.is_some()
-                        });
+                        let is_key_string = key.downcast_ref::<String>().is_some()
+                            || key.downcast_ref::<ImmutableString>().is_some();
 
                         if is_key_string {
                             // Strip quotes at the beginning and the end, because Debug impl for String adds
@@ -547,15 +531,12 @@ impl dyn Reflect {
                     &compound_path
                 };
 
-                field
-                    .value
-                    .field_value_as_reflect()
-                    .enumerate_fields_recursively_internal(
-                        field_path,
-                        Some(field),
-                        func,
-                        ignored_types,
-                    );
+                field.value.enumerate_fields_recursively_internal(
+                    field_path,
+                    Some(field),
+                    func,
+                    ignored_types,
+                );
             }
         })
     }
@@ -621,10 +602,7 @@ impl dyn Reflect {
 
         self.fields_ref(&mut |fields| {
             for field_info_ref in fields {
-                field_info_ref
-                    .value
-                    .field_value_as_reflect()
-                    .apply_recursively(func, ignored_types);
+                field_info_ref.value.apply_recursively(func, ignored_types);
             }
         })
     }
@@ -690,8 +668,7 @@ impl dyn Reflect {
 
         self.fields_mut(&mut |fields| {
             for field_info_mut in fields {
-                (*field_info_mut.value.field_value_as_reflect_mut())
-                    .apply_recursively_mut(func, ignored_types);
+                (*field_info_mut.value).apply_recursively_mut(func, ignored_types);
             }
         })
     }
@@ -718,16 +695,14 @@ pub trait ResolvePath {
         self.resolve_path(path, &mut |resolve_result| {
             match resolve_result {
                 Ok(value) => {
-                    value.downcast_ref(&mut |result| {
-                        match result {
-                            Some(value) => {
-                                func(Ok(value));
-                            }
-                            None => {
-                                func(Err(ReflectPathError::InvalidDowncast));
-                            }
-                        };
-                    });
+                    match value.downcast_ref::<T>() {
+                        Some(value) => {
+                            func(Ok(value));
+                        }
+                        None => {
+                            func(Err(ReflectPathError::InvalidDowncast));
+                        }
+                    };
                 }
                 Err(err) => {
                     func(Err(err));
@@ -742,10 +717,10 @@ pub trait ResolvePath {
         func: &mut dyn FnMut(Result<&mut T, ReflectPathError<'p>>),
     ) {
         self.resolve_path_mut(path, &mut |result| match result {
-            Ok(value) => value.downcast_mut(&mut |result| match result {
+            Ok(value) => match value.downcast_mut() {
                 Some(value) => func(Ok(value)),
                 None => func(Err(ReflectPathError::InvalidDowncast)),
-            }),
+            },
             Err(err) => func(Err(err)),
         })
     }
@@ -796,18 +771,14 @@ impl<R: Reflect> GetField for R {
     fn get_field<T: 'static>(&self, name: &str, func: &mut dyn FnMut(Option<&T>)) {
         self.find_field(name, &mut |opt_field| match opt_field {
             None => func(None),
-            Some(field) => {
-                field.inner_ref(&mut |reflect| func((reflect as &dyn Any).downcast_ref()))
-            }
+            Some(field) => func((field as &dyn Any).downcast_ref()),
         })
     }
 
     fn get_field_mut<T: 'static>(&mut self, name: &str, func: &mut dyn FnMut(Option<&mut T>)) {
         self.find_field_mut(name, &mut |opt_field| match opt_field {
             None => func(None),
-            Some(field) => {
-                field.inner_mut(&mut |reflect| func((reflect as &mut dyn Any).downcast_mut()))
-            }
+            Some(field) => func((field as &mut dyn Any).downcast_mut()),
         })
     }
 }
@@ -1022,7 +993,7 @@ pub fn is_path_to_array_element(path: &str) -> bool {
 impl dyn ReflectList {
     pub fn get_reflect_index<T: Reflect>(&self, index: usize, func: &mut dyn FnMut(Option<&T>)) {
         if let Some(reflect) = self.reflect_index(index) {
-            reflect.downcast_ref(func)
+            func(reflect.downcast_ref())
         } else {
             func(None)
         }
@@ -1034,7 +1005,7 @@ impl dyn ReflectList {
         func: &mut dyn FnMut(Option<&mut T>),
     ) {
         if let Some(reflect) = self.reflect_index_mut(index) {
-            reflect.downcast_mut(func)
+            func(reflect.downcast_mut())
         } else {
             func(None)
         }
@@ -1096,11 +1067,14 @@ mod test {
             &[],
         );
 
-        foo.resolve_path("enum_field.Stuff@field", &mut |result| {
+        foo.resolve_path("enum_field.Content.Stuff@field", &mut |result| {
             let enum_field = result.expect("the field must exist!");
-            enum_field.downcast_ref::<u32>(&mut |result| {
-                assert_eq!(*result.expect("the type must be u32"), 123);
-            });
+            assert_eq!(
+                *enum_field
+                    .downcast_ref::<u32>()
+                    .expect("the type must be u32"),
+                123
+            );
         });
 
         assert_eq!(names[0], "");

--- a/fyrox-core/src/reflect/mod.rs
+++ b/fyrox-core/src/reflect/mod.rs
@@ -148,15 +148,12 @@ pub struct TypeInfo {
 /// for every type that should support `Reflect` trait. It is a good compromise between development speed
 /// and the quality of the string output.
 pub trait Reflect: Any + Debug {
-    /// Returns the info about the type that implements this trait. The result of the call of this
-    /// method can be different from the call of [`Self::type_info_ref`] on an instance of the type.
+    /// Returns the info about the type that implements this trait.
     fn type_info() -> TypeInfo
     where
         Self: Sized;
 
-    /// Returns the info about the type that implements this trait. The result of the call of this
-    /// method can be different from the call of [`Self::type_info`]. This may happen if the type
-    /// that implements the trait is a wrapper type.
+    /// Returns the info about the type that implements this trait.
     fn type_info_ref(&self) -> TypeInfo;
 
     /// Tries to clone the object and return it as a boxed trait object. This method can return
@@ -171,13 +168,15 @@ pub trait Reflect: Any + Debug {
     /// fields in the object.
     fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut]));
 
+    /// Replaces the self value with the specified value. If the call is successful, returns
+    /// `Ok(previous_value)`, otherwise returns `Err(specified_value)`.
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>>;
 
     /// Tries to get a shared reference to a field at the specified index. Returns [`None`] in two cases:
     /// 1) The type does not have such field
     /// 2) The type uses interior mutability. This case is special - pretty much every type with
     ///    interior mutability (Mutex, RefCell, etc.) requires holding some sort of lock guard
-    ///    while the giving access to its content. This method returns the field reference directly,
+    ///    while giving access to its content. This method returns the field reference directly,
     ///    but returning a lock guard would require boxing which in most cases would ruin performance.
     ///    If you need to get a field reference for types with interior mutability, then use
     ///    [`Reflect::fields_ref`] instead.
@@ -187,7 +186,7 @@ pub trait Reflect: Any + Debug {
     /// 1) The type does not have such field
     /// 2) The type uses interior mutability. This case is special - pretty much every type with
     ///    interior mutability (Mutex, RefCell, etc.) requires holding some sort of lock guard
-    ///    while the giving access to its content. This method returns the field reference directly,
+    ///    while giving access to its content. This method returns the field reference directly,
     ///    but returning a lock guard would require boxing which in most cases would ruin performance.
     ///    If you need to get a field reference for types with interior mutability, then use
     ///    [`Reflect::fields_ref`] instead.
@@ -200,8 +199,10 @@ pub trait Reflect: Any + Debug {
         count
     }
 
-    /// Calls user method specified with `#[reflect(setter = ..)]` or falls back to
-    /// [`Reflect::find_field_mut`]
+    /// Tries to find a field with the specified name and set its value to the specified `value`.
+    /// This method may fail in two main reasons:
+    /// 1) The field does not exist (or it is hidden via `#[reflect(hidden)]` attribute).
+    /// 2) The type of the specified value does match the type of the field at the given name.
     #[allow(clippy::type_complexity)]
     fn set_field(
         &mut self,
@@ -225,6 +226,8 @@ pub trait Reflect: Any + Debug {
         });
     }
 
+    /// Tries to find a field with the given name and calls the specified function with the result
+    /// (either `Some(field)` or `None`).
     fn find_field(&self, name: &str, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
         self.fields_ref(&mut |fields| {
             func(
@@ -236,6 +239,8 @@ pub trait Reflect: Any + Debug {
         });
     }
 
+    /// Tries to find a field with the given name and calls the specified function with the result
+    /// (either `Some(field)` or `None`).
     fn find_field_mut(&mut self, name: &str, func: &mut dyn FnMut(Option<&mut dyn Reflect>)) {
         self.fields_mut(&mut |fields| {
             func(

--- a/fyrox-core/src/variable.rs
+++ b/fyrox-core/src/variable.rs
@@ -398,6 +398,19 @@ where
     }
 }
 
+static CONTENT_METADATA: FieldMetadata = FieldMetadata {
+    name: "Content",
+    display_name: "Content",
+    tag: "",
+    read_only: false,
+    immutable_collection: false,
+    min_value: None,
+    max_value: None,
+    step: None,
+    precision: None,
+    doc: "",
+};
+
 impl<T> Reflect for InheritableVariable<T>
 where
     T: Reflect + Clone + PartialEq + Debug,
@@ -413,97 +426,59 @@ where
     }
 
     fn type_info_ref(&self) -> TypeInfo {
-        let inner_type_info = self.value.type_info_ref();
-
-        TypeInfo {
-            source_path: inner_type_info.source_path,
-            type_name: inner_type_info.type_name,
-            assembly_name: inner_type_info.assembly_name,
-            doc_comment: inner_type_info.doc_comment,
-            derived_types: inner_type_info.derived_types,
-        }
+        Self::type_info()
     }
 
     fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-        Some(Box::new(self.value.clone()))
+        Some(Box::new(self.clone()))
     }
 
-    #[inline]
     fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        self.value.fields_ref(func)
+        func(&[{
+            FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: &self.value,
+            }
+        }])
     }
 
-    #[inline]
     fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        self.value.fields_mut(func)
+        self.mark_modified_and_need_sync();
+        func(&mut [{
+            FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: &mut self.value,
+            }
+        }])
     }
 
-    #[inline]
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-        Box::new(self.value).into_inner()
-    }
-
-    #[inline]
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-        self.value.inner_ref(func)
-    }
-
-    #[inline]
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-        self.value.inner_mut(func)
-    }
-
-    #[inline]
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
         self.mark_modified_and_need_sync();
-        self.value.set(value)
+        let this = std::mem::replace(self, value.take()?);
+        Ok(Box::new(this))
     }
 
-    #[inline]
-    fn set_field(
-        &mut self,
-        field: &str,
-        value: Box<dyn Reflect>,
-        func: &mut dyn FnMut(Result<Box<dyn Reflect>, SetFieldError>),
-    ) {
-        self.mark_modified_and_need_sync();
-        self.value.set_field(field, value, func)
+    fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
+        if index == 0 {
+            Some(FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: &self.value,
+            })
+        } else {
+            None
+        }
     }
 
-    #[inline]
-    fn find_field(&self, name: &str, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
-        self.value.find_field(name, func)
-    }
-
-    #[inline]
-    fn find_field_mut(&mut self, name: &str, func: &mut dyn FnMut(Option<&mut dyn Reflect>)) {
-        // Any modifications inside of compound structs must mark the variable as modified.
-        self.mark_modified_and_need_sync();
-        self.value.find_field_mut(name, func)
-    }
-
-    #[inline]
-    fn as_array(&self, func: &mut dyn FnMut(Option<&dyn ReflectArray>)) {
-        self.value.as_array(func)
-    }
-
-    #[inline]
-    fn as_array_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectArray>)) {
-        // Any modifications inside of inheritable arrays must mark the variable as modified.
-        self.mark_modified_and_need_sync();
-        self.value.as_array_mut(func)
-    }
-
-    #[inline]
-    fn as_list(&self, func: &mut dyn FnMut(Option<&dyn ReflectList>)) {
-        self.value.as_list(func)
-    }
-
-    #[inline]
-    fn as_list_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectList>)) {
-        // Any modifications inside of inheritable lists must mark the variable as modified.
-        self.mark_modified_and_need_sync();
-        self.value.as_list_mut(func)
+    fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
+        if index == 0 {
+            self.mark_modified_and_need_sync();
+            Some(FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: &mut self.value,
+            })
+        } else {
+            None
+        }
     }
 
     #[inline]
@@ -520,30 +495,6 @@ where
         func: &mut dyn FnMut(Option<&mut dyn ReflectInheritableVariable>),
     ) {
         func(Some(self))
-    }
-
-    #[inline]
-    fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
-        self.value.field_direct_ref(index)
-    }
-
-    #[inline]
-    fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
-        // Any modifications inside of inheritable lists must mark the variable as modified.
-        self.mark_modified_and_need_sync();
-        self.value.field_direct_mut(index)
-    }
-
-    #[inline]
-    fn inner_ref_direct(&self) -> &dyn Reflect {
-        self.value.inner_ref_direct()
-    }
-
-    #[inline]
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-        // Any modifications inside of inheritable lists must mark the variable as modified.
-        self.mark_modified_and_need_sync();
-        self.value.inner_mut_direct()
     }
 }
 
@@ -607,16 +558,9 @@ where
 
     #[inline]
     fn value_equals(&self, other: &dyn ReflectInheritableVariable) -> bool {
-        let mut output_result = false;
-        other.inner_ref(&mut |reflect| {
-            reflect.downcast_ref::<T>(&mut |result| {
-                output_result = match result {
-                    Some(other) => &self.value == other,
-                    None => false,
-                };
-            })
-        });
-        output_result
+        (other as &dyn Reflect)
+            .downcast_ref::<Self>()
+            .is_some_and(|v| v == self)
     }
 
     #[inline]
@@ -751,11 +695,9 @@ pub fn try_inherit_properties(
                 for (child_field, parent_field) in child_fields.iter_mut().zip(parent_fields) {
                     // Look into inner properties recursively and try to inherit them. This is mandatory step, because inner
                     // fields may also be InheritableVariable<T>.
-                    if let Err(e) = try_inherit_properties(
-                        child_field.value.field_value_as_reflect_mut(),
-                        parent_field.value.field_value_as_reflect(),
-                        ignored_types,
-                    ) {
+                    if let Err(e) =
+                        try_inherit_properties(child_field.value, parent_field.value, ignored_types)
+                    {
                         result = Some(Err(e));
                     }
 
@@ -1190,7 +1132,7 @@ mod test {
     fn inheritable_variable_type_name() {
         let v = InheritableVariable::from(42);
 
-        assert_eq!(v.type_info_ref().type_name, "i32");
+        assert_eq!(v.type_info_ref().type_name, std::any::type_name_of_val(&v));
     }
 
     #[test]

--- a/fyrox-core/src/variable.rs
+++ b/fyrox-core/src/variable.rs
@@ -398,7 +398,7 @@ where
     }
 }
 
-static CONTENT_METADATA: FieldMetadata = FieldMetadata {
+pub static CONTENT_METADATA: FieldMetadata = FieldMetadata {
     name: "Content",
     display_name: "Content",
     tag: "",

--- a/fyrox-core/src/variable.rs
+++ b/fyrox-core/src/variable.rs
@@ -482,19 +482,13 @@ where
     }
 
     #[inline]
-    fn as_inheritable_variable(
-        &self,
-        func: &mut dyn FnMut(Option<&dyn ReflectInheritableVariable>),
-    ) {
-        func(Some(self))
+    fn as_inheritable_variable(&self) -> Option<&dyn ReflectInheritableVariable> {
+        Some(self)
     }
 
     #[inline]
-    fn as_inheritable_variable_mut(
-        &mut self,
-        func: &mut dyn FnMut(Option<&mut dyn ReflectInheritableVariable>),
-    ) {
-        func(Some(self))
+    fn as_inheritable_variable_mut(&mut self) -> Option<&mut dyn ReflectInheritableVariable> {
+        Some(self)
     }
 }
 
@@ -638,55 +632,44 @@ pub fn try_inherit_properties(
 
     let mut result = None;
 
-    child.as_inheritable_variable_mut(&mut |inheritable_child| {
-        if let Some(inheritable_child) = inheritable_child {
-            parent.as_inheritable_variable(&mut |inheritable_parent| {
-                if let Some(inheritable_parent) = inheritable_parent {
-                    if let Err(e) = inheritable_child.try_inherit(inheritable_parent, ignored_types)
-                    {
-                        result = Some(Err(e));
-                    }
+    if let Some(inheritable_child) = child.as_inheritable_variable_mut() {
+        if let Some(inheritable_parent) = parent.as_inheritable_variable() {
+            if let Err(e) = inheritable_child.try_inherit(inheritable_parent, ignored_types) {
+                result = Some(Err(e));
+            }
 
-                    if !matches!(result, Some(Err(_))) {
-                        result = Some(try_inherit_properties(
-                            inheritable_child.inner_value_mut(),
-                            inheritable_parent.inner_value_ref(),
-                            ignored_types,
-                        ));
-                    }
-                }
-            })
+            if !matches!(result, Some(Err(_))) {
+                result = Some(try_inherit_properties(
+                    inheritable_child.inner_value_mut(),
+                    inheritable_parent.inner_value_ref(),
+                    ignored_types,
+                ));
+            }
         }
-    });
+    }
 
     if result.is_none() {
-        child.as_array_mut(&mut |child_collection| {
-            if let Some(child_collection) = child_collection {
-                parent.as_array(&mut |parent_collection| {
-                    if let Some(parent_collection) = parent_collection {
-                        if child_collection.reflect_len() == parent_collection.reflect_len() {
-                            for i in 0..child_collection.reflect_len() {
-                                // Sparse arrays (like Pool) could have empty entries.
-                                if let (Some(child_item), Some(parent_item)) = (
-                                    child_collection.reflect_index_mut(i),
-                                    parent_collection.reflect_index(i),
-                                ) {
-                                    if let Err(e) = try_inherit_properties(
-                                        child_item,
-                                        parent_item,
-                                        ignored_types,
-                                    ) {
-                                        result = Some(Err(e));
+        if let Some(child_collection) = child.as_array_mut() {
+            if let Some(parent_collection) = parent.as_array() {
+                if child_collection.reflect_len() == parent_collection.reflect_len() {
+                    for i in 0..child_collection.reflect_len() {
+                        // Sparse arrays (like Pool) could have empty entries.
+                        if let (Some(child_item), Some(parent_item)) = (
+                            child_collection.reflect_index_mut(i),
+                            parent_collection.reflect_index(i),
+                        ) {
+                            if let Err(e) =
+                                try_inherit_properties(child_item, parent_item, ignored_types)
+                            {
+                                result = Some(Err(e));
 
-                                        break;
-                                    }
-                                }
+                                break;
                             }
                         }
                     }
-                })
+                }
             }
-        })
+        }
     }
 
     if result.is_none() {
@@ -721,11 +704,9 @@ pub fn do_with_inheritable_variables<F>(
 {
     root.apply_recursively_mut(
         &mut |object| {
-            object.as_inheritable_variable_mut(&mut |variable| {
-                if let Some(variable) = variable {
-                    func(variable);
-                }
-            });
+            if let Some(variable) = object.as_inheritable_variable_mut() {
+                func(variable);
+            }
         },
         ignored_types,
     )

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -855,7 +855,7 @@ pub trait SceneGraph: 'static {
         T: Reflect,
     {
         self.try_get_node(handle).and_then(|n| {
-            (n.inner_ref() as &dyn Reflect)
+            n.inner_ref()
                 .self_or_field_ref()
                 .ok_or(PoolError::NoSuchField(handle.into()))
         })
@@ -869,7 +869,7 @@ pub trait SceneGraph: 'static {
         T: Reflect,
     {
         self.try_get_node_mut(handle).and_then(|n| {
-            (n.inner_mut() as &mut dyn Reflect)
+            n.inner_mut()
                 .self_or_field_mut()
                 .ok_or(PoolError::NoSuchField(handle.into()))
         })

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -232,70 +232,62 @@ where
         }
 
         // Handle derived entities handles.
-        entity.as_handle_mut(&mut |handle| {
-            if let Some(handle) = handle {
-                if handle
-                    .type_info_ref()
-                    .derived_types
-                    .contains(&TypeId::of::<N>())
-                    && handle.reflect_is_some()
-                    && !self.try_map_reflect(handle)
-                {
-                    Log::warn(format!(
-                        "Failed to remap handle {}:{} of node {}!",
-                        handle.reflect_index(),
-                        handle.reflect_generation(),
-                        node_name
-                    ));
-                }
-                mapped = true;
+        if let Some(handle) = entity.as_handle_mut() {
+            if handle
+                .type_info_ref()
+                .derived_types
+                .contains(&TypeId::of::<N>())
+                && handle.reflect_is_some()
+                && !self.try_map_reflect(handle)
+            {
+                Log::warn(format!(
+                    "Failed to remap handle {}:{} of node {}!",
+                    handle.reflect_index(),
+                    handle.reflect_generation(),
+                    node_name
+                ));
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
         }
 
-        entity.as_inheritable_variable_mut(&mut |inheritable| {
-            if let Some(inheritable) = inheritable {
-                // In case of inheritable variable we must take inner value and do not mark variables as modified.
-                self.remap_handles_any(inheritable.inner_value_mut(), node_name, ignored_types);
+        if let Some(inheritable) = entity.as_inheritable_variable_mut() {
+            // In case of inheritable variable we must take inner value and do not mark variables as modified.
+            self.remap_handles_any(inheritable.inner_value_mut(), node_name, ignored_types);
 
-                mapped = true;
-            }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
         }
 
-        entity.as_array_mut(&mut |array| {
-            if let Some(array) = array {
-                // Look in every array item.
-                for i in 0..array.reflect_len() {
-                    // Sparse arrays (like Pool) could have empty entries.
-                    if let Some(item) = array.reflect_index_mut(i) {
-                        self.remap_handles_any(item, node_name, ignored_types);
-                    }
+        if let Some(array) = entity.as_array_mut() {
+            // Look in every array item.
+            for i in 0..array.reflect_len() {
+                // Sparse arrays (like Pool) could have empty entries.
+                if let Some(item) = array.reflect_index_mut(i) {
+                    self.remap_handles_any(item, node_name, ignored_types);
                 }
-                mapped = true;
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
         }
 
-        entity.as_hash_map_mut(&mut |hash_map| {
-            if let Some(hash_map) = hash_map {
-                for i in 0..hash_map.reflect_len() {
-                    if let Some(item) = hash_map.reflect_get_nth_value_mut(i) {
-                        self.remap_handles_any(item, node_name, ignored_types);
-                    }
+        if let Some(hash_map) = entity.as_hash_map_mut() {
+            for i in 0..hash_map.reflect_len() {
+                if let Some(item) = hash_map.reflect_get_nth_value_mut(i) {
+                    self.remap_handles_any(item, node_name, ignored_types);
                 }
-                mapped = true;
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
@@ -328,22 +320,20 @@ where
 
         let mut mapped = false;
 
-        entity.as_inheritable_variable_mut(&mut |result| {
-            if let Some(inheritable) = result {
-                // In case of inheritable variable we must take inner value and do not mark variables as modified.
-                if !inheritable.is_modified() {
-                    self.remap_inheritable_handles_internal(
-                        inheritable.inner_value_mut(),
-                        node_name,
-                        // Raise mapping flag, any handle in inner value will be mapped. The flag is propagated
-                        // to unlimited depth.
-                        true,
-                        ignored_types,
-                    );
-                }
-                mapped = true;
+        if let Some(inheritable) = entity.as_inheritable_variable_mut() {
+            // In case of inheritable variable we must take inner value and do not mark variables as modified.
+            if !inheritable.is_modified() {
+                self.remap_inheritable_handles_internal(
+                    inheritable.inner_value_mut(),
+                    node_name,
+                    // Raise mapping flag, any handle in inner value will be mapped. The flag is propagated
+                    // to unlimited depth.
+                    true,
+                    ignored_types,
+                );
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
@@ -364,72 +354,66 @@ where
         }
 
         // Handle derived entities handles.
-        entity.as_handle_mut(&mut |handle| {
-            if let Some(handle) = handle {
-                if do_map
-                    && handle
-                        .type_info_ref()
-                        .derived_types
-                        .contains(&TypeId::of::<N>())
-                    && handle.reflect_is_some()
-                    && !self.try_map_reflect(handle)
-                {
-                    Log::warn(format!(
-                        "Failed to remap handle {}:{} of node {}!",
-                        handle.reflect_index(),
-                        handle.reflect_generation(),
-                        node_name
-                    ));
-                }
-                mapped = true;
+        if let Some(handle) = entity.as_handle_mut() {
+            if do_map
+                && handle
+                    .type_info_ref()
+                    .derived_types
+                    .contains(&TypeId::of::<N>())
+                && handle.reflect_is_some()
+                && !self.try_map_reflect(handle)
+            {
+                Log::warn(format!(
+                    "Failed to remap handle {}:{} of node {}!",
+                    handle.reflect_index(),
+                    handle.reflect_generation(),
+                    node_name
+                ));
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
         }
 
-        entity.as_array_mut(&mut |result| {
-            if let Some(array) = result {
-                // Look in every array item.
-                for i in 0..array.reflect_len() {
-                    // Sparse arrays (like Pool) could have empty entries.
-                    if let Some(item) = array.reflect_index_mut(i) {
-                        self.remap_inheritable_handles_internal(
-                            item,
-                            node_name,
-                            // Propagate mapping flag - it means that we're inside inheritable variable. In this
-                            // case we will map handles.
-                            do_map,
-                            ignored_types,
-                        );
-                    }
+        if let Some(array) = entity.as_array_mut() {
+            // Look in every array item.
+            for i in 0..array.reflect_len() {
+                // Sparse arrays (like Pool) could have empty entries.
+                if let Some(item) = array.reflect_index_mut(i) {
+                    self.remap_inheritable_handles_internal(
+                        item,
+                        node_name,
+                        // Propagate mapping flag - it means that we're inside inheritable variable. In this
+                        // case we will map handles.
+                        do_map,
+                        ignored_types,
+                    );
                 }
-                mapped = true;
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
         }
 
-        entity.as_hash_map_mut(&mut |result| {
-            if let Some(hash_map) = result {
-                for i in 0..hash_map.reflect_len() {
-                    if let Some(item) = hash_map.reflect_get_nth_value_mut(i) {
-                        self.remap_inheritable_handles_internal(
-                            item,
-                            node_name,
-                            // Propagate mapping flag - it means that we're inside inheritable variable. In this
-                            // case we will map handles.
-                            do_map,
-                            ignored_types,
-                        );
-                    }
+        if let Some(hash_map) = entity.as_hash_map_mut() {
+            for i in 0..hash_map.reflect_len() {
+                if let Some(item) = hash_map.reflect_get_nth_value_mut(i) {
+                    self.remap_inheritable_handles_internal(
+                        item,
+                        node_name,
+                        // Propagate mapping flag - it means that we're inside inheritable variable. In this
+                        // case we will map handles.
+                        do_map,
+                        ignored_types,
+                    );
                 }
-                mapped = true;
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
@@ -558,11 +542,11 @@ pub trait SceneGraphNode: Reflect + NameProvider + Clone {
             parent
                 .inner_ref()
                 .resolve_path(path, &mut |result| match result {
-                    Ok(parent_field) => parent_field.as_inheritable_variable(&mut |parent_field| {
-                        if let Some(parent_inheritable) = parent_field {
+                    Ok(parent_field) => {
+                        if let Some(parent_inheritable) = parent_field.as_inheritable_variable() {
                             parent_value = Some(parent_inheritable.clone_value_box());
                         }
-                    }),
+                    }
                     Err(e) => Log::err(format!(
                         "Failed to resolve parent path {path}. Reason: {e:?}"
                     )),
@@ -574,13 +558,11 @@ pub trait SceneGraphNode: Reflect + NameProvider + Clone {
             self.inner_mut()
                 .resolve_path_mut(path, &mut |result| match result {
                     Ok(child_field) => {
-                        child_field.as_inheritable_variable_mut(&mut |child_inheritable| {
-                            if let Some(child_inheritable) = child_inheritable {
-                                need_revert = child_inheritable.is_modified();
-                            } else {
-                                Log::err(format!("Property {path} is not inheritable!"))
-                            }
-                        })
+                        if let Some(child_inheritable) = child_field.as_inheritable_variable_mut() {
+                            need_revert = child_inheritable.is_modified();
+                        } else {
+                            Log::err(format!("Property {path} is not inheritable!"))
+                        }
                     }
                     Err(e) => Log::err(format!(
                         "Failed to resolve child path {path}. Reason: {e:?}"
@@ -1608,7 +1590,6 @@ mod test {
         NameProvider,
     };
     use fyrox_resource::{untyped::UntypedResource, Resource, ResourceData};
-    use std::any::type_name;
     use std::marker::PhantomData;
     use std::{
         any::{Any, TypeId},

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -1677,8 +1677,8 @@ mod test {
         }
     }
 
-    #[derive(Debug)]
-    pub struct Node(Box<dyn NodeTrait>);
+    #[derive(Debug, Reflect)]
+    pub struct Node(#[reflect(deref, display_name = "Node")] Box<dyn NodeTrait>);
 
     impl Clone for Node {
         fn clone(&self) -> Self {
@@ -1695,67 +1695,6 @@ mod test {
     impl Visit for Node {
         fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
             self.0.visit(name, visitor)
-        }
-    }
-
-    impl Reflect for Node {
-        fn type_info() -> TypeInfo {
-            TypeInfo {
-                source_path: file!(),
-                type_name: type_name::<Self>(),
-                assembly_name: env!("CARGO_PKG_NAME"),
-                doc_comment: "",
-                derived_types: &[],
-            }
-        }
-
-        fn type_info_ref(&self) -> TypeInfo {
-            Self::type_info()
-        }
-
-        fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-            self.0.deref().fields_ref(func)
-        }
-
-        fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-            self.0.deref_mut().fields_mut(func)
-        }
-
-        fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-            self.0.deref_mut().set(value)
-        }
-
-        fn set_field(
-            &mut self,
-            field: &str,
-            value: Box<dyn Reflect>,
-            func: &mut dyn FnMut(Result<Box<dyn Reflect>, SetFieldError>),
-        ) {
-            self.0.deref_mut().set_field(field, value, func)
-        }
-
-        fn find_field(&self, name: &str, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
-            self.0.deref().find_field(name, func)
-        }
-
-        fn find_field_mut(&mut self, name: &str, func: &mut dyn FnMut(Option<&mut dyn Reflect>)) {
-            self.0.deref_mut().find_field_mut(name, func)
-        }
-
-        fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-            Some(Box::new(self.clone()))
-        }
-
-        fn field_direct_ref(&self, index: usize) -> Option<FieldRef<'_, '_>> {
-            self.0.deref().field_direct_ref(index)
-        }
-
-        fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut<'_, '_>> {
-            self.0.deref_mut().field_direct_mut(index)
-        }
-
-        fn fields_count(&self) -> usize {
-            self.0.fields_count()
         }
     }
 

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -202,7 +202,7 @@ where
     #[inline]
     pub fn remap_handles(&self, node: &mut N, ignored_types: &[TypeId]) {
         let name = node.name().to_string();
-        node.inner_mut(&mut |node| self.remap_handles_any(node, &name, ignored_types));
+        self.remap_handles_any(node, &name, ignored_types);
     }
 
     pub fn remap_handles_any(
@@ -217,17 +217,15 @@ where
 
         let mut mapped = false;
 
-        entity.downcast_mut::<Handle<N>>(&mut |handle| {
-            if let Some(handle) = handle {
-                if handle.is_some() && !self.try_map(handle) {
-                    Log::warn(format!(
-                        "Failed to remap handle {} of node {}!",
-                        *handle, node_name
-                    ));
-                }
-                mapped = true;
+        if let Some(handle) = entity.downcast_mut::<Handle<N>>() {
+            if handle.is_some() && !self.try_map(handle) {
+                Log::warn(format!(
+                    "Failed to remap handle {} of node {}!",
+                    *handle, node_name
+                ));
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
@@ -306,10 +304,7 @@ where
         // Continue remapping recursively for every compound field.
         entity.fields_mut(&mut |fields| {
             for field_info_mut in fields {
-                field_info_mut
-                    .value
-                    .field_value_as_reflect_mut()
-                    .inner_mut(&mut |field| self.remap_handles_any(field, node_name, ignored_types))
+                self.remap_handles_any(field_info_mut.value, node_name, ignored_types)
             }
         })
     }
@@ -317,9 +312,7 @@ where
     #[inline]
     pub fn remap_inheritable_handles(&self, node: &mut N, ignored_types: &[TypeId]) {
         let name = node.name().to_string();
-        node.inner_mut(&mut |node| {
-            self.remap_inheritable_handles_internal(node, &name, false, ignored_types)
-        });
+        self.remap_inheritable_handles_internal(node, &name, false, ignored_types);
     }
 
     fn remap_inheritable_handles_internal(
@@ -356,17 +349,15 @@ where
             return;
         }
 
-        entity.downcast_mut::<Handle<N>>(&mut |result| {
-            if let Some(handle) = result {
-                if do_map && handle.is_some() && !self.try_map(handle) {
-                    Log::warn(format!(
-                        "Failed to remap handle {} of node {}!",
-                        *handle, node_name
-                    ));
-                }
-                mapped = true;
+        if let Some(handle) = entity.downcast_mut::<Handle<N>>() {
+            if do_map && handle.is_some() && !self.try_map(handle) {
+                Log::warn(format!(
+                    "Failed to remap handle {} of node {}!",
+                    *handle, node_name
+                ));
             }
-        });
+            mapped = true;
+        }
 
         if mapped {
             return;
@@ -448,7 +439,7 @@ where
         entity.fields_mut(&mut |fields| {
             for field_info_mut in fields {
                 self.remap_inheritable_handles_internal(
-                    field_info_mut.value.field_value_as_reflect_mut(),
+                    field_info_mut.value,
                     node_name,
                     // Propagate mapping flag - it means that we're inside inheritable variable. In this
                     // case we will map handles.
@@ -461,21 +452,21 @@ where
 }
 
 fn reset_property_modified_flag(entity: &mut dyn Reflect, path: &str) {
-    entity.inner_mut(&mut |entity| {
-        entity.resolve_path_mut(path, &mut |result| {
-            variable::mark_inheritable_properties_non_modified(
-                result.unwrap(),
-                &[TypeId::of::<UntypedResource>()],
-            );
-        })
+    entity.resolve_path_mut(path, &mut |result| {
+        variable::mark_inheritable_properties_non_modified(
+            result.unwrap(),
+            &[TypeId::of::<UntypedResource>()],
+        );
     })
 }
 
-pub trait SceneGraphNode: Reflect + NameProvider + Clone + 'static {
+pub trait SceneGraphNode: Reflect + NameProvider + Clone {
     type Base: Clone;
     type SceneGraph: SceneGraph<Node = Self>;
     type ResourceData: PrefabData<Graph = Self::SceneGraph>;
 
+    fn inner_ref(&self) -> &dyn Reflect;
+    fn inner_mut(&mut self) -> &mut dyn Reflect;
     fn base(&self) -> &Self::Base;
     fn set_base(&mut self, base: Self::Base);
     fn is_resource_instance_root(&self) -> bool;
@@ -564,8 +555,9 @@ pub trait SceneGraphNode: Reflect + NameProvider + Clone + 'static {
             let mut parent_value = None;
 
             // Find and clone parent's value first.
-            parent.inner_ref(&mut |parent| {
-                parent.resolve_path(path, &mut |result| match result {
+            parent
+                .inner_ref()
+                .resolve_path(path, &mut |result| match result {
                     Ok(parent_field) => parent_field.as_inheritable_variable(&mut |parent_field| {
                         if let Some(parent_inheritable) = parent_field {
                             parent_value = Some(parent_inheritable.clone_value_box());
@@ -574,14 +566,13 @@ pub trait SceneGraphNode: Reflect + NameProvider + Clone + 'static {
                     Err(e) => Log::err(format!(
                         "Failed to resolve parent path {path}. Reason: {e:?}"
                     )),
-                })
-            });
+                });
 
             // Check whether the child's field is inheritable and modified.
             let mut need_revert = false;
 
-            self.inner_mut(&mut |child| {
-                child.resolve_path_mut(path, &mut |result| match result {
+            self.inner_mut()
+                .resolve_path_mut(path, &mut |result| match result {
                     Ok(child_field) => {
                         child_field.as_inheritable_variable_mut(&mut |child_inheritable| {
                             if let Some(child_inheritable) = child_inheritable {
@@ -595,7 +586,6 @@ pub trait SceneGraphNode: Reflect + NameProvider + Clone + 'static {
                         "Failed to resolve child path {path}. Reason: {e:?}"
                     )),
                 });
-            });
 
             // Try to apply it to the child.
             if need_revert {
@@ -603,26 +593,25 @@ pub trait SceneGraphNode: Reflect + NameProvider + Clone + 'static {
                     let mut was_set = false;
 
                     let mut parent_value = Some(parent_value);
-                    self.inner_mut(&mut |child| {
-                        child.set_field_by_path(
-                            path,
-                            parent_value.take().unwrap(),
-                            &mut |result| match result {
-                                Ok(old_value) => {
-                                    previous_value = Some(old_value);
 
-                                    was_set = true;
-                                }
-                                Err(_) => Log::err(format!(
-                                    "Failed to revert property {path}. Reason: no such property!"
-                                )),
-                            },
-                        );
-                    });
+                    self.inner_mut().set_field_by_path(
+                        path,
+                        parent_value.take().unwrap(),
+                        &mut |result| match result {
+                            Ok(old_value) => {
+                                previous_value = Some(old_value);
+
+                                was_set = true;
+                            }
+                            Err(_) => Log::err(format!(
+                                "Failed to revert property {path}. Reason: no such property!"
+                            )),
+                        },
+                    );
 
                     if was_set {
                         // Reset modified flag.
-                        reset_property_modified_flag(self, path);
+                        reset_property_modified_flag(self.inner_mut(), path);
                     }
                 }
             }
@@ -635,14 +624,14 @@ pub trait SceneGraphNode: Reflect + NameProvider + Clone + 'static {
     /// field of the specified type.
     #[inline]
     fn self_or_field_ref<T: Reflect>(&self) -> Option<&T> {
-        (self as &dyn Reflect).self_or_field_ref::<T>()
+        self.inner_ref().self_or_field_ref::<T>()
     }
 
     /// Tries to downcast self to the specified type, or if it is not possible, tries to find a
     /// field of the specified type.
     #[inline]
     fn self_or_field_mut<T: Reflect>(&mut self) -> Option<&mut T> {
-        (self as &mut dyn Reflect).self_or_field_mut::<T>()
+        self.inner_mut().self_or_field_mut::<T>()
     }
 
     /// Checks if the node is an instance of the given type or has a field of the same type.
@@ -884,7 +873,7 @@ pub trait SceneGraph: 'static {
         T: Reflect,
     {
         self.try_get_node(handle).and_then(|n| {
-            (n as &dyn Reflect)
+            (n.inner_ref() as &dyn Reflect)
                 .self_or_field_ref()
                 .ok_or(PoolError::NoSuchField(handle.into()))
         })
@@ -898,7 +887,7 @@ pub trait SceneGraph: 'static {
         T: Reflect,
     {
         self.try_get_node_mut(handle).and_then(|n| {
-            (n as &mut dyn Reflect)
+            (n.inner_mut() as &mut dyn Reflect)
                 .self_or_field_mut()
                 .ok_or(PoolError::NoSuchField(handle.into()))
         })
@@ -983,7 +972,7 @@ pub trait SceneGraph: 'static {
         T: Reflect,
     {
         self.find_up_map(node_handle, &mut |node| {
-            (node as &dyn Reflect).self_or_field_ref::<T>()
+            node.inner_ref().self_or_field_ref::<T>()
         })
     }
 
@@ -996,7 +985,7 @@ pub trait SceneGraph: 'static {
         T: Reflect,
     {
         self.find_map(node_handle, &mut |node| {
-            (node as &dyn Reflect).self_or_field_ref::<T>()
+            node.inner_ref().self_or_field_ref::<T>()
         })
     }
 
@@ -1386,26 +1375,17 @@ pub trait SceneGraph: 'static {
 
                         // Check if the actual node types (this and parent's) are equal, and if not - copy the
                         // node and replace its base.
-                        let mut types_match = true;
-                        node.inner_ref(&mut |node_reflect| {
-                            resource_node.inner_ref(&mut |resource_node_reflect| {
-                                types_match =
-                                    node_reflect.type_id() == resource_node_reflect.type_id();
-
-                                if !types_match {
-                                    Log::warn(format!(
-                                        "Node {}({}:{}) instance \
+                        if node.inner_ref().type_id() != resource_node.inner_ref().type_id() {
+                            Log::warn(format!(
+                                "Node {}({}:{}) instance \
                                         have different type than in the respective parent \
                                         asset {}. The type will be fixed.",
-                                        node.name(),
-                                        node.self_handle().index(),
-                                        node.self_handle().generation(),
-                                        model_kind
-                                    ));
-                                }
-                            })
-                        });
-                        if !types_match {
+                                node.name(),
+                                node.self_handle().index(),
+                                node.self_handle().generation(),
+                                model_kind
+                            ));
+
                             let base = node.base().clone();
                             let mut resource_node_clone = resource_node.clone();
                             variable::mark_inheritable_properties_non_modified(
@@ -1417,15 +1397,11 @@ pub trait SceneGraph: 'static {
                         }
 
                         // Then try to inherit properties.
-                        node.inner_mut(&mut |node_reflect| {
-                            resource_node.inner_ref(&mut |resource_node_reflect| {
-                                Log::verify(variable::try_inherit_properties(
-                                    node_reflect,
-                                    resource_node_reflect,
-                                    &ignored_types,
-                                ));
-                            })
-                        })
+                        Log::verify(variable::try_inherit_properties(
+                            node,
+                            resource_node,
+                            &ignored_types,
+                        ));
                     } else {
                         Log::warn(format!(
                             "Unable to find original handle for node {}. The node will be removed!",
@@ -1734,14 +1710,7 @@ mod test {
         }
 
         fn type_info_ref(&self) -> TypeInfo {
-            let inner_type_info = self.0.deref().type_info_ref();
-            TypeInfo {
-                source_path: inner_type_info.source_path,
-                type_name: inner_type_info.type_name,
-                assembly_name: inner_type_info.assembly_name,
-                doc_comment: inner_type_info.doc_comment,
-                derived_types: inner_type_info.derived_types,
-            }
+            Self::type_info()
         }
 
         fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
@@ -1750,18 +1719,6 @@ mod test {
 
         fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
             self.0.deref_mut().fields_mut(func)
-        }
-
-        fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-            Reflect::into_inner(self.0)
-        }
-
-        fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-            self.0.deref().inner_ref(func)
-        }
-
-        fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-            self.0.deref_mut().inner_mut(func)
         }
 
         fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
@@ -1799,14 +1756,6 @@ mod test {
 
         fn fields_count(&self) -> usize {
             self.0.fields_count()
-        }
-
-        fn inner_ref_direct(&self) -> &dyn Reflect {
-            self.0.inner_ref_direct()
-        }
-
-        fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-            self.0.inner_mut_direct()
         }
     }
 
@@ -1878,6 +1827,14 @@ mod test {
         type Base = Base;
         type SceneGraph = Graph;
         type ResourceData = Graph;
+
+        fn inner_ref(&self) -> &dyn Reflect {
+            self.0.deref()
+        }
+
+        fn inner_mut(&mut self) -> &mut dyn Reflect {
+            self.0.deref_mut()
+        }
 
         #[allow(clippy::explicit_auto_deref)] // False-positive
         fn base(&self) -> &Self::Base {
@@ -2093,7 +2050,7 @@ mod test {
         fn actual_type_name(&self, handle: Handle<Self::Node>) -> Result<&'static str, PoolError> {
             self.nodes
                 .try_borrow(handle)
-                .map(|n| n.0.deref().type_name())
+                .map(|n| n.0.deref().type_info_ref().type_name)
         }
 
         fn pair_iter(&self) -> impl Iterator<Item = (Handle<Self::Node>, &Self::Node)> {
@@ -2322,11 +2279,12 @@ mod test {
             .unwrap()
             .transmute::<RigidBody>();
         let joint_copy = mapping.inner().get(&joint).cloned().unwrap();
-        scene_graph.nodes[joint_copy].inner_ref(&mut |reflect| {
-            let joint_copy_ref = (reflect as &dyn Any).downcast_ref::<Joint>().unwrap();
-            assert_eq!(joint_copy_ref.connected_body1, rigid_body_copy);
-            assert_eq!(joint_copy_ref.connected_body2, rigid_body2_copy);
-        });
+        let joint_copy_ref = scene_graph.nodes[joint_copy]
+            .inner_ref()
+            .downcast_ref::<Joint>()
+            .unwrap();
+        assert_eq!(joint_copy_ref.connected_body1, rigid_body_copy);
+        assert_eq!(joint_copy_ref.connected_body2, rigid_body2_copy);
     }
 
     #[test]

--- a/fyrox-impl/src/engine/mod.rs
+++ b/fyrox-impl/src/engine/mod.rs
@@ -2641,11 +2641,9 @@ impl Engine {
             for resource in state.resources().iter() {
                 let data = resource.lock();
                 if let ResourceState::Ok { ref data, .. } = data.state {
-                    data.inner_ref(&mut |reflect| {
-                        if reflect.type_info_ref().assembly_name == plugin_assembly_name {
-                            resources_to_reload.insert(resource.clone());
-                        }
-                    })
+                    if data.type_info_ref().assembly_name == plugin_assembly_name {
+                        resources_to_reload.insert(resource.clone());
+                    }
                 }
             }
 

--- a/fyrox-impl/src/plugin/mod.rs
+++ b/fyrox-impl/src/plugin/mod.rs
@@ -397,11 +397,10 @@ impl<'a, 'b> PluginContext<'a, 'b> {
                                 &mut |object| {
                                     let type_id = (*object).type_id();
                                     if type_id != TypeId::of::<NodePool>() {
-                                        object.as_inheritable_variable_mut(&mut |variable| {
-                                            if let Some(variable) = variable {
-                                                variable.reset_modified_flag();
-                                            }
-                                        });
+                                        if let Some(variable) = object.as_inheritable_variable_mut()
+                                        {
+                                            variable.reset_modified_flag();
+                                        }
                                     }
                                 },
                                 &[

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -77,7 +77,6 @@ use crate::{
 use bitflags::bitflags;
 use fxhash::{FxHashMap, FxHashSet};
 use fyrox_material::MaterialResourceExtension;
-use std::any::Any;
 use std::{
     any::TypeId,
     fmt::{Debug, Display, Formatter, Write},
@@ -538,13 +537,11 @@ impl Graph {
         for (node_handle, node) in self.pair_iter() {
             (node as &dyn Reflect).apply_recursively(
                 &mut |object| {
-                    object.inner_ref(&mut |reflect| {
-                        if let Some(handle) = (reflect as &dyn Any).downcast_ref::<Handle<Node>>() {
-                            if *handle == target {
-                                references.push(node_handle);
-                            }
+                    if let Some(handle) = object.downcast_ref::<Handle<Node>>() {
+                        if *handle == target {
+                            references.push(node_handle);
                         }
-                    })
+                    }
                 },
                 &[TypeId::of::<UntypedResource>()],
             );
@@ -2179,7 +2176,7 @@ impl SceneGraph for Graph {
     fn actual_type_name(&self, handle: Handle<Self::Node>) -> Result<&'static str, PoolError> {
         self.pool
             .try_borrow(handle)
-            .map(|n| n.0.deref().type_name())
+            .map(|n| n.0.deref().type_info_ref().type_name)
     }
 
     #[inline]

--- a/fyrox-impl/src/scene/node/mod.rs
+++ b/fyrox-impl/src/scene/node/mod.rs
@@ -270,11 +270,11 @@ pub trait NodeTrait: BaseNodeTrait + Reflect + Visit {
 // See ObjectOrVariantHelper for the cause of the indirection.
 impl<T: NodeTrait> ObjectOrVariantHelper<Node, T> for PhantomData<T> {
     fn convert_to_dest_type_helper(node: &Node) -> Option<&T> {
-        (node.0.deref() as &dyn Reflect).self_or_field_ref()
+        node.inner_ref().self_or_field_ref()
     }
 
     fn convert_to_dest_type_helper_mut(node: &mut Node) -> Option<&mut T> {
-        (node.0.deref_mut() as &mut dyn Reflect).self_or_field_mut()
+        node.inner_mut().self_or_field_mut()
     }
 }
 

--- a/fyrox-impl/src/scene/node/mod.rs
+++ b/fyrox-impl/src/scene/node/mod.rs
@@ -139,9 +139,10 @@ pub trait NodeTrait: BaseNodeTrait + Reflect + Visit {
         use std::fmt::Write;
         let mut result = String::new();
         let type_name = self
-            .type_name()
+            .type_info_ref()
+            .type_name
             .strip_prefix("fyrox_impl::scene::")
-            .unwrap_or(self.type_name());
+            .unwrap_or(self.type_info_ref().type_name);
         write!(result, "{} {}<{}>", self.handle(), self.name(), type_name,).unwrap();
         if self.children().len() == 1 {
             result.push_str(" 1 child");
@@ -378,6 +379,14 @@ impl SceneGraphNode for Node {
     type SceneGraph = Graph;
     type ResourceData = Model;
 
+    fn inner_ref(&self) -> &dyn Reflect {
+        self.0.deref()
+    }
+
+    fn inner_mut(&mut self) -> &mut dyn Reflect {
+        self.0.deref_mut()
+    }
+
     fn base(&self) -> &Self::Base {
         self.0.deref()
     }
@@ -532,9 +541,7 @@ impl Node {
 
         // Reset inheritable properties, so property inheritance system will take properties
         // from parent objects on resolve stage.
-        self.inner_mut(&mut |reflect| {
-            mark_inheritable_properties_non_modified(reflect, &[TypeId::of::<UntypedResource>()])
-        });
+        mark_inheritable_properties_non_modified(self, &[TypeId::of::<UntypedResource>()]);
 
         // Fill original handles to instances.
         self.original_handle_in_resource = original_handle;
@@ -571,6 +578,19 @@ impl Visit for Node {
     }
 }
 
+static CONTENT_METADATA: FieldMetadata = FieldMetadata {
+    name: "Content",
+    display_name: "Content",
+    tag: "",
+    read_only: false,
+    immutable_collection: false,
+    min_value: None,
+    max_value: None,
+    step: None,
+    precision: None,
+    doc: "",
+};
+
 impl Reflect for Node {
     fn type_info() -> TypeInfo {
         TypeInfo {
@@ -583,55 +603,30 @@ impl Reflect for Node {
     }
 
     fn type_info_ref(&self) -> TypeInfo {
-        let inner_type_info = self.0.deref().type_info_ref();
-        TypeInfo {
-            source_path: inner_type_info.source_path,
-            type_name: inner_type_info.type_name,
-            assembly_name: inner_type_info.assembly_name,
-            doc_comment: inner_type_info.doc_comment,
-            derived_types: inner_type_info.derived_types,
-        }
+        Self::type_info()
     }
 
     fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        self.0.deref().fields_ref(func)
+        func(&[{
+            FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: &*self.0,
+            }
+        }])
     }
 
     fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        self.0.deref_mut().fields_mut(func)
-    }
-
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-        Reflect::into_inner(self.0)
-    }
-
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-        self.0.deref().inner_ref(func)
-    }
-
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-        self.0.deref_mut().inner_mut(func)
+        func(&mut [{
+            FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: &mut *self.0,
+            }
+        }])
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-        self.0.deref_mut().set(value)
-    }
-
-    fn set_field(
-        &mut self,
-        field: &str,
-        value: Box<dyn Reflect>,
-        func: &mut dyn FnMut(Result<Box<dyn Reflect>, SetFieldError>),
-    ) {
-        self.0.deref_mut().set_field(field, value, func)
-    }
-
-    fn find_field(&self, name: &str, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
-        self.0.deref().find_field(name, func)
-    }
-
-    fn find_field_mut(&mut self, name: &str, func: &mut dyn FnMut(Option<&mut dyn Reflect>)) {
-        self.0.deref_mut().find_field_mut(name, func)
+        let this = std::mem::replace(self, value.take()?);
+        Ok(Box::new(this))
     }
 
     fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
@@ -639,19 +634,25 @@ impl Reflect for Node {
     }
 
     fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
-        self.0.deref().field_direct_ref(index)
+        if index == 0 {
+            Some(FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: &*self.0,
+            })
+        } else {
+            None
+        }
     }
 
     fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
-        self.0.deref_mut().field_direct_mut(index)
-    }
-
-    fn inner_ref_direct(&self) -> &dyn Reflect {
-        self.0.inner_ref_direct()
-    }
-
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-        self.0.inner_mut_direct()
+        if index == 0 {
+            Some(FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: &mut *self.0,
+            })
+        } else {
+            None
+        }
     }
 }
 

--- a/fyrox-impl/src/scene/node/mod.rs
+++ b/fyrox-impl/src/scene/node/mod.rs
@@ -63,7 +63,6 @@ use crate::{
     },
 };
 use fyrox_core::{define_as_any_trait, pool::ObjectOrVariantHelper};
-use std::any::type_name;
 use std::{
     any::TypeId,
     fmt::Debug,
@@ -359,8 +358,8 @@ impl<T: NodeTrait> ObjectOrVariantHelper<Node, T> for PhantomData<T> {
 /// Such implementation of property inheritance has its drawbacks, major one is: each instance still holds its own copy of
 /// of every field, even those inheritable variables which are non-modified. Which means that there's no benefits of RAM
 /// consumption, only disk space usage is reduced.
-#[derive(Debug)]
-pub struct Node(pub(crate) Box<dyn NodeTrait>);
+#[derive(Debug, Reflect)]
+pub struct Node(#[reflect(deref, display_name = "Node")] pub(crate) Box<dyn NodeTrait>);
 
 impl<T: NodeTrait> From<T> for Node {
     fn from(value: T) -> Self {
@@ -575,84 +574,6 @@ impl Node {
 impl Visit for Node {
     fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
         self.0.visit(name, visitor)
-    }
-}
-
-static CONTENT_METADATA: FieldMetadata = FieldMetadata {
-    name: "Content",
-    display_name: "Content",
-    tag: "",
-    read_only: false,
-    immutable_collection: false,
-    min_value: None,
-    max_value: None,
-    step: None,
-    precision: None,
-    doc: "",
-};
-
-impl Reflect for Node {
-    fn type_info() -> TypeInfo {
-        TypeInfo {
-            source_path: file!(),
-            type_name: type_name::<Self>(),
-            assembly_name: env!("CARGO_PKG_NAME"),
-            doc_comment: "",
-            derived_types: &[],
-        }
-    }
-
-    fn type_info_ref(&self) -> TypeInfo {
-        Self::type_info()
-    }
-
-    fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        func(&[{
-            FieldRef {
-                metadata: &CONTENT_METADATA,
-                value: &*self.0,
-            }
-        }])
-    }
-
-    fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        func(&mut [{
-            FieldMut {
-                metadata: &CONTENT_METADATA,
-                value: &mut *self.0,
-            }
-        }])
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-        let this = std::mem::replace(self, value.take()?);
-        Ok(Box::new(this))
-    }
-
-    fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-        Some(Box::new(self.clone()))
-    }
-
-    fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
-        if index == 0 {
-            Some(FieldRef {
-                metadata: &CONTENT_METADATA,
-                value: &*self.0,
-            })
-        } else {
-            None
-        }
-    }
-
-    fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
-        if index == 0 {
-            Some(FieldMut {
-                metadata: &CONTENT_METADATA,
-                value: &mut *self.0,
-            })
-        } else {
-            None
-        }
     }
 }
 

--- a/fyrox-impl/src/script/mod.rs
+++ b/fyrox-impl/src/script/mod.rs
@@ -43,7 +43,6 @@ use fyrox_core::pool::ObjectOrVariant;
 use fyrox_core::reflect::{FieldMetadata, TypeInfo};
 pub use fyrox_core_derive::ScriptMessagePayload;
 use fyrox_graph::SceneGraph;
-use std::any::type_name;
 use std::{
     any::Any,
     fmt::{Debug, Formatter},
@@ -711,94 +710,19 @@ pub trait ScriptTrait: BaseScript {
 }
 
 /// A wrapper for actual script instance internals, it used by the engine.
-#[derive(Debug)]
+#[derive(Debug, Reflect)]
 pub struct Script {
+    #[reflect(deref, display_name = "Script")]
     instance: Box<dyn ScriptTrait>,
+    #[reflect(hidden)]
     pub(crate) initialized: bool,
+    #[reflect(hidden)]
     pub(crate) started: bool,
 }
 
 impl TypeUuidProvider for Script {
     fn type_uuid() -> Uuid {
         Uuid::from_str("24ecd17d-9b46-4cc8-9d07-a1273e50a20e").unwrap()
-    }
-}
-
-static CONTENT_METADATA: FieldMetadata = FieldMetadata {
-    name: "Content",
-    display_name: "Content",
-    tag: "",
-    read_only: false,
-    immutable_collection: false,
-    min_value: None,
-    max_value: None,
-    step: None,
-    precision: None,
-    doc: "",
-};
-
-impl Reflect for Script {
-    fn type_info() -> TypeInfo {
-        TypeInfo {
-            source_path: file!(),
-            type_name: type_name::<Self>(),
-            assembly_name: env!("CARGO_PKG_NAME"),
-            doc_comment: "",
-            derived_types: &[],
-        }
-    }
-
-    fn type_info_ref(&self) -> TypeInfo {
-        Self::type_info()
-    }
-
-    fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        func(&[{
-            FieldRef {
-                metadata: &CONTENT_METADATA,
-                value: &*self.instance,
-            }
-        }])
-    }
-
-    fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        func(&mut [{
-            FieldMut {
-                metadata: &CONTENT_METADATA,
-                value: &mut *self.instance,
-            }
-        }])
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-        let this = std::mem::replace(self, value.take()?);
-        Ok(Box::new(this))
-    }
-
-    fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-        Some(Box::new(self.clone()))
-    }
-
-    fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
-        if index == 0 {
-            Some(FieldRef {
-                metadata: &CONTENT_METADATA,
-                value: &*self.instance,
-            })
-        } else {
-            None
-        }
-    }
-
-    fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
-        if index == 0 {
-            Some(FieldMut {
-                metadata: &CONTENT_METADATA,
-                value: &mut *self.instance,
-            })
-        } else {
-            None
-        }
     }
 }
 

--- a/fyrox-impl/src/script/mod.rs
+++ b/fyrox-impl/src/script/mod.rs
@@ -72,7 +72,7 @@ pub type DynamicTypeId = i64;
 ///     }
 /// ```
 pub trait ScriptMessagePayload: Any + Send + Debug {
-    /// By default messages are dispatched by [`TypeId::of`]`::<Self>()`.
+    /// By default messages are dispatched by `TypeId::of::<Self>()`.
     ///
     /// If this method returns [`Some`], then the message become dynamically typed.
     /// Dynamically typed messages are dispatched by the returned type identifier instead of static type.

--- a/fyrox-impl/src/script/mod.rs
+++ b/fyrox-impl/src/script/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     core::{
         log::Log,
         pool::{Handle, PoolError},
-        reflect::{FieldMut, FieldRef, Reflect, ReflectArray, ReflectList},
+        reflect::{FieldMut, FieldRef, Reflect},
         uuid::Uuid,
         visitor::{Visit, VisitResult, Visitor},
         TypeUuidProvider,
@@ -40,7 +40,7 @@ use crate::{
     scene::{base::NodeScriptMessage, node::Node, Scene},
 };
 use fyrox_core::pool::ObjectOrVariant;
-use fyrox_core::reflect::TypeInfo;
+use fyrox_core::reflect::{FieldMetadata, TypeInfo};
 pub use fyrox_core_derive::ScriptMessagePayload;
 use fyrox_graph::SceneGraph;
 use std::any::type_name;
@@ -724,6 +724,19 @@ impl TypeUuidProvider for Script {
     }
 }
 
+static CONTENT_METADATA: FieldMetadata = FieldMetadata {
+    name: "Content",
+    display_name: "Content",
+    tag: "",
+    read_only: false,
+    immutable_collection: false,
+    min_value: None,
+    max_value: None,
+    step: None,
+    precision: None,
+    doc: "",
+};
+
 impl Reflect for Script {
     fn type_info() -> TypeInfo {
         TypeInfo {
@@ -736,62 +749,30 @@ impl Reflect for Script {
     }
 
     fn type_info_ref(&self) -> TypeInfo {
-        let inner_type_info = self.instance.type_info_ref();
-        TypeInfo {
-            source_path: inner_type_info.source_path,
-            type_name: inner_type_info.type_name,
-            assembly_name: inner_type_info.assembly_name,
-            doc_comment: inner_type_info.doc_comment,
-            derived_types: inner_type_info.derived_types,
-        }
+        Self::type_info()
     }
 
     fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        self.instance.fields_ref(func)
+        func(&[{
+            FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: &*self.instance,
+            }
+        }])
     }
 
     fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        self.instance.fields_mut(func)
-    }
-
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-        self.instance.into_inner()
-    }
-
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-        self.instance.deref().inner_ref(func)
-    }
-
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-        self.instance.deref_mut().inner_mut(func)
+        func(&mut [{
+            FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: &mut *self.instance,
+            }
+        }])
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-        self.instance.deref_mut().set(value)
-    }
-
-    fn find_field(&self, name: &str, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
-        self.instance.deref().find_field(name, func)
-    }
-
-    fn find_field_mut(&mut self, name: &str, func: &mut dyn FnMut(Option<&mut dyn Reflect>)) {
-        self.instance.deref_mut().find_field_mut(name, func)
-    }
-
-    fn as_array(&self, func: &mut dyn FnMut(Option<&dyn ReflectArray>)) {
-        self.instance.deref().as_array(func)
-    }
-
-    fn as_array_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectArray>)) {
-        self.instance.deref_mut().as_array_mut(func)
-    }
-
-    fn as_list(&self, func: &mut dyn FnMut(Option<&dyn ReflectList>)) {
-        self.instance.deref().as_list(func)
-    }
-
-    fn as_list_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectList>)) {
-        self.instance.deref_mut().as_list_mut(func)
+        let this = std::mem::replace(self, value.take()?);
+        Ok(Box::new(this))
     }
 
     fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
@@ -799,19 +780,25 @@ impl Reflect for Script {
     }
 
     fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
-        self.instance.deref().field_direct_ref(index)
+        if index == 0 {
+            Some(FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: &*self.instance,
+            })
+        } else {
+            None
+        }
     }
 
     fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
-        self.instance.deref_mut().field_direct_mut(index)
-    }
-
-    fn inner_ref_direct(&self) -> &dyn Reflect {
-        self.instance.inner_ref_direct()
-    }
-
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-        self.instance.inner_mut_direct()
+        if index == 0 {
+            Some(FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: &mut *self.instance,
+            })
+        } else {
+            None
+        }
     }
 }
 
@@ -958,11 +945,7 @@ mod test {
             field: InheritableVariable::new_non_modified(3.21),
         })));
 
-        child.inner_mut(&mut |child| {
-            parent.inner_ref(&mut |parent| {
-                try_inherit_properties(child, parent, &[]).unwrap();
-            })
-        });
+        try_inherit_properties(&mut child, &parent, &[]).unwrap();
 
         assert_eq!(
             *child.script(0).unwrap().cast::<MyScript>().unwrap().field,
@@ -980,11 +963,7 @@ mod test {
             field: InheritableVariable::new_non_modified(3.21),
         });
 
-        child.inner_mut(&mut |child| {
-            parent.inner_ref(&mut |parent| {
-                try_inherit_properties(child, parent, &[]).unwrap();
-            })
-        });
+        try_inherit_properties(&mut child, &parent, &[]).unwrap();
 
         assert_eq!(*child.cast::<MyScript>().unwrap().field, 3.21);
     }
@@ -999,11 +978,7 @@ mod test {
             field: InheritableVariable::new_non_modified(3.21),
         }));
 
-        child.inner_mut(&mut |child| {
-            parent.inner_ref(&mut |parent| {
-                try_inherit_properties(child, parent, &[]).unwrap();
-            })
-        });
+        try_inherit_properties(&mut child, &parent, &[]).unwrap();
 
         assert_eq!(
             *child.as_ref().unwrap().cast::<MyScript>().unwrap().field,

--- a/fyrox-resource/src/graph.rs
+++ b/fyrox-resource/src/graph.rs
@@ -42,9 +42,7 @@ impl ResourceGraphNode {
 
         let header = resource.lock();
         if let ResourceState::Ok { ref data, .. } = header.state {
-            (**data).inner_ref(&mut |entity| {
-                collect_used_resources(entity, &mut dependent_resources);
-            });
+            collect_used_resources(data, &mut dependent_resources);
         }
 
         children.extend(

--- a/fyrox-resource/src/lib.rs
+++ b/fyrox-resource/src/lib.rs
@@ -637,46 +637,40 @@ pub fn collect_used_resources(
         return;
     }
 
-    entity.as_array(&mut |array| {
-        if let Some(array) = array {
-            for i in 0..array.reflect_len() {
-                if let Some(item) = array.reflect_index(i) {
-                    collect_used_resources(item, resources_collection)
-                }
+    if let Some(array) = entity.as_array() {
+        for i in 0..array.reflect_len() {
+            if let Some(item) = array.reflect_index(i) {
+                collect_used_resources(item, resources_collection)
             }
-
-            finished = true;
         }
-    });
+
+        finished = true;
+    }
 
     if finished {
         return;
     }
 
-    entity.as_inheritable_variable(&mut |inheritable| {
-        if let Some(inheritable) = inheritable {
-            collect_used_resources(inheritable.inner_value_ref(), resources_collection);
+    if let Some(inheritable) = entity.as_inheritable_variable() {
+        collect_used_resources(inheritable.inner_value_ref(), resources_collection);
 
-            finished = true;
-        }
-    });
+        finished = true;
+    }
 
     if finished {
         return;
     }
 
-    entity.as_hash_map(&mut |hash_map| {
-        if let Some(hash_map) = hash_map {
-            for i in 0..hash_map.reflect_len() {
-                if let Some((key, value)) = hash_map.reflect_get_at(i) {
-                    collect_used_resources(key, resources_collection);
-                    collect_used_resources(value, resources_collection);
-                }
+    if let Some(hash_map) = entity.as_hash_map() {
+        for i in 0..hash_map.reflect_len() {
+            if let Some((key, value)) = hash_map.reflect_get_at(i) {
+                collect_used_resources(key, resources_collection);
+                collect_used_resources(value, resources_collection);
             }
-
-            finished = true;
         }
-    });
+
+        finished = true;
+    }
 
     if finished {
         return;

--- a/fyrox-resource/src/lib.rs
+++ b/fyrox-resource/src/lib.rs
@@ -607,11 +607,7 @@ pub fn collect_used_resources(
 ) {
     #[inline(always)]
     fn type_is<T: Reflect>(entity: &dyn Reflect) -> bool {
-        let mut types_match = false;
-        entity.downcast_ref::<T>(&mut |v| {
-            types_match = v.is_some();
-        });
-        types_match
+        entity.downcast_ref::<T>().is_some()
     }
 
     // Skip potentially large chunks of numeric data, that definitely cannot contain any resources.
@@ -632,12 +628,10 @@ pub fn collect_used_resources(
         return;
     }
 
-    entity.downcast_ref::<UntypedResource>(&mut |v| {
-        if let Some(resource) = v {
-            resources_collection.insert(resource.clone());
-            finished = true;
-        }
-    });
+    if let Some(resource) = entity.downcast_ref::<UntypedResource>() {
+        resources_collection.insert(resource.clone());
+        finished = true;
+    }
 
     if finished {
         return;
@@ -690,7 +684,7 @@ pub fn collect_used_resources(
 
     entity.fields_ref(&mut |fields| {
         for field in fields {
-            collect_used_resources(field.value.field_value_as_reflect(), resources_collection);
+            collect_used_resources(field.value, resources_collection);
         }
     })
 }

--- a/fyrox-resource/src/state.rs
+++ b/fyrox-resource/src/state.rs
@@ -21,7 +21,6 @@
 //! A module that handles resource states.
 
 use crate::{core::reflect::prelude::*, ResourceData, ResourceLoadError, TypedResourceData};
-use fyrox_core::reflect::ReflectHandle;
 use std::any::{type_name, Any};
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
@@ -83,6 +82,19 @@ impl Display for LoadError {
     }
 }
 
+static CONTENT_METADATA: FieldMetadata = FieldMetadata {
+    name: "Content",
+    display_name: "Content",
+    tag: "",
+    read_only: false,
+    immutable_collection: false,
+    min_value: None,
+    max_value: None,
+    step: None,
+    precision: None,
+    doc: "",
+};
+
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct ResourceDataWrapper(pub Box<dyn ResourceData>);
@@ -99,121 +111,56 @@ impl Reflect for ResourceDataWrapper {
     }
 
     fn type_info_ref(&self) -> TypeInfo {
-        let inner_type_info = self.deref().type_info_ref();
-        TypeInfo {
-            source_path: inner_type_info.source_path,
-            type_name: inner_type_info.type_name,
-            assembly_name: inner_type_info.assembly_name,
-            doc_comment: inner_type_info.doc_comment,
-            derived_types: inner_type_info.derived_types,
-        }
+        Self::type_info()
     }
 
     fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-        Reflect::try_clone_box(&*self.0)
+        Some(Box::new(self.clone()))
     }
 
     fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        self.deref().fields_ref(func)
+        func(&[{
+            FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: &*self.0,
+            }
+        }])
     }
 
     fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        self.deref_mut().fields_mut(func)
-    }
-
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn inner_ref_direct(&self) -> &dyn Reflect {
-        self.deref().inner_ref_direct()
-    }
-
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-        self.deref_mut().inner_mut_direct()
-    }
-
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-        self.deref().inner_ref(func)
-    }
-
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-        self.deref_mut().inner_mut(func)
+        func(&mut [{
+            FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: &mut *self.0,
+            }
+        }])
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-        self.deref_mut().set(value)
+        let this = std::mem::replace(self, value.take()?);
+        Ok(Box::new(this))
     }
 
     fn field_direct_ref(&self, index: usize) -> Option<FieldRef<'_, '_>> {
-        self.deref().field_direct_ref(index)
+        if index == 0 {
+            Some(FieldRef {
+                metadata: &CONTENT_METADATA,
+                value: &*self.0,
+            })
+        } else {
+            None
+        }
     }
 
     fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut<'_, '_>> {
-        self.deref_mut().field_direct_mut(index)
-    }
-
-    fn set_field(
-        &mut self,
-        field: &str,
-        value: Box<dyn Reflect>,
-        func: &mut dyn FnMut(Result<Box<dyn Reflect>, SetFieldError>),
-    ) {
-        self.deref_mut().set_field(field, value, func)
-    }
-
-    fn find_field(&self, name: &str, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
-        self.deref().find_field(name, func)
-    }
-
-    fn find_field_mut(&mut self, name: &str, func: &mut dyn FnMut(Option<&mut dyn Reflect>)) {
-        self.deref_mut().find_field_mut(name, func)
-    }
-
-    fn as_array(&self, func: &mut dyn FnMut(Option<&dyn ReflectArray>)) {
-        self.deref().as_array(func)
-    }
-
-    fn as_array_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectArray>)) {
-        self.deref_mut().as_array_mut(func)
-    }
-
-    fn as_list(&self, func: &mut dyn FnMut(Option<&dyn ReflectList>)) {
-        self.deref().as_list(func)
-    }
-
-    fn as_list_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectList>)) {
-        self.deref_mut().as_list_mut(func)
-    }
-
-    fn as_inheritable_variable(
-        &self,
-        func: &mut dyn FnMut(Option<&dyn ReflectInheritableVariable>),
-    ) {
-        self.deref().as_inheritable_variable(func)
-    }
-
-    fn as_inheritable_variable_mut(
-        &mut self,
-        func: &mut dyn FnMut(Option<&mut dyn ReflectInheritableVariable>),
-    ) {
-        self.deref_mut().as_inheritable_variable_mut(func)
-    }
-
-    fn as_hash_map(&self, func: &mut dyn FnMut(Option<&dyn ReflectHashMap>)) {
-        self.deref().as_hash_map(func)
-    }
-
-    fn as_hash_map_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectHashMap>)) {
-        self.deref_mut().as_hash_map_mut(func)
-    }
-
-    fn as_handle(&self, func: &mut dyn FnMut(Option<&dyn ReflectHandle>)) {
-        self.deref().as_handle(func)
-    }
-
-    fn as_handle_mut(&mut self, func: &mut dyn FnMut(Option<&mut dyn ReflectHandle>)) {
-        self.deref_mut().as_handle_mut(func)
+        if index == 0 {
+            Some(FieldMut {
+                metadata: &CONTENT_METADATA,
+                value: &mut *self.0,
+            })
+        } else {
+            None
+        }
     }
 }
 

--- a/fyrox-resource/src/state.rs
+++ b/fyrox-resource/src/state.rs
@@ -21,7 +21,7 @@
 //! A module that handles resource states.
 
 use crate::{core::reflect::prelude::*, ResourceData, ResourceLoadError, TypedResourceData};
-use std::any::{type_name, Any};
+use std::any::Any;
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
 use std::{
@@ -82,87 +82,11 @@ impl Display for LoadError {
     }
 }
 
-static CONTENT_METADATA: FieldMetadata = FieldMetadata {
-    name: "Content",
-    display_name: "Content",
-    tag: "",
-    read_only: false,
-    immutable_collection: false,
-    min_value: None,
-    max_value: None,
-    step: None,
-    precision: None,
-    doc: "",
-};
-
 #[doc(hidden)]
-#[derive(Debug)]
-pub struct ResourceDataWrapper(pub Box<dyn ResourceData>);
-
-impl Reflect for ResourceDataWrapper {
-    fn type_info() -> TypeInfo {
-        TypeInfo {
-            source_path: file!(),
-            type_name: type_name::<Self>(),
-            assembly_name: env!("CARGO_PKG_NAME"),
-            doc_comment: "",
-            derived_types: &[],
-        }
-    }
-
-    fn type_info_ref(&self) -> TypeInfo {
-        Self::type_info()
-    }
-
-    fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-        Some(Box::new(self.clone()))
-    }
-
-    fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        func(&[{
-            FieldRef {
-                metadata: &CONTENT_METADATA,
-                value: &*self.0,
-            }
-        }])
-    }
-
-    fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        func(&mut [{
-            FieldMut {
-                metadata: &CONTENT_METADATA,
-                value: &mut *self.0,
-            }
-        }])
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-        let this = std::mem::replace(self, value.take()?);
-        Ok(Box::new(this))
-    }
-
-    fn field_direct_ref(&self, index: usize) -> Option<FieldRef<'_, '_>> {
-        if index == 0 {
-            Some(FieldRef {
-                metadata: &CONTENT_METADATA,
-                value: &*self.0,
-            })
-        } else {
-            None
-        }
-    }
-
-    fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut<'_, '_>> {
-        if index == 0 {
-            Some(FieldMut {
-                metadata: &CONTENT_METADATA,
-                value: &mut *self.0,
-            })
-        } else {
-            None
-        }
-    }
-}
+#[derive(Debug, Reflect)]
+pub struct ResourceDataWrapper(
+    #[reflect(deref, display_name = "Resource Data")] pub Box<dyn ResourceData>,
+);
 
 impl Deref for ResourceDataWrapper {
     type Target = dyn ResourceData;

--- a/fyrox-ui/src/control.rs
+++ b/fyrox-ui/src/control.rs
@@ -29,6 +29,7 @@ use crate::{
 use fyrox_core::{define_as_any_trait, pool::ObjectOrVariantHelper};
 
 use fyrox_core::algebra::Matrix3;
+use fyrox_graph::SceneGraphNode;
 use std::{
     any::Any,
     marker::PhantomData,
@@ -456,10 +457,10 @@ pub trait Control: BaseControl + Deref<Target = Widget> + DerefMut + Reflect + V
 // See ObjectOrVariantHelper for the cause of the indirection.
 impl<T: Control> ObjectOrVariantHelper<UiNode, T> for PhantomData<T> {
     fn convert_to_dest_type_helper(node: &UiNode) -> Option<&T> {
-        (node.0.deref() as &dyn Reflect).self_or_field_ref()
+        node.inner_ref().self_or_field_ref()
     }
 
     fn convert_to_dest_type_helper_mut(node: &mut UiNode) -> Option<&mut T> {
-        (node.0.deref_mut() as &mut dyn Reflect).self_or_field_mut()
+        node.inner_mut().self_or_field_mut()
     }
 }

--- a/fyrox-ui/src/inspector/editors/array.rs
+++ b/fyrox-ui/src/inspector/editors/array.rs
@@ -119,6 +119,7 @@ fn create_items<'a, 'b, T, I>(
     generate_property_string_values: bool,
     filter: PropertyFilter,
     name_column_width: f32,
+    hide_name_column: bool,
     base_path: String,
     has_parent_object: bool,
 ) -> Result<Vec<Item>, InspectorError>
@@ -163,6 +164,7 @@ where
                         generate_property_string_values,
                         filter: filter.clone(),
                         name_column_width,
+                        hide_name_column,
                         base_path: format!("{base_path}[{index}]"),
                         has_parent_object,
                     })?;
@@ -243,6 +245,7 @@ where
         ctx: &mut BuildContext,
         property_info: &FieldRef<'a, '_>,
         name_column_width: f32,
+        hide_name_column: bool,
         base_path: String,
         has_parent_object: bool,
     ) -> Result<Handle<ArrayEditor>, InspectorError> {
@@ -262,6 +265,7 @@ where
                 self.generate_property_string_values,
                 self.filter,
                 name_column_width,
+                hide_name_column,
                 base_path,
                 has_parent_object,
             )?
@@ -345,12 +349,14 @@ where
                     ctx.build_context,
                     ctx.property_info,
                     ctx.name_column_width,
+                    ctx.hide_name_column,
                     ctx.base_path.clone(),
                     ctx.has_parent_object,
                 )?;
                 editor
             },
             ctx.name_column_width,
+            false,
             ctx.build_context,
         );
 
@@ -374,6 +380,7 @@ where
             definition_container,
             environment,
             name_column_width,
+            hide_name_column,
             base_path,
             has_parent_object,
         } = ctx;
@@ -430,6 +437,7 @@ where
                             generate_property_string_values,
                             filter: filter.clone(),
                             name_column_width,
+                            hide_name_column,
                             base_path: format!("{base_path}[{index}]"),
                             has_parent_object,
                         })?

--- a/fyrox-ui/src/inspector/editors/array.rs
+++ b/fyrox-ui/src/inspector/editors/array.rs
@@ -293,7 +293,7 @@ where
 
 impl<T, const N: usize> ArrayPropertyEditorDefinition<T, N>
 where
-    T: Reflect,
+    T: Reflect + Clone,
 {
     pub fn new() -> Self {
         Self::default()
@@ -302,7 +302,7 @@ where
 
 impl<T, const N: usize> Default for ArrayPropertyEditorDefinition<T, N>
 where
-    T: Reflect,
+    T: Reflect + Clone,
 {
     fn default() -> Self {
         Self {
@@ -313,7 +313,7 @@ where
 
 impl<T, const N: usize> PropertyEditorDefinition for ArrayPropertyEditorDefinition<T, N>
 where
-    T: Reflect,
+    T: Reflect + Clone,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<[T; N]>()

--- a/fyrox-ui/src/inspector/editors/cell.rs
+++ b/fyrox-ui/src/inspector/editors/cell.rs
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 use crate::{
-    core::{reflect::prelude::*, reflect::FieldValue},
+    core::reflect::prelude::*,
     inspector::{
         editors::{
             PropertyEditorBuildContext, PropertyEditorDefinition, PropertyEditorInstance,
@@ -38,7 +38,7 @@ use std::{
 
 pub struct CellPropertyEditorDefinition<T>
 where
-    T: FieldValue + Copy,
+    T: Reflect + Copy,
 {
     #[allow(dead_code)]
     phantom: PhantomDataSendSync<T>,
@@ -46,7 +46,7 @@ where
 
 impl<T> CellPropertyEditorDefinition<T>
 where
-    T: FieldValue + Copy,
+    T: Reflect + Copy,
 {
     pub fn new() -> Self {
         Self {
@@ -57,7 +57,7 @@ where
 
 impl<T> Debug for CellPropertyEditorDefinition<T>
 where
-    T: Reflect + FieldValue + Copy,
+    T: Reflect + Copy,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "CellPropertyEditorDefinition")
@@ -66,7 +66,7 @@ where
 
 impl<T> PropertyEditorDefinition for CellPropertyEditorDefinition<T>
 where
-    T: Reflect + FieldValue + Copy,
+    T: Reflect + Copy,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<Cell<T>>()

--- a/fyrox-ui/src/inspector/editors/cell.rs
+++ b/fyrox-ui/src/inspector/editors/cell.rs
@@ -112,6 +112,7 @@ where
                     generate_property_string_values: ctx.generate_property_string_values,
                     filter: ctx.filter,
                     name_column_width: ctx.name_column_width,
+                    hide_name_column: ctx.hide_name_column,
                     base_path: ctx.base_path.clone(),
                     has_parent_object: ctx.has_parent_object,
                 })
@@ -161,6 +162,7 @@ where
                     generate_property_string_values: ctx.generate_property_string_values,
                     filter: ctx.filter,
                     name_column_width: ctx.name_column_width,
+                    hide_name_column: ctx.hide_name_column,
                     base_path: ctx.base_path.clone(),
                     has_parent_object: ctx.has_parent_object,
                 });

--- a/fyrox-ui/src/inspector/editors/collection.rs
+++ b/fyrox-ui/src/inspector/editors/collection.rs
@@ -224,6 +224,7 @@ fn create_items<'a, 'b, T, I>(
     filter: PropertyFilter,
     immutable_collection: bool,
     name_column_width: f32,
+    hide_name_column: bool,
     base_path: String,
     has_parent_object: bool,
 ) -> Result<Vec<Item>, InspectorError>
@@ -266,6 +267,7 @@ where
                         generate_property_string_values,
                         filter: filter.clone(),
                         name_column_width,
+                        hide_name_column,
                         base_path: format!("{base_path}[{index}]"),
                         has_parent_object,
                     })?;
@@ -371,6 +373,7 @@ where
         ctx: &mut BuildContext,
         property_info: &FieldRef<'a, '_>,
         name_column_width: f32,
+        hide_name_column: bool,
         base_path: String,
         has_parent_object: bool,
     ) -> Result<Handle<CollectionEditor<T>>, InspectorError> {
@@ -391,6 +394,7 @@ where
                 self.filter,
                 self.immutable_collection,
                 name_column_width,
+                hide_name_column,
                 base_path,
                 has_parent_object,
             )?
@@ -502,12 +506,14 @@ where
                     ctx.build_context,
                     ctx.property_info,
                     ctx.name_column_width,
+                    ctx.hide_name_column,
                     ctx.base_path.clone(),
                     ctx.has_parent_object,
                 )?;
                 editor
             },
             ctx.name_column_width,
+            ctx.hide_name_column,
             ctx.build_context,
         );
 
@@ -531,6 +537,7 @@ where
             generate_property_string_values,
             filter,
             name_column_width,
+            hide_name_column,
             base_path,
             has_parent_object,
         } = ctx;
@@ -558,6 +565,7 @@ where
                 filter,
                 property_info.immutable_collection,
                 name_column_width,
+                hide_name_column,
                 base_path,
                 has_parent_object,
             )?;
@@ -607,6 +615,7 @@ where
                                 generate_property_string_values,
                                 filter: filter.clone(),
                                 name_column_width,
+                                hide_name_column,
                                 base_path: format!("{base_path}[{index}]"),
                                 has_parent_object,
                             })?

--- a/fyrox-ui/src/inspector/editors/enumeration.rs
+++ b/fyrox-ui/src/inspector/editors/enumeration.rs
@@ -168,6 +168,7 @@ impl<T: InspectableEnum> Control for EnumPropertyEditor<T> {
                 generate_property_string_values: self.generate_property_string_values,
                 filter: self.filter.clone(),
                 name_column_width: self.name_column_width,
+                hide_name_column: false,
                 base_path: self.base_path.clone(),
                 has_parent_object: self.has_parent_object,
             });
@@ -276,6 +277,7 @@ impl EnumPropertyEditorBuilder {
             generate_property_string_values: self.generate_property_string_values,
             filter: self.filter.clone(),
             name_column_width,
+            hide_name_column: false,
             base_path: base_path.clone(),
             has_parent_object,
         });
@@ -423,6 +425,7 @@ where
                 editor
             },
             ctx.name_column_width,
+            ctx.hide_name_column,
             ctx.build_context,
         );
 
@@ -471,6 +474,7 @@ where
                 generate_property_string_values: ctx.generate_property_string_values,
                 filter: ctx.filter,
                 name_column_width: ctx.name_column_width,
+                hide_name_column: false,
                 base_path: ctx.base_path.clone(),
                 has_parent_object: ctx.has_parent_object,
             });

--- a/fyrox-ui/src/inspector/editors/inherit.rs
+++ b/fyrox-ui/src/inspector/editors/inherit.rs
@@ -25,8 +25,8 @@ use crate::button::Button;
 use crate::{
     button::{ButtonBuilder, ButtonMessage},
     core::{
-        pool::Handle, reflect::prelude::*, reflect::FieldValue, uuid_provider,
-        variable::InheritableVariable, visitor::prelude::*, PhantomDataSendSync,
+        pool::Handle, reflect::prelude::*, uuid_provider, variable::InheritableVariable,
+        visitor::prelude::*, PhantomDataSendSync,
     },
     grid::{Column, GridBuilder, Row},
     image::ImageBuilder,
@@ -184,7 +184,7 @@ impl InheritablePropertyEditorBuilder {
 
 pub struct InheritablePropertyEditorDefinition<T>
 where
-    T: FieldValue,
+    T: Reflect + Clone + PartialEq,
 {
     #[allow(dead_code)]
     phantom: PhantomDataSendSync<T>,
@@ -192,7 +192,7 @@ where
 
 impl<T> InheritablePropertyEditorDefinition<T>
 where
-    T: FieldValue,
+    T: Reflect + Clone + PartialEq,
 {
     pub fn new() -> Self {
         Self {
@@ -203,7 +203,7 @@ where
 
 impl<T> Debug for InheritablePropertyEditorDefinition<T>
 where
-    T: Reflect + FieldValue,
+    T: Reflect + Clone + PartialEq,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "InheritablePropertyEditorDefinition")
@@ -212,7 +212,7 @@ where
 
 impl<T> PropertyEditorDefinition for InheritablePropertyEditorDefinition<T>
 where
-    T: Reflect + FieldValue,
+    T: Reflect + Clone + PartialEq,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<InheritableVariable<T>>()

--- a/fyrox-ui/src/inspector/editors/inherit.rs
+++ b/fyrox-ui/src/inspector/editors/inherit.rs
@@ -218,7 +218,8 @@ where
             layer_index: ctx.layer_index + 1,
             generate_property_string_values: ctx.generate_property_string_values,
             filter: ctx.filter,
-            name_column_width: 0.0,
+            name_column_width: ctx.name_column_width,
+            hide_name_column: true,
             base_path: ctx.base_path.clone(),
             has_parent_object: ctx.has_parent_object,
         });

--- a/fyrox-ui/src/inspector/editors/inherit.rs
+++ b/fyrox-ui/src/inspector/editors/inherit.rs
@@ -21,13 +21,13 @@
 //! Property editor for [`InheritableVariable`]. It acts like a proxy to inner property, but also
 //!  adds a special "revert" button that is used to revert value to its parent's value.
 
-use crate::button::Button;
 use crate::{
-    button::{ButtonBuilder, ButtonMessage},
+    button::{Button, ButtonBuilder, ButtonMessage},
     core::{
-        pool::Handle, reflect::prelude::*, uuid_provider, variable::InheritableVariable,
+        pool::Handle, reflect::prelude::*, type_traits::prelude::*, variable::InheritableVariable,
         visitor::prelude::*, PhantomDataSendSync,
     },
+    define_widget_deref,
     grid::{Column, GridBuilder, Row},
     image::ImageBuilder,
     inspector::{
@@ -35,7 +35,8 @@ use crate::{
             PropertyEditorBuildContext, PropertyEditorDefinition, PropertyEditorInstance,
             PropertyEditorMessageContext, PropertyEditorTranslationContext,
         },
-        FieldAction, InheritableAction, InspectorError, PropertyChanged,
+        FieldAction, InheritableAction, Inspector, InspectorBuilder, InspectorContext,
+        InspectorContextArgs, InspectorError, InspectorMessage, PropertyChanged,
     },
     message::{MessageData, UiMessage},
     resources::REVERT_ICON,
@@ -49,39 +50,26 @@ use fyrox_graph::SceneGraph;
 use std::{
     any::TypeId,
     fmt::{Debug, Formatter},
-    ops::{Deref, DerefMut},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum InheritablePropertyEditorMessage {
     Revert,
     Modified(bool),
+    PropertyChanged(PropertyChanged),
 }
 impl MessageData for InheritablePropertyEditorMessage {}
 
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone, Visit, Reflect, TypeUuidProvider)]
+#[type_uuid(id = "d5dce72c-a54b-4754-96a3-2e923eaa802f")]
 #[reflect(derived_type = "UiNode")]
 pub struct InheritablePropertyEditor {
     widget: Widget,
     revert: Handle<Button>,
-    inner_editor: Handle<UiNode>,
+    inspector: Handle<UiNode>,
 }
 
-impl Deref for InheritablePropertyEditor {
-    type Target = Widget;
-
-    fn deref(&self) -> &Self::Target {
-        &self.widget
-    }
-}
-
-impl DerefMut for InheritablePropertyEditor {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.widget
-    }
-}
-
-uuid_provider!(InheritablePropertyEditor = "d5dce72c-a54b-4754-96a3-2e923eaa802f");
+define_widget_deref!(InheritablePropertyEditor);
 
 impl Control for InheritablePropertyEditor {
     fn handle_routed_message(&mut self, ui: &mut UserInterface, message: &mut UiMessage) {
@@ -93,26 +81,20 @@ impl Control for InheritablePropertyEditor {
             if message.destination() == self.handle {
                 ui.send(self.revert, WidgetMessage::Visibility(*modified));
             }
-        }
-
-        // Re-cast messages from inner editor as message from this editor.
-        // If anything is listening to messages from this editor, let them hear the messages from the inner
-        // editor as if they were coming from this editor, but *do not* re-cast messages to the inner editor
-        // to this editor. Particularly, when the inner editor is made invisible, that does not mean that
-        // this editor should be invisible.
-        if message.destination() == self.inner_editor
-            && message.direction == MessageDirection::FromWidget
+        } else if let Some(InspectorMessage::PropertyChanged(property_changed)) =
+            message.data_from(self.inspector)
         {
-            let mut clone = message.clone();
-            clone.destination = self.handle;
-            ui.send_message(clone);
+            ui.post(
+                self.handle(),
+                InheritablePropertyEditorMessage::PropertyChanged(property_changed.clone()),
+            )
         }
     }
 }
 
 struct InheritablePropertyEditorBuilder {
     widget_builder: WidgetBuilder,
-    inner_editor: Handle<UiNode>,
+    inspector: Handle<UiNode>,
     container: Handle<UiNode>,
     modified: bool,
 }
@@ -121,14 +103,14 @@ impl InheritablePropertyEditorBuilder {
     pub fn new(widget_builder: WidgetBuilder) -> Self {
         Self {
             widget_builder,
-            inner_editor: Handle::NONE,
+            inspector: Handle::NONE,
             container: Handle::NONE,
             modified: false,
         }
     }
 
     pub fn with_inner_editor(mut self, inner_editor: Handle<UiNode>) -> Self {
-        self.inner_editor = inner_editor;
+        self.inspector = inner_editor;
         self
     }
 
@@ -143,32 +125,34 @@ impl InheritablePropertyEditorBuilder {
     }
 
     pub fn build(self, ctx: &mut BuildContext) -> Handle<InheritablePropertyEditor> {
-        let revert;
-        let grid = GridBuilder::new(WidgetBuilder::new().with_child(self.container).with_child({
-            revert = ButtonBuilder::new(
+        let revert = ButtonBuilder::new(
+            WidgetBuilder::new()
+                .with_visibility(self.modified)
+                .with_width(22.0)
+                .with_height(22.0)
+                .with_vertical_alignment(VerticalAlignment::Top)
+                .with_tooltip(make_simple_tooltip(ctx, "Revert To Parent"))
+                .with_margin(Thickness::uniform(1.0))
+                .on_column(1),
+        )
+        .with_content(
+            ImageBuilder::new(
                 WidgetBuilder::new()
-                    .with_visibility(self.modified)
-                    .with_width(22.0)
-                    .with_height(22.0)
-                    .with_vertical_alignment(VerticalAlignment::Top)
-                    .with_tooltip(make_simple_tooltip(ctx, "Revert To Parent"))
-                    .with_margin(Thickness::uniform(1.0))
-                    .on_column(1),
+                    .with_background(ctx.style.property(Style::BRUSH_BRIGHTEST))
+                    .with_margin(Thickness::uniform(3.0))
+                    .with_width(16.0)
+                    .with_height(16.0),
             )
-            .with_content(
-                ImageBuilder::new(
-                    WidgetBuilder::new()
-                        .with_background(ctx.style.property(Style::BRUSH_BRIGHTEST))
-                        .with_margin(Thickness::uniform(3.0))
-                        .with_width(16.0)
-                        .with_height(16.0),
-                )
-                .with_opt_texture(REVERT_ICON.clone())
-                .build(ctx),
-            )
-            .build(ctx);
-            revert
-        }))
+            .with_opt_texture(REVERT_ICON.clone())
+            .build(ctx),
+        )
+        .build(ctx);
+
+        let grid = GridBuilder::new(
+            WidgetBuilder::new()
+                .with_child(self.container)
+                .with_child(revert),
+        )
         .add_row(Row::auto())
         .add_column(Column::stretch())
         .add_column(Column::auto())
@@ -177,7 +161,7 @@ impl InheritablePropertyEditorBuilder {
         ctx.add(InheritablePropertyEditor {
             widget: self.widget_builder.with_child(grid).build(ctx),
             revert,
-            inner_editor: self.inner_editor,
+            inspector: self.inspector,
         })
     }
 }
@@ -222,143 +206,93 @@ where
         &self,
         ctx: PropertyEditorBuildContext,
     ) -> Result<PropertyEditorInstance, InspectorError> {
-        if let Some(definition) = ctx
-            .definition_container
-            .definitions()
-            .get(&TypeId::of::<T>())
-        {
-            let property_info = ctx.property_info;
+        let property_info = ctx.property_info;
 
-            let value = property_info.cast_value::<InheritableVariable<T>>()?;
+        let value = property_info.cast_value::<InheritableVariable<T>>()?;
 
-            let proxy_property_info = FieldRef {
-                metadata: &FieldMetadata {
-                    name: property_info.name,
-                    display_name: property_info.display_name,
-                    read_only: property_info.read_only,
-                    immutable_collection: property_info.immutable_collection,
-                    min_value: property_info.min_value,
-                    max_value: property_info.max_value,
-                    step: property_info.step,
-                    precision: property_info.precision,
-                    tag: property_info.tag,
-                    doc: property_info.doc,
-                },
-                value: &**value,
-            };
+        let inspector_context = InspectorContext::from_object(InspectorContextArgs {
+            object: value,
+            ctx: ctx.build_context,
+            definition_container: ctx.definition_container.clone(),
+            environment: ctx.environment.clone(),
+            layer_index: ctx.layer_index + 1,
+            generate_property_string_values: ctx.generate_property_string_values,
+            filter: ctx.filter,
+            name_column_width: 0.0,
+            base_path: ctx.base_path.clone(),
+            has_parent_object: ctx.has_parent_object,
+        });
 
-            let instance =
-                definition
-                    .property_editor
-                    .create_instance(PropertyEditorBuildContext {
-                        build_context: ctx.build_context,
-                        property_info: &proxy_property_info,
-                        environment: ctx.environment.clone(),
-                        definition_container: ctx.definition_container.clone(),
-                        layer_index: ctx.layer_index,
-                        generate_property_string_values: ctx.generate_property_string_values,
-                        filter: ctx.filter,
-                        name_column_width: ctx.name_column_width,
-                        base_path: ctx.base_path.clone(),
-                        has_parent_object: ctx.has_parent_object,
-                    })?;
+        let editor = InspectorBuilder::new(WidgetBuilder::new())
+            .with_context(inspector_context)
+            .build(ctx.build_context)
+            .to_base();
 
-            let wrapper = InheritablePropertyEditorBuilder::new(WidgetBuilder::new())
-                .with_container(match instance {
-                    PropertyEditorInstance::Simple { editor } => editor,
-                    PropertyEditorInstance::Custom { container, .. } => container,
-                })
-                .with_inner_editor(match instance {
-                    PropertyEditorInstance::Simple { editor } => editor,
-                    PropertyEditorInstance::Custom { editor, .. } => editor,
-                })
-                .with_modified(
-                    ctx.has_parent_object
-                        && ctx
-                            .property_info
-                            .cast_value::<InheritableVariable<T>>()?
-                            .is_modified(),
-                )
-                .build(ctx.build_context)
-                .to_base();
+        let wrapper = InheritablePropertyEditorBuilder::new(WidgetBuilder::new())
+            .with_container(editor)
+            .with_inner_editor(editor)
+            .with_modified(
+                ctx.has_parent_object
+                    && ctx
+                        .property_info
+                        .cast_value::<InheritableVariable<T>>()?
+                        .is_modified(),
+            )
+            .build(ctx.build_context)
+            .to_base();
 
-            Ok(match instance {
-                PropertyEditorInstance::Simple { .. } => {
-                    PropertyEditorInstance::Simple { editor: wrapper }
-                }
-                PropertyEditorInstance::Custom { .. } => PropertyEditorInstance::Custom {
-                    container: wrapper,
-                    editor: wrapper,
-                },
-            })
-        } else {
-            Err(InspectorError::Custom("No editor!".to_string()))
-        }
+        Ok(PropertyEditorInstance::Simple { editor: wrapper })
     }
 
     fn create_message(
         &self,
         ctx: PropertyEditorMessageContext,
     ) -> Result<Option<UiMessage>, InspectorError> {
-        if let Some(definition) = ctx
-            .definition_container
-            .definitions()
-            .get(&TypeId::of::<T>())
-        {
-            let instance = ctx
-                .ui
-                .node(ctx.instance)
-                .cast::<InheritablePropertyEditor>()
-                .unwrap();
+        let instance = ctx
+            .ui
+            .node(ctx.instance)
+            .cast::<InheritablePropertyEditor>()
+            .unwrap();
 
-            let is_modified = ctx.has_parent_object
-                && ctx
-                    .property_info
-                    .cast_value::<InheritableVariable<T>>()?
-                    .is_modified();
-            ctx.ui.send_sync(
-                instance.handle,
-                InheritablePropertyEditorMessage::Modified(is_modified),
-            );
+        let is_modified = ctx.has_parent_object
+            && ctx
+                .property_info
+                .cast_value::<InheritableVariable<T>>()?
+                .is_modified();
+        ctx.ui.send_sync(
+            instance.handle,
+            InheritablePropertyEditorMessage::Modified(is_modified),
+        );
 
-            let property_info = ctx.property_info;
+        let property_info = ctx.property_info;
 
-            let value = property_info.cast_value::<InheritableVariable<T>>()?;
+        let value = property_info.cast_value::<InheritableVariable<T>>()?;
 
-            let proxy_property_info = FieldRef {
-                metadata: &FieldMetadata {
-                    name: property_info.name,
-                    display_name: property_info.display_name,
-                    read_only: property_info.read_only,
-                    immutable_collection: property_info.immutable_collection,
-                    min_value: property_info.min_value,
-                    max_value: property_info.max_value,
-                    step: property_info.step,
-                    precision: property_info.precision,
-                    tag: property_info.tag,
-                    doc: property_info.doc,
-                },
-                value: &**value,
-            };
+        let mut error_group = Vec::new();
 
-            return definition
-                .property_editor
-                .create_message(PropertyEditorMessageContext {
-                    property_info: &proxy_property_info,
-                    environment: ctx.environment.clone(),
-                    definition_container: ctx.definition_container.clone(),
-                    instance: instance.inner_editor,
-                    layer_index: ctx.layer_index,
-                    ui: ctx.ui,
-                    generate_property_string_values: ctx.generate_property_string_values,
-                    filter: ctx.filter,
-                    name_column_width: ctx.name_column_width,
-                    base_path: ctx.base_path.clone(),
-                    has_parent_object: ctx.has_parent_object,
-                });
+        let inspector_context = ctx
+            .ui
+            .node(instance.inspector)
+            .cast::<Inspector>()
+            .expect("Must be Inspector!")
+            .context()
+            .clone();
+        if let Err(e) = inspector_context.sync(
+            value,
+            ctx.ui,
+            ctx.layer_index + 1,
+            ctx.generate_property_string_values,
+            ctx.filter,
+            ctx.base_path.clone(),
+        ) {
+            error_group.extend(e)
         }
 
-        Err(InspectorError::Custom("No editor!".to_string()))
+        if error_group.is_empty() {
+            Ok(None)
+        } else {
+            Err(InspectorError::Group(error_group))
+        }
     }
 
     fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
@@ -369,20 +303,13 @@ where
             });
         }
 
-        // Try to translate other messages using inner property editor.
-        if let Some(definition) = ctx
-            .definition_container
-            .definitions()
-            .get(&TypeId::of::<T>())
-        {
-            return definition.property_editor.translate_message(
-                PropertyEditorTranslationContext {
-                    environment: ctx.environment.clone(),
-                    name: ctx.name,
-                    message: ctx.message,
-                    definition_container: ctx.definition_container.clone(),
-                },
-            );
+        if let Some(InheritablePropertyEditorMessage::PropertyChanged(msg)) = ctx.message.data() {
+            if ctx.message.direction() == MessageDirection::FromWidget {
+                return Some(PropertyChanged {
+                    name: ctx.name.to_owned(),
+                    action: FieldAction::InspectableAction(Box::new(msg.clone())),
+                });
+            }
         }
 
         None

--- a/fyrox-ui/src/inspector/editors/inspectable.rs
+++ b/fyrox-ui/src/inspector/editors/inspectable.rs
@@ -99,6 +99,7 @@ where
             generate_property_string_values: ctx.generate_property_string_values,
             filter: ctx.filter,
             name_column_width: ctx.name_column_width,
+            hide_name_column: false,
             base_path: ctx.base_path.clone(),
             has_parent_object: ctx.has_parent_object,
         });
@@ -117,6 +118,7 @@ where
                 editor
             },
             ctx.name_column_width,
+            ctx.hide_name_column,
             ctx.build_context,
         );
 

--- a/fyrox-ui/src/inspector/editors/mod.rs
+++ b/fyrox-ui/src/inspector/editors/mod.rs
@@ -806,13 +806,22 @@ impl PropertyEditorDefinitionContainer {
     /// Panic if these types already have editor definitions.
     pub fn register_inheritable_vec_collection<T>(&self)
     where
-        T: CollectionItem + FieldValue,
+        T: CollectionItem + PartialEq,
     {
         assert!(self
             .insert(VecCollectionPropertyEditorDefinition::<T>::new())
             .is_none());
         assert!(self
             .insert(InheritablePropertyEditorDefinition::<Vec<T>>::new())
+            .is_none());
+    }
+
+    pub fn register_vec_collection<T>(&self)
+    where
+        T: CollectionItem,
+    {
+        assert!(self
+            .insert(VecCollectionPropertyEditorDefinition::<T>::new())
             .is_none());
     }
 
@@ -826,7 +835,7 @@ impl PropertyEditorDefinitionContainer {
     /// Panic if these types already have editor definitions.
     pub fn register_inheritable_inspectable<T>(&self)
     where
-        T: Reflect + FieldValue,
+        T: Reflect + Clone + PartialEq,
     {
         assert!(self
             .insert(InspectablePropertyEditorDefinition::<T>::new())
@@ -836,9 +845,18 @@ impl PropertyEditorDefinitionContainer {
             .is_none());
     }
 
+    pub fn register_inspectable<T>(&self)
+    where
+        T: Reflect,
+    {
+        assert!(self
+            .insert(InspectablePropertyEditorDefinition::<T>::new())
+            .is_none());
+    }
+
     pub fn register_inheritable_styleable_inspectable<T>(&self)
     where
-        T: Reflect + FieldValue + Clone + PartialEq,
+        T: Reflect + Clone + PartialEq,
     {
         assert!(self
             .insert(InspectablePropertyEditorDefinition::<T>::new())
@@ -860,7 +878,7 @@ impl PropertyEditorDefinitionContainer {
     /// Panic if these types already have editor definitions.
     pub fn register_inheritable_enum<T, E: Debug>(&self)
     where
-        T: InspectableEnum + FieldValue + VariantNames + AsRef<str> + FromStr<Err = E> + Debug,
+        T: InspectableEnum + VariantNames + AsRef<str> + FromStr<Err = E> + Debug + PartialEq,
     {
         assert!(self
             .insert(EnumPropertyEditorDefinition::<T>::new())
@@ -870,15 +888,18 @@ impl PropertyEditorDefinitionContainer {
             .is_none());
     }
 
+    pub fn register_enum<T, E: Debug>(&self)
+    where
+        T: InspectableEnum + VariantNames + AsRef<str> + FromStr<Err = E> + Debug,
+    {
+        assert!(self
+            .insert(EnumPropertyEditorDefinition::<T>::new())
+            .is_none());
+    }
+
     pub fn register_inheritable_styleable_enum<T, E: Debug>(&self)
     where
-        T: InspectableEnum
-            + FieldValue
-            + VariantNames
-            + AsRef<str>
-            + FromStr<Err = E>
-            + Debug
-            + PartialEq,
+        T: InspectableEnum + VariantNames + AsRef<str> + FromStr<Err = E> + Debug + PartialEq,
     {
         assert!(self
             .insert(EnumPropertyEditorDefinition::<T>::new())
@@ -900,7 +921,7 @@ impl PropertyEditorDefinitionContainer {
     /// Panic if these types already have editor definitions.
     pub fn register_inheritable_option<T>(&self)
     where
-        T: InspectableEnum + FieldValue + Default,
+        T: InspectableEnum + Default + PartialEq,
     {
         assert!(self
             .insert(EnumPropertyEditorDefinition::<T>::new_optional())

--- a/fyrox-ui/src/inspector/editors/mod.rs
+++ b/fyrox-ui/src/inspector/editors/mod.rs
@@ -183,6 +183,7 @@ pub struct PropertyEditorBuildContext<'a, 'b, 'c, 'd> {
     pub filter: PropertyFilter,
     /// Width of the property name column.
     pub name_column_width: f32,
+    pub hide_name_column: bool,
     pub base_path: String,
     /// A flag, that defines whether the inspectable object has a parent object from which it can
     /// obtain initial property values when clicking on the "Revert" button. This flag is used only for
@@ -223,6 +224,7 @@ pub struct PropertyEditorMessageContext<'a, 'b, 'c> {
     pub filter: PropertyFilter,
     /// Width of the property name column.
     pub name_column_width: f32,
+    pub hide_name_column: bool,
     pub base_path: String,
     /// A flag, that defines whether the inspectable object has a parent object from which it can
     /// obtain initial property values when clicking on the "Revert" button. This flag is used only for

--- a/fyrox-ui/src/inspector/editors/refcell.rs
+++ b/fyrox-ui/src/inspector/editors/refcell.rs
@@ -19,17 +19,20 @@
 // SOFTWARE.
 
 use crate::{
-    core::reflect::prelude::*,
+    core::{pool::Handle, reflect::prelude::*, PhantomDataSendSync},
     inspector::{
         editors::{
             PropertyEditorBuildContext, PropertyEditorDefinition, PropertyEditorInstance,
             PropertyEditorMessageContext, PropertyEditorTranslationContext,
         },
-        InspectorError, PropertyChanged,
+        make_expander_container, FieldAction, Inspector, InspectorBuilder, InspectorContext,
+        InspectorContextArgs, InspectorError, InspectorMessage, PropertyChanged,
     },
-    message::UiMessage,
+    message::{MessageDirection, UiMessage},
+    widget::WidgetBuilder,
+    UiNode,
 };
-use fyrox_core::PhantomDataSendSync;
+use fyrox_graph::SceneGraph;
 use std::{
     any::TypeId,
     cell::RefCell,
@@ -76,117 +79,88 @@ where
         &self,
         ctx: PropertyEditorBuildContext,
     ) -> Result<PropertyEditorInstance, InspectorError> {
-        if let Some(definition) = ctx
-            .definition_container
-            .definitions()
-            .get(&TypeId::of::<T>())
-        {
-            let property_info = ctx.property_info;
+        let value = ctx.property_info.cast_value::<RefCell<T>>()?;
 
-            let value = property_info.cast_value::<RefCell<T>>()?.borrow();
+        let inspector_context = InspectorContext::from_object(InspectorContextArgs {
+            object: value,
+            ctx: ctx.build_context,
+            definition_container: ctx.definition_container.clone(),
+            environment: ctx.environment.clone(),
+            layer_index: ctx.layer_index + 1,
+            generate_property_string_values: ctx.generate_property_string_values,
+            filter: ctx.filter,
+            name_column_width: ctx.name_column_width,
+            hide_name_column: false,
+            base_path: ctx.base_path.clone(),
+            has_parent_object: ctx.has_parent_object,
+        });
 
-            let proxy_property_info = FieldRef {
-                metadata: &FieldMetadata {
-                    name: property_info.name,
-                    display_name: property_info.display_name,
-                    read_only: property_info.read_only,
-                    immutable_collection: property_info.immutable_collection,
-                    min_value: property_info.min_value,
-                    max_value: property_info.max_value,
-                    step: property_info.step,
-                    precision: property_info.precision,
-                    tag: property_info.tag,
-                    doc: property_info.doc,
-                },
-                value: &*value,
-            };
+        let editor;
+        let container = make_expander_container(
+            ctx.layer_index,
+            ctx.property_info.display_name,
+            ctx.property_info.doc,
+            Handle::<UiNode>::NONE,
+            {
+                editor = InspectorBuilder::new(WidgetBuilder::new())
+                    .with_context(inspector_context)
+                    .build(ctx.build_context)
+                    .to_base();
+                editor
+            },
+            ctx.name_column_width,
+            ctx.hide_name_column,
+            ctx.build_context,
+        );
 
-            definition
-                .property_editor
-                .create_instance(PropertyEditorBuildContext {
-                    build_context: ctx.build_context,
-                    property_info: &proxy_property_info,
-                    environment: ctx.environment.clone(),
-                    definition_container: ctx.definition_container.clone(),
-                    layer_index: ctx.layer_index,
-                    generate_property_string_values: ctx.generate_property_string_values,
-                    filter: ctx.filter,
-                    name_column_width: ctx.name_column_width,
-                    hide_name_column: ctx.hide_name_column,
-                    base_path: ctx.base_path.clone(),
-                    has_parent_object: ctx.has_parent_object,
-                })
-        } else {
-            Err(InspectorError::Custom("No editor!".to_string()))
-        }
+        Ok(PropertyEditorInstance::Custom { container, editor })
     }
 
+    /// Instead of creating a message to update its widget,
+    /// call [InspectorContext::sync] to directly send whatever messages are necessary
+    /// and return None.
     fn create_message(
         &self,
         ctx: PropertyEditorMessageContext,
     ) -> Result<Option<UiMessage>, InspectorError> {
-        if let Some(definition) = ctx
-            .definition_container
-            .definitions()
-            .get(&TypeId::of::<T>())
-        {
-            let property_info = ctx.property_info;
+        let value = ctx.property_info.cast_value::<RefCell<T>>()?;
 
-            let value = ctx.property_info.cast_value::<RefCell<T>>()?.borrow();
+        let mut error_group = Vec::new();
 
-            let proxy_property_info = FieldRef {
-                metadata: &FieldMetadata {
-                    name: property_info.name,
-                    display_name: property_info.display_name,
-                    read_only: property_info.read_only,
-                    immutable_collection: property_info.immutable_collection,
-                    min_value: property_info.min_value,
-                    max_value: property_info.max_value,
-                    step: property_info.step,
-                    precision: property_info.precision,
-                    tag: property_info.tag,
-                    doc: property_info.doc,
-                },
-                value: &*value,
-            };
-
-            return definition
-                .property_editor
-                .create_message(PropertyEditorMessageContext {
-                    property_info: &proxy_property_info,
-                    environment: ctx.environment.clone(),
-                    definition_container: ctx.definition_container.clone(),
-                    instance: ctx.instance,
-                    layer_index: ctx.layer_index,
-                    ui: ctx.ui,
-                    generate_property_string_values: ctx.generate_property_string_values,
-                    filter: ctx.filter,
-                    name_column_width: ctx.name_column_width,
-                    hide_name_column: ctx.hide_name_column,
-                    base_path: ctx.base_path.clone(),
-                    has_parent_object: ctx.has_parent_object,
-                });
+        let inspector_context = ctx
+            .ui
+            .node(ctx.instance)
+            .cast::<Inspector>()
+            .expect("Must be Inspector!")
+            .context()
+            .clone();
+        if let Err(e) = inspector_context.sync(
+            value,
+            ctx.ui,
+            ctx.layer_index + 1,
+            ctx.generate_property_string_values,
+            ctx.filter,
+            ctx.base_path.clone(),
+        ) {
+            error_group.extend(e)
         }
 
-        Err(InspectorError::Custom("No editor!".to_string()))
+        if error_group.is_empty() {
+            Ok(None)
+        } else {
+            Err(InspectorError::Group(error_group))
+        }
     }
 
     fn translate_message(&self, ctx: PropertyEditorTranslationContext) -> Option<PropertyChanged> {
-        // Try translate other messages using inner property editor.
-        if let Some(definition) = ctx
-            .definition_container
-            .definitions()
-            .get(&TypeId::of::<T>())
+        if let Some(InspectorMessage::PropertyChanged(msg)) = ctx.message.data::<InspectorMessage>()
         {
-            return definition.property_editor.translate_message(
-                PropertyEditorTranslationContext {
-                    environment: ctx.environment.clone(),
-                    name: ctx.name,
-
-                    message: ctx.message,
-                    definition_container: ctx.definition_container.clone(),
-                },
-            );
+            if ctx.message.direction() == MessageDirection::FromWidget {
+                return Some(PropertyChanged {
+                    name: ctx.name.to_owned(),
+                    action: FieldAction::InspectableAction(Box::new(msg.clone())),
+                });
+            }
         }
 
         None

--- a/fyrox-ui/src/inspector/editors/refcell.rs
+++ b/fyrox-ui/src/inspector/editors/refcell.rs
@@ -112,6 +112,7 @@ where
                     generate_property_string_values: ctx.generate_property_string_values,
                     filter: ctx.filter,
                     name_column_width: ctx.name_column_width,
+                    hide_name_column: ctx.hide_name_column,
                     base_path: ctx.base_path.clone(),
                     has_parent_object: ctx.has_parent_object,
                 })
@@ -161,6 +162,7 @@ where
                     generate_property_string_values: ctx.generate_property_string_values,
                     filter: ctx.filter,
                     name_column_width: ctx.name_column_width,
+                    hide_name_column: ctx.hide_name_column,
                     base_path: ctx.base_path.clone(),
                     has_parent_object: ctx.has_parent_object,
                 });

--- a/fyrox-ui/src/inspector/editors/refcell.rs
+++ b/fyrox-ui/src/inspector/editors/refcell.rs
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 use crate::{
-    core::{reflect::prelude::*, reflect::FieldValue},
+    core::reflect::prelude::*,
     inspector::{
         editors::{
             PropertyEditorBuildContext, PropertyEditorDefinition, PropertyEditorInstance,
@@ -38,7 +38,7 @@ use std::{
 
 pub struct RefCellPropertyEditorDefinition<T>
 where
-    T: FieldValue,
+    T: Reflect + Clone,
 {
     #[allow(dead_code)]
     phantom: PhantomDataSendSync<T>,
@@ -46,7 +46,7 @@ where
 
 impl<T> RefCellPropertyEditorDefinition<T>
 where
-    T: FieldValue,
+    T: Reflect + Clone,
 {
     pub fn new() -> Self {
         Self {
@@ -57,7 +57,7 @@ where
 
 impl<T> Debug for RefCellPropertyEditorDefinition<T>
 where
-    T: Reflect + FieldValue,
+    T: Reflect + Clone,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "RefCellPropertyEditorDefinition")
@@ -66,7 +66,7 @@ where
 
 impl<T> PropertyEditorDefinition for RefCellPropertyEditorDefinition<T>
 where
-    T: Reflect + FieldValue,
+    T: Reflect + Clone,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<RefCell<T>>()

--- a/fyrox-ui/src/inspector/editors/style.rs
+++ b/fyrox-ui/src/inspector/editors/style.rs
@@ -28,8 +28,8 @@ use crate::window::WindowAlignment;
 use crate::{
     button::{ButtonBuilder, ButtonMessage},
     core::{
-        pool::Handle, reflect::prelude::*, reflect::FieldValue, type_traits::prelude::*,
-        visitor::prelude::*, ImmutableString, PhantomDataSendSync,
+        pool::Handle, reflect::prelude::*, type_traits::prelude::*, visitor::prelude::*,
+        ImmutableString, PhantomDataSendSync,
     },
     define_widget_deref,
     draw::DrawingContext,
@@ -474,7 +474,7 @@ impl StyledPropertyEditorBuilder {
 
 pub struct StyledPropertyEditorDefinition<T>
 where
-    T: FieldValue,
+    T: Reflect + Clone,
 {
     #[allow(dead_code)]
     phantom: PhantomDataSendSync<T>,
@@ -482,7 +482,7 @@ where
 
 impl<T> StyledPropertyEditorDefinition<T>
 where
-    T: FieldValue,
+    T: Reflect + Clone,
 {
     pub fn new() -> Self {
         Self {
@@ -493,7 +493,7 @@ where
 
 impl<T> Debug for StyledPropertyEditorDefinition<T>
 where
-    T: Reflect + FieldValue,
+    T: Reflect + Clone,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "StyledPropertyEditorDefinition")
@@ -502,7 +502,7 @@ where
 
 impl<T> PropertyEditorDefinition for StyledPropertyEditorDefinition<T>
 where
-    T: Reflect + FieldValue,
+    T: Reflect + Clone,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<StyledProperty<T>>()

--- a/fyrox-ui/src/inspector/editors/style.rs
+++ b/fyrox-ui/src/inspector/editors/style.rs
@@ -548,6 +548,7 @@ where
                         generate_property_string_values: ctx.generate_property_string_values,
                         filter: ctx.filter,
                         name_column_width: ctx.name_column_width,
+                        hide_name_column: ctx.hide_name_column,
                         base_path: format!("{}.{}", ctx.base_path, StyledProperty::<T>::PROPERTY),
                         has_parent_object: ctx.has_parent_object,
                     })?;
@@ -633,6 +634,7 @@ where
                     generate_property_string_values: ctx.generate_property_string_values,
                     filter: ctx.filter,
                     name_column_width: ctx.name_column_width,
+                    hide_name_column: ctx.hide_name_column,
                     base_path: ctx.base_path.clone(),
                     has_parent_object: ctx.has_parent_object,
                 });

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -978,8 +978,10 @@ fn make_simple_property_container(
 ) -> Handle<UiNode> {
     ctx[editor.to_base()].set_row(0).set_column(1);
 
-    let tooltip = make_tooltip(ctx, description);
-    ctx[title].set_tooltip(tooltip);
+    if title.is_some() {
+        let tooltip = make_tooltip(ctx, description);
+        ctx[title].set_tooltip(tooltip);
+    }
 
     GridBuilder::new(WidgetBuilder::new().with_child(title).with_child(editor))
         .add_row(Row::auto())
@@ -1120,7 +1122,11 @@ impl InspectorContext {
                             let (container, editor) = match instance {
                                 PropertyEditorInstance::Simple { editor } => (
                                     make_simple_property_container(
-                                        create_header(ctx, info.display_name, layer_index),
+                                        if name_column_width != 0.0 {
+                                            create_header(ctx, info.display_name, layer_index)
+                                        } else {
+                                            Handle::NONE
+                                        },
                                         editor,
                                         &description,
                                         name_column_width,

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -818,6 +818,7 @@ pub struct InspectorContext {
     pub object_type_id: TypeId,
     /// A width of the property name column.
     pub name_column_width: f32,
+    pub hide_name_column: bool,
     /// A flag, that defines whether the inspectable object has a parent object from which it can
     /// obtain initial property values when clicking on "Revert" button. This flag is used only for
     /// [`crate::core::variable::InheritableVariable`] properties, primarily to hide "Revert" button
@@ -847,6 +848,7 @@ impl Default for InspectorContext {
             environment: None,
             object_type_id: ().type_id(),
             name_column_width: 150.0,
+            hide_name_column: false,
             has_parent_object: false,
         }
     }
@@ -879,14 +881,9 @@ fn make_expander_check_box(
     layer_index: usize,
     property_name: &str,
     property_description: &str,
+    hide_name: bool,
     ctx: &mut BuildContext,
 ) -> Handle<CheckBox> {
-    let description = if property_description.is_empty() {
-        property_name.to_string()
-    } else {
-        format!("{property_name}\n\n{property_description}")
-    };
-
     let handle = CheckBoxBuilder::new(
         WidgetBuilder::new()
             .with_vertical_alignment(VerticalAlignment::Center)
@@ -901,7 +898,14 @@ fn make_expander_check_box(
         .with_stroke_thickness(Thickness::zero().into())
         .build(ctx),
     )
-    .with_content(
+    .with_content(if hide_name {
+        Handle::NONE
+    } else {
+        let description = if property_description.is_empty() {
+            property_name.to_string()
+        } else {
+            format!("{property_name}\n\n{property_description}")
+        };
         TextBuilder::new(
             WidgetBuilder::new()
                 .with_opt_tooltip(make_tooltip(ctx, &description))
@@ -910,8 +914,8 @@ fn make_expander_check_box(
         )
         .with_vertical_text_alignment(VerticalAlignment::Center)
         .with_text(property_name)
-        .build(ctx),
-    )
+        .build(ctx)
+    })
     .checked(Some(true))
     .with_check_mark(make_arrow(ctx, ArrowDirection::Bottom, 8.0))
     .with_uncheck_mark(make_arrow(ctx, ArrowDirection::Right, 8.0))
@@ -937,6 +941,7 @@ pub fn make_expander_container(
     header: Handle<impl ObjectOrVariant<UiNode>>,
     content: Handle<impl ObjectOrVariant<UiNode>>,
     width: f32,
+    hide_name_column: bool,
     ctx: &mut BuildContext,
 ) -> Handle<UiNode> {
     ExpanderBuilder::new(WidgetBuilder::new())
@@ -944,9 +949,14 @@ pub fn make_expander_container(
             layer_index,
             property_name,
             description,
+            hide_name_column,
             ctx,
         ))
-        .with_expander_column(Column::strict(width))
+        .with_expander_column(if hide_name_column {
+            Column::strict(0.0)
+        } else {
+            Column::strict(width)
+        })
         .with_expanded(true)
         .with_header(header)
         .with_content(content)
@@ -974,6 +984,7 @@ fn make_simple_property_container(
     editor: Handle<impl ObjectOrVariant<UiNode>>,
     description: &str,
     width: f32,
+    hide_name_column: bool,
     ctx: &mut BuildContext,
 ) -> Handle<UiNode> {
     ctx[editor.to_base()].set_row(0).set_column(1);
@@ -985,7 +996,10 @@ fn make_simple_property_container(
 
     GridBuilder::new(WidgetBuilder::new().with_child(title).with_child(editor))
         .add_row(Row::auto())
-        .add_columns(vec![Column::strict(width), Column::stretch()])
+        .add_columns(vec![
+            Column::strict(if hide_name_column { 0.0 } else { width }),
+            Column::stretch(),
+        ])
         .build(ctx)
         .to_base()
 }
@@ -1037,6 +1051,7 @@ pub struct InspectorContextArgs<'a, 'b, 'c> {
     pub generate_property_string_values: bool,
     pub filter: PropertyFilter,
     pub name_column_width: f32,
+    pub hide_name_column: bool,
     pub base_path: String,
     /// A flag, that defines whether the inspectable object has a parent object from which it can
     /// obtain initial property values when clicking on "Revert" button. This flag is used only for
@@ -1069,6 +1084,7 @@ impl InspectorContext {
             generate_property_string_values,
             filter,
             name_column_width,
+            hide_name_column,
             base_path,
             has_parent_object,
         } = context;
@@ -1114,6 +1130,7 @@ impl InspectorContext {
                             generate_property_string_values,
                             filter: filter.clone(),
                             name_column_width,
+                            hide_name_column,
                             base_path: property_path.clone(),
                             has_parent_object,
                         },
@@ -1122,14 +1139,15 @@ impl InspectorContext {
                             let (container, editor) = match instance {
                                 PropertyEditorInstance::Simple { editor } => (
                                     make_simple_property_container(
-                                        if name_column_width != 0.0 {
-                                            create_header(ctx, info.display_name, layer_index)
-                                        } else {
+                                        if hide_name_column {
                                             Handle::NONE
+                                        } else {
+                                            create_header(ctx, info.display_name, layer_index)
                                         },
                                         editor,
                                         &description,
                                         name_column_width,
+                                        hide_name_column,
                                         ctx,
                                     ),
                                     editor,
@@ -1173,6 +1191,7 @@ impl InspectorContext {
                                     .build(ctx),
                                 &description,
                                 name_column_width,
+                                false,
                                 ctx,
                             )
                         }
@@ -1192,6 +1211,7 @@ impl InspectorContext {
                             .build(ctx),
                         &description,
                         name_column_width,
+                        false,
                         ctx,
                     ));
                 }
@@ -1257,6 +1277,7 @@ impl InspectorContext {
             environment,
             object_type_id: object_type_id(object),
             name_column_width,
+            hide_name_column,
             has_parent_object,
         }
     }
@@ -1308,6 +1329,7 @@ impl InspectorContext {
                             generate_property_string_values,
                             filter: filter.clone(),
                             name_column_width: self.name_column_width,
+                            hide_name_column: self.hide_name_column,
                             base_path: base_path.clone(),
                             has_parent_object: self.has_parent_object,
                         };

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -505,6 +505,7 @@ pub trait InspectorEnvironment: Send + Sync + Reflect {
 ///         generate_property_string_values: true,
 ///         filter: Default::default(),
 ///         name_column_width: 150.0,
+///         hide_name_column: false,
 ///         base_path: Default::default(),
 ///         has_parent_object: false
 ///     });

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -260,7 +260,7 @@ where
     }
 
     fn into_box_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        Box::new(*(self.into_inner() as Box<dyn Any>).downcast::<T>().unwrap())
+        Box::new(*(self as Box<dyn Reflect>).downcast::<T>().unwrap())
     }
 }
 
@@ -290,24 +290,21 @@ impl PartialEq for ObjectValue {
 }
 
 impl ObjectValue {
-    pub fn cast_value<T: 'static>(&self, func: &mut dyn FnMut(Option<&T>)) {
-        (*self.value).inner_ref(&mut |reflect| func((reflect as &dyn Any).downcast_ref::<T>()))
+    pub fn cast_value<T: Reflect>(&self) -> Option<&T> {
+        (&*self.value as &dyn Reflect).downcast_ref::<T>()
     }
 
-    pub fn cast_clone<T: Clone + 'static>(&self, func: &mut dyn FnMut(Option<T>)) {
-        (*self.value)
-            .inner_ref(&mut |reflect| func((reflect as &dyn Any).downcast_ref::<T>().cloned()))
+    pub fn cast_clone<T: Clone + Reflect>(&self) -> Option<T> {
+        (&*self.value as &dyn Reflect).downcast_ref::<T>().cloned()
     }
 
-    pub fn try_override<T: Clone + 'static>(&self, value: &mut T) -> bool {
-        let mut result = false;
-        (*self.value).inner_ref(&mut |reflect| {
-            if let Some(self_value) = (reflect as &dyn Any).downcast_ref::<T>() {
-                *value = self_value.clone();
-                result = true;
-            }
-        });
-        false
+    pub fn try_override<T: Clone + Reflect>(&self, value: &mut T) -> bool {
+        if let Some(self_value) = (&*self.value as &dyn Reflect).downcast_ref::<T>() {
+            *value = self_value.clone();
+            true
+        } else {
+            false
+        }
     }
 
     pub fn into_box_reflect(self) -> Box<dyn Reflect> {
@@ -583,11 +580,7 @@ impl Inspector {
                         can_clone = field.try_clone_box().is_some();
 
                         if let Some(clipboard_value) = clipboard_value {
-                            clipboard_value.inner_ref(&mut |clipboard_value| {
-                                field.inner_ref(&mut |field| {
-                                    can_paste = field.type_id() == clipboard_value.type_id();
-                                })
-                            });
+                            can_paste = field.type_id() == (**clipboard_value).type_id();
                         }
                     }
                 });
@@ -843,9 +836,7 @@ impl PartialEq for InspectorContext {
 }
 
 fn object_type_id(object: &dyn Reflect) -> TypeId {
-    let mut object_type_id = None;
-    object.inner_ref(&mut |reflect| object_type_id = Some(reflect.type_id()));
-    object_type_id.unwrap()
+    object.type_id()
 }
 
 impl Default for InspectorContext {
@@ -1090,12 +1081,12 @@ impl InspectorContext {
         object.fields_ref(&mut |fields_ref| {
             for (i, info) in fields_ref.iter().enumerate() {
                 let field_text = if generate_property_string_values {
-                    format!("{:?}", info.value.field_value_as_reflect())
+                    format!("{:?}", info.value)
                 } else {
                     Default::default()
                 };
 
-                if !filter.pass(info.value.field_value_as_reflect()) {
+                if !filter.pass(info.value) {
                     continue;
                 }
 
@@ -1194,7 +1185,7 @@ impl InspectorContext {
                             .with_vertical_text_alignment(VerticalAlignment::Center)
                             .with_text(format!(
                                 "Property Editor Is Missing For Type {}!",
-                                info.value.type_name()
+                                info.value.type_info_ref().type_name
                             ))
                             .build(ctx),
                         &description,
@@ -1295,7 +1286,7 @@ impl InspectorContext {
 
         object.fields_ref(&mut |fields_ref| {
             for info in fields_ref {
-                if !filter.pass(info.value.field_value_as_reflect()) {
+                if !filter.pass(info.value) {
                     continue;
                 }
 

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -199,19 +199,17 @@ impl PropertyAction {
                 let mut value = Some(value);
                 target.resolve_path_mut(path, &mut |result| {
                     if let Ok(field) = result {
-                        field.as_list_mut(&mut |result| {
-                            if let Some(list) = result {
-                                if let Err(value) = list.reflect_push(value.take().unwrap()) {
-                                    result_callback(Err(Self::AddItem { value }))
-                                } else {
-                                    result_callback(Ok(None))
-                                }
+                        if let Some(list) = field.as_list_mut() {
+                            if let Err(value) = list.reflect_push(value.take().unwrap()) {
+                                result_callback(Err(Self::AddItem { value }))
                             } else {
-                                result_callback(Err(Self::AddItem {
-                                    value: value.take().unwrap(),
-                                }))
+                                result_callback(Ok(None))
                             }
-                        })
+                        } else {
+                            result_callback(Err(Self::AddItem {
+                                value: value.take().unwrap(),
+                            }))
+                        }
                     } else {
                         result_callback(Err(Self::AddItem {
                             value: value.take().unwrap(),
@@ -221,17 +219,15 @@ impl PropertyAction {
             }
             PropertyAction::RemoveItem { index } => target.resolve_path_mut(path, &mut |result| {
                 if let Ok(field) = result {
-                    field.as_list_mut(&mut |result| {
-                        if let Some(list) = result {
-                            if let Some(value) = list.reflect_remove(index) {
-                                result_callback(Ok(Some(value)))
-                            } else {
-                                result_callback(Err(Self::RemoveItem { index }))
-                            }
+                    if let Some(list) = field.as_list_mut() {
+                        if let Some(value) = list.reflect_remove(index) {
+                            result_callback(Ok(Some(value)))
                         } else {
                             result_callback(Err(Self::RemoveItem { index }))
                         }
-                    })
+                    } else {
+                        result_callback(Err(Self::RemoveItem { index }))
+                    }
                 } else {
                     result_callback(Err(Self::RemoveItem { index }))
                 }

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -3554,7 +3554,7 @@ impl SceneGraph for UserInterface {
     fn derived_type_ids(&self, handle: Handle<Self::Node>) -> Result<Vec<TypeId>, PoolError> {
         self.nodes
             .try_borrow(handle)
-            .map(|n| n.0.type_info_ref().derived_types.to_vec())
+            .map(|n| n.0.deref().type_info_ref().derived_types.to_vec())
     }
 
     #[inline]

--- a/fyrox-ui/src/node/mod.rs
+++ b/fyrox-ui/src/node/mod.rs
@@ -31,7 +31,6 @@ use crate::{
 
 use fyrox_graph::SceneGraphNode;
 use fyrox_resource::{untyped::UntypedResource, Resource};
-use std::any::type_name;
 use std::{
     any::TypeId,
     fmt::{Debug, Formatter},
@@ -47,7 +46,8 @@ pub mod container;
 /// `Box<dyn Control>` everywhere, just `UiNode`) and to provide some useful methods such as type
 /// casting, field fetching, etc. You could also be interested in [`Control`] docs, since it
 /// contains all the interesting stuff and detailed description for each method.
-pub struct UiNode(pub Box<dyn Control>);
+#[derive(Reflect)]
+pub struct UiNode(#[reflect(deref, display_name = "UiNode")] pub Box<dyn Control>);
 
 impl<T: Control> From<T> for UiNode {
     fn from(value: T) -> Self {
@@ -268,62 +268,5 @@ impl UiNode {
 impl Visit for UiNode {
     fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
         self.0.visit(name, visitor)
-    }
-}
-
-impl Reflect for UiNode {
-    fn type_info() -> TypeInfo {
-        TypeInfo {
-            source_path: file!(),
-            type_name: type_name::<Self>(),
-            assembly_name: env!("CARGO_PKG_NAME"),
-            doc_comment: "",
-            derived_types: &[],
-        }
-    }
-
-    fn type_info_ref(&self) -> TypeInfo {
-        Self::type_info()
-    }
-
-    fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
-        Some(Box::new(self.clone()))
-    }
-
-    fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
-        self.0.deref().fields_ref(func)
-    }
-
-    fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
-        self.0.deref_mut().fields_mut(func)
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {
-        self.0.deref_mut().set(value)
-    }
-
-    fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
-        self.0.deref().field_direct_ref(index)
-    }
-
-    fn field_direct_mut(&mut self, index: usize) -> Option<FieldMut> {
-        self.0.deref_mut().field_direct_mut(index)
-    }
-
-    fn set_field(
-        &mut self,
-        field: &str,
-        value: Box<dyn Reflect>,
-        func: &mut dyn FnMut(Result<Box<dyn Reflect>, SetFieldError>),
-    ) {
-        self.0.deref_mut().set_field(field, value, func)
-    }
-
-    fn find_field(&self, name: &str, func: &mut dyn FnMut(Option<&dyn Reflect>)) {
-        self.0.deref().find_field(name, func)
-    }
-
-    fn find_field_mut(&mut self, name: &str, func: &mut dyn FnMut(Option<&mut dyn Reflect>)) {
-        self.0.deref_mut().find_field_mut(name, func)
     }
 }

--- a/fyrox-ui/src/node/mod.rs
+++ b/fyrox-ui/src/node/mod.rs
@@ -69,6 +69,14 @@ impl SceneGraphNode for UiNode {
     type SceneGraph = UserInterface;
     type ResourceData = UserInterface;
 
+    fn inner_ref(&self) -> &dyn Reflect {
+        self.0.deref()
+    }
+
+    fn inner_mut(&mut self) -> &mut dyn Reflect {
+        self.0.deref_mut()
+    }
+
     fn base(&self) -> &Self::Base {
         self.0.deref()
     }
@@ -247,12 +255,10 @@ impl UiNode {
 
         // Reset inheritable properties, so property inheritance system will take properties
         // from parent objects on resolve stage.
-        self.inner_mut(&mut |reflect| {
-            variable::mark_inheritable_properties_non_modified(
-                reflect,
-                &[TypeId::of::<UntypedResource>()],
-            )
-        });
+        variable::mark_inheritable_properties_non_modified(
+            self,
+            &[TypeId::of::<UntypedResource>()],
+        );
 
         // Fill original handles to instances.
         self.original_handle_in_resource = original_handle;
@@ -277,14 +283,7 @@ impl Reflect for UiNode {
     }
 
     fn type_info_ref(&self) -> TypeInfo {
-        let inner_type_info = self.deref().type_info_ref();
-        TypeInfo {
-            source_path: inner_type_info.source_path,
-            type_name: inner_type_info.type_name,
-            assembly_name: inner_type_info.assembly_name,
-            doc_comment: inner_type_info.doc_comment,
-            derived_types: inner_type_info.derived_types,
-        }
+        Self::type_info()
     }
 
     fn try_clone_box(&self) -> Option<Box<dyn Reflect>> {
@@ -297,26 +296,6 @@ impl Reflect for UiNode {
 
     fn fields_mut(&mut self, func: &mut dyn FnMut(&mut [FieldMut])) {
         self.0.deref_mut().fields_mut(func)
-    }
-
-    fn into_inner(self: Box<Self>) -> Box<dyn Reflect> {
-        Reflect::into_inner(self.0)
-    }
-
-    fn inner_ref_direct(&self) -> &dyn Reflect {
-        self.0.deref().inner_ref_direct()
-    }
-
-    fn inner_mut_direct(&mut self) -> &mut dyn Reflect {
-        self.0.deref_mut().inner_mut_direct()
-    }
-
-    fn inner_ref(&self, func: &mut dyn FnMut(&dyn Reflect)) {
-        self.0.deref().inner_ref(func)
-    }
-
-    fn inner_mut(&mut self, func: &mut dyn FnMut(&mut dyn Reflect)) {
-        self.0.deref_mut().inner_mut(func)
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<Box<dyn Reflect>, Box<dyn Reflect>> {

--- a/project-manager/src/settings.rs
+++ b/project-manager/src/settings.rs
@@ -242,6 +242,7 @@ impl SettingsWindow {
             generate_property_string_values: true,
             filter: Default::default(),
             name_column_width: 170.0,
+            hide_name_column: false,
             base_path: Default::default(),
             has_parent_object: false,
         });


### PR DESCRIPTION
This PR refactored `Reflect` trait to make its usage more clear and concise. Removed unnecessary proxy methods that overly complicated the implementation and added a lot of confusion and subtle bugs. This is breaking change, it also breaks some of existing assets (they're still loadable, but may not function as expected). For example, animation for arbitrary properties via property path will be broken and needs to be rebound. In general new `Reflect` implementation is much more clear now. 