### PR TITLE
`Reflect::try_compare` 

### DIFF
--- a/editor/src/asset/item.rs
+++ b/editor/src/asset/item.rs
@@ -26,7 +26,7 @@ use crate::{
         asset::{manager::ResourceManager, untyped::UntypedResource, Resource, TypedResourceData},
         core::{
             algebra::Vector2, color::Color, futures::executor::block_on, make_relative_path,
-            parking_lot::lock_api::Mutex, pool::Handle, reflect::prelude::*, visitor::prelude::*,
+            pool::Handle, reflect::prelude::*, visitor::prelude::*,
         },
         graph::SceneGraph,
         gui::{
@@ -54,10 +54,10 @@ use fyrox::core::ok_or_return;
 use fyrox::gui::border::Border;
 use fyrox::gui::image::Image;
 use fyrox::gui::message::MessageData;
+use fyrox::gui::widget::UserData;
 use std::{
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 pub const DEFAULT_SIZE: f32 = 60.0;
@@ -79,7 +79,7 @@ pub enum AssetItemMessage {
 impl MessageData for AssetItemMessage {}
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "54f7d9c1-e707-4c8c-a5c9-3fc5cc80b545"
@@ -432,7 +432,7 @@ impl AssetItemBuilder {
         let item = AssetItem {
             widget: self
                 .widget_builder
-                .with_user_data(Arc::new(Mutex::new(self.path.clone())))
+                .with_user_data(UserData::new(self.path.clone()))
                 .with_margin(Thickness::uniform(1.0))
                 .with_allow_drag(true)
                 .with_allow_drop(true)

--- a/editor/src/asset/menu.rs
+++ b/editor/src/asset/menu.rs
@@ -61,7 +61,7 @@ use std::{
     path::PathBuf,
 };
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "8c9934ad-b4e1-4c68-9876-f253e34c6667")]
 struct AssetRenameDialog {

--- a/editor/src/asset/selector.rs
+++ b/editor/src/asset/selector.rs
@@ -79,7 +79,7 @@ pub enum AssetSelectorMessage {
 impl MessageData for AssetSelectorMessage {}
 
 #[derive(Clone, Debug, Reflect, Visit)]
-#[reflect(type_uuid = "aa4f0726-8d25-4c90-add1-92ba392310c6")]
+#[reflect(type_uuid = "aa4f0726-8d25-4c90-add1-92ba392310c6", non_comparable)]
 struct Item {
     pub widget: Widget,
     image: Handle<Image>,
@@ -229,7 +229,7 @@ impl ItemBuilder {
     }
 }
 
-#[derive(Clone, Debug, Reflect, Visit)]
+#[derive(Clone, Debug, PartialEq, Reflect, Visit)]
 #[reflect(type_uuid = "970bb83b-51e8-48e7-8050-f97bf0ac470b")]
 pub struct AssetSelector {
     pub widget: Widget,
@@ -387,7 +387,7 @@ impl<'a> AssetSelectorBuilder<'a> {
     }
 }
 
-#[derive(Clone, Debug, Reflect, Visit)]
+#[derive(Clone, Debug, PartialEq, Reflect, Visit)]
 #[reflect(type_uuid = "c348ad3d-52a6-40ad-a5e4-bf63fefe1906")]
 pub struct AssetSelectorWindow {
     pub window: Window,
@@ -591,7 +591,7 @@ impl<'a> AssetSelectorWindowBuilder<'a> {
 }
 
 #[derive(Reflect, Visit, Debug)]
-#[reflect(type_uuid = "7839eb64-1e6e-4e40-a8fb-53c9d0945b16")]
+#[reflect(type_uuid = "7839eb64-1e6e-4e40-a8fb-53c9d0945b16", non_comparable)]
 pub struct AssetSelectorMixin<T: TypedResourceData> {
     pub selector: Cell<Handle<AssetSelectorWindow>>,
     pub select: Handle<Button>,

--- a/editor/src/audio/bus.rs
+++ b/editor/src/audio/bus.rs
@@ -47,7 +47,7 @@ pub enum AudioBusViewMessage {
 }
 impl MessageData for AudioBusViewMessage {}
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "5439e3a9-096a-4155-922c-ed57a76a46f3"

--- a/editor/src/interaction/gizmo/move_gizmo.rs
+++ b/editor/src/interaction/gizmo/move_gizmo.rs
@@ -52,7 +52,7 @@ use fyrox::scene::camera::Camera;
 use fyrox::scene::mesh::Mesh;
 use fyrox::scene::pivot::Pivot;
 
-#[derive(Reflect, Debug, Clone)]
+#[derive(PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "060abe31-ce96-4696-aa5d-e44e9639df0e")]
 pub struct MoveGizmo {
     pub origin: Handle<Pivot>,

--- a/editor/src/interaction/gizmo/rotate_gizmo.rs
+++ b/editor/src/interaction/gizmo/rotate_gizmo.rs
@@ -51,7 +51,7 @@ use fyrox::scene::camera::Camera;
 use fyrox::scene::mesh::Mesh;
 use fyrox::scene::pivot::Pivot;
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "5ef2c27b-18af-458d-9549-1395f0869551")]
 pub enum RotateGizmoMode {
     Pitch,
@@ -59,7 +59,7 @@ pub enum RotateGizmoMode {
     Roll,
 }
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "36fc1ea4-33cd-4108-ae61-bab544f8ac02")]
 pub struct RotationGizmo {
     mode: RotateGizmoMode,

--- a/editor/src/interaction/gizmo/scale_gizmo.rs
+++ b/editor/src/interaction/gizmo/scale_gizmo.rs
@@ -49,7 +49,7 @@ use fyrox::core::reflect::prelude::*;
 use fyrox::scene::camera::Camera;
 use fyrox::scene::mesh::Mesh;
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "0555e074-bbd8-4753-a2ab-56d7092251c1")]
 pub enum ScaleGizmoMode {
     None,
@@ -59,7 +59,7 @@ pub enum ScaleGizmoMode {
     Uniform,
 }
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "c8827bb2-1aac-41e7-b2c1-ba04e0dc59e0")]
 pub struct ScaleGizmo {
     mode: ScaleGizmoMode,

--- a/editor/src/interaction/move_mode.rs
+++ b/editor/src/interaction/move_mode.rs
@@ -52,7 +52,7 @@ use crate::{
 use fyrox::core::some_or_return;
 use fyrox::gui::button::Button;
 
-#[derive(Reflect, Debug, Clone)]
+#[derive(PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "067c67e2-865b-4112-8d60-133ee1e1883a")]
 struct Entry {
     node: Handle<Node>,
@@ -62,7 +62,7 @@ struct Entry {
     new_local_position: Vector3<f32>,
 }
 
-#[derive(Reflect, Debug, Clone)]
+#[derive(PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "f50af953-308e-40e8-85ae-48c905ba5f46")]
 struct MoveContext {
     #[reflect(hidden)]
@@ -280,7 +280,7 @@ impl MoveContext {
     }
 }
 
-#[derive(Reflect, Debug, Clone)]
+#[derive(PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "067c67e2-865b-4112-8d60-133ee1e1883a")]
 pub struct MoveInteractionMode {
     move_context: Option<MoveContext>,

--- a/editor/src/interaction/navmesh/mod.rs
+++ b/editor/src/interaction/navmesh/mod.rs
@@ -198,7 +198,7 @@ impl NavmeshPanel {
     }
 }
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(
     non_cloneable,
     type_uuid = "986eb5f1-5f17-4373-bffb-1e213e7c97e5",
@@ -220,7 +220,7 @@ impl DragContext {
     }
 }
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "a8ed875d-0932-400d-b5b0-e0dcfb78c6c1")]
 pub struct EditNavmeshMode {
     move_gizmo: MoveGizmo,

--- a/editor/src/interaction/plane.rs
+++ b/editor/src/interaction/plane.rs
@@ -22,7 +22,7 @@ use crate::fyrox::core::{algebra::Vector3, math::plane::Plane, num_traits::Zero}
 use fyrox::core::reflect::prelude::*;
 use strum_macros::EnumIter;
 
-#[derive(Copy, Clone, Debug, EnumIter, Reflect)]
+#[derive(Copy, Clone, PartialEq, Debug, EnumIter, Reflect)]
 #[reflect(type_uuid = "f50af953-308e-40e8-85ae-48c905ba5f46")]
 pub enum PlaneKind {
     X,

--- a/editor/src/interaction/rotate_mode.rs
+++ b/editor/src/interaction/rotate_mode.rs
@@ -47,7 +47,7 @@ use crate::{
 };
 use fyrox::gui::button::Button;
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "37f20364-feb5-4731-8c19-c3df922818d6")]
 pub struct RotateInteractionMode {
     initial_rotations: Vec<UnitQuaternion<f32>>,

--- a/editor/src/interaction/scale_mode.rs
+++ b/editor/src/interaction/scale_mode.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 use fyrox::gui::button::Button;
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "64b4da1a-5d0f-49e1-9f48-011165cd1ec5")]
 pub struct ScaleInteractionMode {
     initial_scales: Vec<Vector3<f32>>,

--- a/editor/src/interaction/select_mode.rs
+++ b/editor/src/interaction/select_mode.rs
@@ -41,7 +41,7 @@ use fyrox::gui::button::Button;
 use fyrox::gui::image::Image;
 use fyrox::gui::widget::WidgetMessage;
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "bab9ce8c-d679-4c49-beb9-f5a8482e0678")]
 pub struct SelectInteractionMode {
     preview: Handle<Image>,

--- a/editor/src/interaction/terrain.rs
+++ b/editor/src/interaction/terrain.rs
@@ -106,7 +106,7 @@ fn handle_undo_chunks(undo_chunks: UndoData, sender: &MessageSender) {
     }
 }
 
-#[derive(Reflect)]
+#[derive(PartialEq, Reflect)]
 #[reflect(
     non_cloneable,
     type_uuid = "bc19eff3-3e3a-49c0-9a9d-17d36fccc34e",
@@ -243,6 +243,7 @@ impl TerrainInteractionMode {
     }
 }
 
+#[derive(PartialEq)]
 pub struct BrushGizmo {
     brush: Handle<Mesh>,
 }
@@ -558,6 +559,7 @@ impl InteractionMode for TerrainInteractionMode {
     }
 }
 
+#[derive(PartialEq)]
 struct BrushPanel {
     window: Handle<Window>,
     inspector: Handle<Inspector>,

--- a/editor/src/light.rs
+++ b/editor/src/light.rs
@@ -55,7 +55,7 @@ use std::{
     },
 };
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(PartialEq, Reflect, Clone, Debug)]
 #[reflect(type_uuid = "86eed637-0d96-4ad2-9566-a451f0b00237")]
 struct LightmapperSettings {
     /// Name of the property in a material that will be modified in all materials for all surfaces

--- a/editor/src/menu/file.rs
+++ b/editor/src/menu/file.rs
@@ -41,13 +41,12 @@ use crate::{
     settings::{recent::RecentFiles, Settings},
     Engine, Message, Mode, Panels, SaveSceneConfirmationDialogAction,
 };
-use fyrox::core::parking_lot::Mutex;
 use fyrox::core::uuid::{uuid, Uuid};
 use fyrox::graph::SceneGraph;
 use fyrox::gui::file_browser::FileSelector;
 use fyrox::gui::menu::MenuItem;
 use fyrox::gui::messagebox::MessageBox;
-use std::sync::Arc;
+use fyrox::gui::widget::UserData;
 use std::{path::PathBuf, sync::mpsc::Sender};
 
 pub struct FileMenu {
@@ -82,7 +81,7 @@ fn make_recent_files_items(
         .iter()
         .map(|f| {
             let item = create_menu_item(f.to_string_lossy().as_ref(), Uuid::new_v4(), vec![], ctx);
-            ctx[item].user_data = Some(Arc::new(Mutex::new(RecentFile(f.to_path_buf()))));
+            ctx[item].user_data = Some(UserData::new(RecentFile(f.to_path_buf())));
             item
         })
         .collect::<Vec<_>>()

--- a/editor/src/message.rs
+++ b/editor/src/message.rs
@@ -128,6 +128,12 @@ pub enum Message {
 #[reflect(hide_all, type_uuid = "86eed637-0d96-4ad2-9566-a451f0b00237")]
 pub struct MessageSender(pub Sender<Message>);
 
+impl PartialEq for MessageSender {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
 impl Default for MessageSender {
     fn default() -> Self {
         let (rx, _) = channel();

--- a/editor/src/plugins/absm/blendspace.rs
+++ b/editor/src/plugins/absm/blendspace.rs
@@ -89,7 +89,7 @@ impl MessageData for BlendSpaceFieldMessage {
     }
 }
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "5cdb0ab3-b6fd-41c3-a6c4-d1178346eb81")]
 struct ContextMenu {
     #[visit(skip)]
@@ -101,13 +101,13 @@ struct ContextMenu {
     remove_point: Handle<MenuItem>,
 }
 
-#[derive(Clone)]
+#[derive(PartialEq, Clone)]
 enum DragContext {
     SamplingPoint,
     Point { point: usize },
 }
 
-#[derive(Clone, Visit, Reflect)]
+#[derive(Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "854a7c2d-3ccd-4331-95e1-956a3a035bd0"
@@ -557,7 +557,7 @@ pub enum BlendSpaceFieldPointMessage {
 }
 impl MessageData for BlendSpaceFieldPointMessage {}
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "22c215c1-ff23-4a64-9aa7-640b5014a78b"

--- a/editor/src/plugins/absm/canvas.rs
+++ b/editor/src/plugins/absm/canvas.rs
@@ -113,7 +113,7 @@ impl MessageData for AbsmCanvasMessage {
     }
 }
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "100b1c33-d017-4fe6-95e7-e1daf310ef27"

--- a/editor/src/plugins/absm/connection.rs
+++ b/editor/src/plugins/absm/connection.rs
@@ -43,7 +43,7 @@ use fyrox::material::MaterialResource;
 const PICKED_BRUSH: Brush = Brush::Solid(Color::opaque(100, 100, 100));
 const NORMAL_BRUSH: Brush = Brush::Solid(Color::opaque(80, 80, 80));
 
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "c802b6fa-a5ef-4464-a097-749c731ffde0"

--- a/editor/src/plugins/absm/node.rs
+++ b/editor/src/plugins/absm/node.rs
@@ -48,7 +48,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-#[derive(Clone, Debug, Visit, Reflect)]
+#[derive(Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "1a5d0042-3607-4fcb-88c6-025a0bce6111")]
 pub struct AbsmBaseNode {
     pub input_sockets: Vec<Handle<Socket>>,
@@ -58,7 +58,8 @@ pub struct AbsmBaseNode {
 #[derive(Visit, Reflect)]
 #[reflect(
     derived_type = "UiNode",
-    type_uuid = "15bc1a7e-a385-46e0-a65c-7e9c014b4a1d"
+    type_uuid = "15bc1a7e-a385-46e0-a65c-7e9c014b4a1d",
+    non_comparable
 )]
 pub struct AbsmNode<T>
 where

--- a/editor/src/plugins/absm/segment.rs
+++ b/editor/src/plugins/absm/segment.rs
@@ -31,7 +31,7 @@ pub enum SegmentMessage {
 }
 impl MessageData for SegmentMessage {}
 
-#[derive(Debug, Clone, Reflect, Visit)]
+#[derive(Debug, Clone, Reflect, PartialEq, Visit)]
 #[reflect(type_uuid = "fda5a731-e927-40e5-9d96-e19104fbb63e")]
 pub struct Segment {
     pub source: Handle<UiNode>,

--- a/editor/src/plugins/absm/socket.rs
+++ b/editor/src/plugins/absm/socket.rs
@@ -53,7 +53,7 @@ pub enum SocketDirection {
     Output,
 }
 
-#[derive(Clone, Debug, Visit, Reflect)]
+#[derive(Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "a6c0473e-7073-4e91-a681-cf88795af52a"

--- a/editor/src/plugins/absm/transition.rs
+++ b/editor/src/plugins/absm/transition.rs
@@ -54,7 +54,7 @@ pub enum TransitionMessage {
 }
 impl MessageData for TransitionMessage {}
 
-#[derive(Clone, Debug, Visit, Reflect)]
+#[derive(Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "01798aee-8fe5-4480-a69d-8e5b95c3cc96"

--- a/editor/src/plugins/animation/ruler.rs
+++ b/editor/src/plugins/animation/ruler.rs
@@ -65,7 +65,7 @@ pub enum RulerMessage {
 }
 impl MessageData for RulerMessage {}
 
-#[derive(Clone)]
+#[derive(PartialEq, Clone)]
 struct ContextMenu {
     menu: RcUiNodeHandle,
     add_signal: Handle<MenuItem>,
@@ -148,18 +148,18 @@ impl SignalView {
     const SIZE: f32 = 10.0;
 }
 
-#[derive(Clone)]
+#[derive(PartialEq, Clone)]
 enum DragEntity {
     TimePosition,
     Signal(Uuid),
 }
 
-#[derive(Clone)]
+#[derive(PartialEq, Clone)]
 struct DragContext {
     entity: DragEntity,
 }
 
-#[derive(Clone, Visit, Reflect)]
+#[derive(Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "98655c9b-428f-4977-a478-ad3674cc66d4"

--- a/editor/src/plugins/animation/thumb.rs
+++ b/editor/src/plugins/animation/thumb.rs
@@ -51,7 +51,7 @@ pub enum ThumbMessage {
 }
 impl MessageData for ThumbMessage {}
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "820ba009-54e0-4050-ba7e-28f1f5b40429"

--- a/editor/src/plugins/animation/track.rs
+++ b/editor/src/plugins/animation/track.rs
@@ -31,7 +31,6 @@ use crate::{
             log::Log,
             math::curve::{CurveKey, CurveKeyKind},
             ok_or_continue,
-            parking_lot::Mutex,
             pool::{ErasedHandle, Handle},
             reflect::{prelude::*, Reflect},
             some_or_return,
@@ -103,12 +102,13 @@ use crate::{
     utils::{self},
 };
 use fyrox::core::warn;
+use fyrox::gui::widget::UserData;
 use std::{
     any::{Any, TypeId},
     cmp::Ordering,
     collections::hash_map::Entry,
     ops::{Deref, DerefMut},
-    sync::{mpsc::Sender, Arc},
+    sync::mpsc::Sender,
 };
 
 #[derive(PartialEq, Eq)]
@@ -346,7 +346,7 @@ pub enum TrackViewMessage {
 }
 impl MessageData for TrackViewMessage {}
 
-#[derive(Clone, Debug, Reflect, Visit)]
+#[derive(Clone, Debug, PartialEq, Reflect, Visit)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "c1e930da-d55d-492e-b87b-16c1adf03319"
@@ -1560,9 +1560,9 @@ impl TrackList {
                                 };
 
                                 let curve_view = TreeBuilder::new(
-                                    WidgetBuilder::new().with_user_data(Arc::new(Mutex::new(
+                                    WidgetBuilder::new().with_user_data(UserData::new(
                                         CurveViewData { id: curve.id() },
-                                    ))),
+                                    )),
                                 )
                                 .with_content(
                                     GridBuilder::new(

--- a/editor/src/plugins/collider/mod.rs
+++ b/editor/src/plugins/collider/mod.rs
@@ -298,7 +298,7 @@ fn make_handle(scene: &mut Scene, root: Handle<Pivot>, visible: bool) -> Handle<
     handle
 }
 
-#[derive(Copy, Clone, Reflect, Debug)]
+#[derive(Copy, Clone, PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "42b19406-299d-4c3d-a7e3-77b41817ae71")]
 enum ShapeHandleValue {
     Scalar(f32),
@@ -323,14 +323,14 @@ impl ShapeHandleValue {
     }
 }
 
-#[derive(Clone, Reflect, Debug)]
+#[derive(Clone, PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "70d6130f-da5d-4f14-bbfd-0744927053a0")]
 enum ColliderInitialShape {
     TwoD(dim2::collider::ColliderShape),
     ThreeD(ColliderShape),
 }
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "e9aac4a5-0755-4d94-94ff-dfa37b40d5ca")]
 struct DragContext {
     handle: Handle<Sprite>,
@@ -344,7 +344,11 @@ struct DragContext {
 }
 
 #[derive(Reflect)]
-#[reflect(non_cloneable, type_uuid = "a012dd4c-ce6d-4e7e-8879-fd8eddaa9677")]
+#[reflect(
+    non_cloneable,
+    non_comparable,
+    type_uuid = "a012dd4c-ce6d-4e7e-8879-fd8eddaa9677"
+)]
 pub struct ColliderShapeInteractionMode {
     collider: Handle<Node>,
     #[reflect(hidden)]

--- a/editor/src/plugins/curve_editor.rs
+++ b/editor/src/plugins/curve_editor.rs
@@ -61,7 +61,7 @@ use crate::{
 };
 use std::{fmt::Debug, path::PathBuf};
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(PartialEq, Reflect, Clone, Debug)]
 #[reflect(type_uuid = "f29aa9c7-e0c4-4602-8588-3e8a20ab7cdc")]
 pub struct CurveEditorContext {}
 

--- a/editor/src/plugins/inspector/editors/dyntype.rs
+++ b/editor/src/plugins/inspector/editors/dyntype.rs
@@ -23,7 +23,7 @@ use crate::{
         core::dyntype::{DynTypeConstructorContainer, DynTypeContainer},
         graph::SceneGraph,
         gui::{
-            core::{parking_lot::Mutex, pool::Handle, reflect::prelude::*, visitor::prelude::*},
+            core::{pool::Handle, reflect::prelude::*, visitor::prelude::*},
             dropdown_list::{DropdownList, DropdownListBuilder, DropdownListMessage},
             grid::{GridBuilder, GridDimension},
             inspector::InspectorContextArgs,
@@ -34,8 +34,8 @@ use crate::{
                     PropertyEditorMessageContext, PropertyEditorTranslationContext,
                 },
                 make_expander_container, FieldAction, Inspector, InspectorBuilder,
-                InspectorContext, InspectorEnvironment, InspectorError, InspectorMessage,
-                PropertyChanged, PropertyFilter,
+                InspectorContext, InspectorError, InspectorMessage, PropertyChanged,
+                PropertyFilter,
             },
             message::MessageData,
             message::{MessageDirection, UiMessage},
@@ -48,6 +48,7 @@ use crate::{
 };
 use fyrox::core::dyntype::DynTypeWrapper;
 use fyrox::gui::inspector::InspectorEnvironmentContainer;
+use fyrox::gui::widget::UserData;
 use std::{
     any::TypeId,
     cell::Cell,
@@ -62,7 +63,7 @@ pub enum DynTypePropertyEditorMessage {
 }
 impl MessageData for DynTypePropertyEditorMessage {}
 
-#[derive(Clone, Debug, Visit, Reflect)]
+#[derive(Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "f43c3bfb-8b39-4cc0-be77-04141a45822e"
@@ -192,13 +193,13 @@ fn create_items(
 ) -> Vec<Handle<UiNode>> {
     let mut items = vec![{
         let empty = make_dropdown_list_option(ctx, "<Not Set>");
-        ctx[empty].user_data = Some(Arc::new(Mutex::new(Uuid::default())));
+        ctx[empty].user_data = Some(UserData::new(Uuid::default()));
         empty
     }];
 
     items.extend(constructors.inner().iter().map(|(type_uuid, constructor)| {
         let item = make_dropdown_list_option(ctx, &constructor.name);
-        ctx[item].user_data = Some(Arc::new(Mutex::new(*type_uuid)));
+        ctx[item].user_data = Some(UserData::new(*type_uuid));
         item
     }));
 

--- a/editor/src/plugins/inspector/editors/dyntype.rs
+++ b/editor/src/plugins/inspector/editors/dyntype.rs
@@ -47,6 +47,7 @@ use crate::{
     plugins::inspector::EditorEnvironment,
 };
 use fyrox::core::dyntype::DynTypeWrapper;
+use fyrox::gui::inspector::InspectorEnvironmentContainer;
 use std::{
     any::TypeId,
     cell::Cell,
@@ -141,7 +142,7 @@ impl DynTypePropertyEditorBuilder {
         self,
         variant_selector: Handle<UiNode>,
         dyn_type_uuid: Option<Uuid>,
-        environment: Option<Arc<dyn InspectorEnvironment>>,
+        environment: Option<InspectorEnvironmentContainer>,
         layer_index: usize,
         generate_property_string_values: bool,
         filter: PropertyFilter,

--- a/editor/src/plugins/inspector/editors/font.rs
+++ b/editor/src/plugins/inspector/editors/font.rs
@@ -54,7 +54,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-#[derive(Clone, Visit, Reflect)]
+#[derive(Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "5db49479-ff89-49b8-a038-0766253d6493"

--- a/editor/src/plugins/inspector/editors/handle.rs
+++ b/editor/src/plugins/inspector/editors/handle.rs
@@ -105,8 +105,11 @@ pub struct HandlePropertyEditorHierarchyMessage(pub HierarchyNode);
 impl MessageData for HandlePropertyEditorHierarchyMessage {}
 
 #[derive(Visit, Reflect)]
-#[reflect(type_uuid = "3ceca8c1-c365-4f03-a413-062f8f3cd685")]
-#[reflect(derived_type = "UiNode")]
+#[reflect(
+    non_comparable,
+    derived_type = "UiNode",
+    type_uuid = "3ceca8c1-c365-4f03-a413-062f8f3cd685"
+)]
 pub struct HandlePropertyEditor<T: Reflect> {
     widget: Widget,
     text: Handle<Text>,

--- a/editor/src/plugins/inspector/editors/resource.rs
+++ b/editor/src/plugins/inspector/editors/resource.rs
@@ -117,7 +117,8 @@ pub type ResourceLoaderCallback<T> = Arc<
 #[derive(Visit, Reflect)]
 #[reflect(
     derived_type = "UiNode",
-    type_uuid = "5179b3b9-855f-43a6-b23a-831129fee1cf"
+    type_uuid = "5179b3b9-855f-43a6-b23a-831129fee1cf",
+    non_comparable
 )]
 pub struct ResourceField<T>
 where

--- a/editor/src/plugins/inspector/editors/script.rs
+++ b/editor/src/plugins/inspector/editors/script.rs
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 use crate::fyrox::{
-    core::{log::Log, parking_lot::Mutex, pool::Handle, reflect::prelude::*, visitor::prelude::*},
+    core::{log::Log, pool::Handle, reflect::prelude::*, visitor::prelude::*},
     engine::SerializationContext,
     graph::SceneGraph,
     gui::{
@@ -33,8 +33,7 @@ use crate::fyrox::{
                 PropertyEditorMessageContext, PropertyEditorTranslationContext,
             },
             make_expander_container, FieldAction, Inspector, InspectorBuilder, InspectorContext,
-            InspectorEnvironment, InspectorError, InspectorMessage, PropertyChanged,
-            PropertyFilter,
+            InspectorError, InspectorMessage, PropertyChanged, PropertyFilter,
         },
         message::{MessageDirection, UiMessage},
         text::TextBuilder,
@@ -54,6 +53,7 @@ use fyrox::gui::button::Button;
 use fyrox::gui::inspector::{InspectorContextArgs, InspectorEnvironmentContainer};
 use fyrox::gui::message::MessageData;
 use fyrox::gui::utils::make_dropdown_list_option;
+use fyrox::gui::widget::UserData;
 use fyrox::gui::{Thickness, VerticalAlignment};
 use std::{
     any::TypeId,
@@ -69,7 +69,7 @@ pub enum ScriptPropertyEditorMessage {
 }
 impl MessageData for ScriptPropertyEditorMessage {}
 
-#[derive(Clone, Debug, Visit, Reflect)]
+#[derive(Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "f43c3bfb-8b39-4cc0-be77-04141a45822e"
@@ -267,10 +267,7 @@ fn create_items(
 ) -> Vec<Handle<UiNode>> {
     let mut items = vec![{
         let empty = make_dropdown_list_option(ctx, "<No Script>");
-        ctx[empty].user_data = Some(Arc::new(Mutex::new((
-            Uuid::default(),
-            Option::<String>::None,
-        ))));
+        ctx[empty].user_data = Some(UserData::new((Uuid::default(), Option::<String>::None)));
         empty
     }];
 
@@ -278,10 +275,10 @@ fn create_items(
         |(type_uuid, constructor)| {
             let item = make_dropdown_list_option(ctx, &constructor.name);
 
-            ctx[item].user_data = Some(Arc::new(Mutex::new((
+            ctx[item].user_data = Some(UserData::new((
                 *type_uuid,
                 Some(constructor.source_path.to_string()),
-            ))));
+            )));
 
             item
         },

--- a/editor/src/plugins/inspector/editors/script.rs
+++ b/editor/src/plugins/inspector/editors/script.rs
@@ -51,7 +51,7 @@ use crate::{
 };
 
 use fyrox::gui::button::Button;
-use fyrox::gui::inspector::InspectorContextArgs;
+use fyrox::gui::inspector::{InspectorContextArgs, InspectorEnvironmentContainer};
 use fyrox::gui::message::MessageData;
 use fyrox::gui::utils::make_dropdown_list_option;
 use fyrox::gui::{Thickness, VerticalAlignment};
@@ -216,7 +216,7 @@ impl ScriptPropertyEditorBuilder {
         open_in_ide_button: Handle<Button>,
         variant_selector: Handle<UiNode>,
         script_uuid: Option<Uuid>,
-        environment: Option<Arc<dyn InspectorEnvironment>>,
+        environment: Option<InspectorEnvironmentContainer>,
         layer_index: usize,
         generate_property_string_values: bool,
         filter: PropertyFilter,

--- a/editor/src/plugins/inspector/editors/shader/field.rs
+++ b/editor/src/plugins/inspector/editors/shader/field.rs
@@ -45,7 +45,7 @@ use crate::{
 use fyrox::gui::button::Button;
 use std::{any::TypeId, cell::RefCell};
 
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "f2024683-812e-4e0d-8065-7d168a82cce6")]
 #[reflect(derived_type = "UiNode")]
 pub struct ShaderSourceCodeEditorField {

--- a/editor/src/plugins/inspector/editors/shader/mod.rs
+++ b/editor/src/plugins/inspector/editors/shader/mod.rs
@@ -42,7 +42,7 @@ pub enum ShaderSourceCodeEditorMessage {
 }
 impl MessageData for ShaderSourceCodeEditorMessage {}
 
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "c2e0bdcc-28a6-4141-93b5-5dad50c8b29c")]
 #[reflect(derived_type = "UiNode")]
 pub struct ShaderSourceCodeEditor {

--- a/editor/src/plugins/inspector/editors/spritesheet/mod.rs
+++ b/editor/src/plugins/inspector/editors/spritesheet/mod.rs
@@ -57,7 +57,7 @@ pub enum SpriteSheetFramesPropertyEditorMessage {
 }
 impl MessageData for SpriteSheetFramesPropertyEditorMessage {}
 
-#[derive(Clone, Debug, Reflect, Visit)]
+#[derive(Clone, Debug, PartialEq, Reflect, Visit)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "8994228d-6106-4e41-872c-5191840badcc"

--- a/editor/src/plugins/inspector/editors/spritesheet/window.rs
+++ b/editor/src/plugins/inspector/editors/spritesheet/window.rs
@@ -20,10 +20,7 @@
 
 use crate::fyrox::graph::SceneGraph;
 use crate::fyrox::{
-    core::{
-        algebra::Vector2, parking_lot::Mutex, pool::Handle, reflect::prelude::*,
-        visitor::prelude::*,
-    },
+    core::{algebra::Vector2, pool::Handle, reflect::prelude::*, visitor::prelude::*},
     gui::{
         border::BorderBuilder,
         button::{ButtonBuilder, ButtonMessage},
@@ -54,12 +51,13 @@ use fyrox::gui::image::Image;
 use fyrox::gui::numeric::NumericUpDown;
 use fyrox::gui::style::resource::StyleResourceExt;
 use fyrox::gui::style::Style;
+use fyrox::gui::widget::UserData;
 use std::{
     ops::{Deref, DerefMut},
-    sync::{mpsc::Sender, Arc},
+    sync::mpsc::Sender,
 };
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "55607fe0-2996-418d-ad31-a5b96fdfa4b7"
@@ -206,7 +204,7 @@ fn make_grid(
                         .with_height(16.0)
                         .on_row(i as usize)
                         .on_column(j as usize)
-                        .with_user_data(Arc::new(Mutex::new(cell_position))),
+                        .with_user_data(UserData::new(cell_position)),
                 )
                 .checked(Some(container.iter().any(|pos| *pos == cell_position)))
                 .build(ctx),

--- a/editor/src/plugins/inspector/editors/surface.rs
+++ b/editor/src/plugins/inspector/editors/surface.rs
@@ -68,8 +68,11 @@ pub enum SurfaceDataPropertyEditorMessage {
 impl MessageData for SurfaceDataPropertyEditorMessage {}
 
 #[derive(Clone, Visit, Reflect, Debug)]
-#[reflect(type_uuid = "8461a183-4fd4-4f74-a4f4-7fd8e84bf423")]
-#[reflect(derived_type = "UiNode")]
+#[reflect(
+    type_uuid = "8461a183-4fd4-4f74-a4f4-7fd8e84bf423",
+    derived_type = "UiNode",
+    non_comparable
+)]
 #[allow(dead_code)]
 pub struct SurfaceDataPropertyEditor {
     widget: Widget,

--- a/editor/src/plugins/inspector/editors/texture.rs
+++ b/editor/src/plugins/inspector/editors/texture.rs
@@ -61,7 +61,8 @@ use std::{
 #[derive(Clone, Visit, Reflect)]
 #[reflect(
     derived_type = "UiNode",
-    type_uuid = "5db49479-ff89-49b8-a038-0766253d6493"
+    type_uuid = "5db49479-ff89-49b8-a038-0766253d6493",
+    non_comparable
 )]
 pub struct TextureEditor {
     widget: Widget,

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -68,7 +68,7 @@ use std::{any::Any, sync::mpsc::Sender, sync::Arc};
 pub mod editors;
 pub mod handlers;
 
-#[derive(Clone, Reflect, Debug)]
+#[derive(Clone, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "e617f0b6-fb5f-4e41-85c2-9dbb1869af30")]
 pub struct AnimationDefinition {
     name: String,
@@ -76,7 +76,11 @@ pub struct AnimationDefinition {
 }
 
 #[derive(Reflect, Clone, Debug)]
-#[reflect(non_cloneable, type_uuid = "ff4bc6f3-a735-47d8-b455-f9fd6354bd5f")]
+#[reflect(
+    non_cloneable,
+    non_comparable,
+    type_uuid = "ff4bc6f3-a735-47d8-b455-f9fd6354bd5f"
+)]
 pub struct EditorEnvironment {
     pub resource_manager: ResourceManager,
     #[reflect(hidden)]
@@ -345,7 +349,7 @@ impl InspectorPlugin {
             object: obj,
             ctx: &mut ui.build_ctx(),
             definition_container: property_editors,
-            environment: Some(environment),
+            environment: Some(InspectorEnvironmentContainer(environment)),
             layer_index: 0,
             generate_property_string_values: true,
             filter: Default::default(),

--- a/editor/src/plugins/inspector/mod.rs
+++ b/editor/src/plugins/inspector/mod.rs
@@ -62,6 +62,7 @@ use crate::{
     utils::window_content,
     Editor, Message, WidgetMessage, WrapMode,
 };
+use fyrox::gui::inspector::InspectorEnvironmentContainer;
 use std::{any::Any, sync::mpsc::Sender, sync::Arc};
 
 pub mod editors;
@@ -93,7 +94,7 @@ pub struct EditorEnvironment {
 
 impl EditorEnvironment {
     pub fn try_get_from(
-        environment: &Option<Arc<dyn InspectorEnvironment>>,
+        environment: &Option<InspectorEnvironmentContainer>,
     ) -> Result<&Self, InspectorError> {
         let environment = &**environment.as_ref().ok_or(InspectorError::Custom(
             "Missing InspectorEnvironment".into(),

--- a/editor/src/plugins/material/editor.rs
+++ b/editor/src/plugins/material/editor.rs
@@ -74,7 +74,8 @@ impl MessageData for MaterialFieldMessage {}
 #[derive(Clone, Visit, Reflect)]
 #[reflect(
     derived_type = "UiNode",
-    type_uuid = "d3fa0a7c-52d6-4cca-885e-0db8b18542e2"
+    type_uuid = "d3fa0a7c-52d6-4cca-885e-0db8b18542e2",
+    non_comparable
 )]
 pub struct MaterialFieldEditor {
     widget: Widget,

--- a/editor/src/plugins/material/mod.rs
+++ b/editor/src/plugins/material/mod.rs
@@ -92,10 +92,11 @@ use crate::{
 };
 use fyrox::gui::dock::DockingManager;
 use fyrox::gui::stack_panel::StackPanel;
+use fyrox::gui::widget::UserData;
 use fyrox::gui::window::Window;
 use std::{
     path::PathBuf,
-    sync::{mpsc::Receiver, mpsc::Sender, Arc},
+    sync::{mpsc::Receiver, mpsc::Sender},
 };
 
 pub mod editor;
@@ -461,7 +462,7 @@ impl MaterialEditor {
                     let editor = TextureEditorBuilder::new(
                         WidgetBuilder::new()
                             .with_height(28.0)
-                            .with_user_data(Arc::new(Mutex::new(resource.name.clone())))
+                            .with_user_data(UserData::new(resource.name.clone()))
                             .with_allow_drop(true)
                             .with_tooltip(make_simple_tooltip(ctx, &path)),
                     )

--- a/editor/src/plugins/probe.rs
+++ b/editor/src/plugins/probe.rs
@@ -138,14 +138,14 @@ impl ReflectionProbePreviewControlPanel {
     }
 }
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "9a535782-87a9-4407-8d12-a723d67e179d")]
 struct DragContext {
     new_position: Vector3<f32>,
     plane_kind: PlaneKind,
 }
 
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable, type_uuid = "d8fd164c-523c-447a-93ab-e86f2d71eed6")]
 pub struct ReflectionProbeInteractionMode {
     probe: Handle<ReflectionProbe>,

--- a/editor/src/plugins/ragdoll.rs
+++ b/editor/src/plugins/ragdoll.rs
@@ -74,7 +74,7 @@ use fyrox::scene::joint::Joint;
 use fyrox::scene::ragdoll::Ragdoll;
 use std::{ops::Range, sync::Arc};
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(PartialEq, Reflect, Clone, Debug)]
 #[reflect(type_uuid = "07d73807-1716-4ea6-bef4-91903c214f7e")]
 pub struct RagdollPreset {
     /// A handle of a hips (pelvis) bone.

--- a/editor/src/plugins/settings.rs
+++ b/editor/src/plugins/settings.rs
@@ -23,9 +23,7 @@
 use crate::menu::create_menu_item_shortcut;
 use crate::{
     fyrox::{
-        core::{
-            log::Log, parking_lot::lock_api::Mutex, pool::Handle, reflect::Reflect, some_or_return,
-        },
+        core::{log::Log, pool::Handle, reflect::Reflect, some_or_return},
         engine::Engine,
         graph::SceneGraph,
         gui::{
@@ -61,6 +59,7 @@ use fyrox::gui::scroll_viewer::ScrollViewer;
 use fyrox::gui::searchbar::SearchBar;
 use fyrox::gui::stack_panel::StackPanel;
 use fyrox::gui::text_box::EmptyTextPlaceholder;
+use fyrox::gui::widget::UserData;
 use fyrox::gui::window::{Window, WindowAlignment};
 use rust_fuzzy_search::fuzzy_compare;
 use std::sync::Arc;
@@ -224,19 +223,19 @@ impl SettingsWindow {
             base_path: Default::default(),
             has_parent_object: false,
         });
-        let groups =
-            context
-                .entries
-                .iter()
-                .map(|entry| {
-                    ButtonBuilder::new(WidgetBuilder::new().with_user_data(Arc::new(Mutex::new(
-                        GroupName(entry.property_tag.clone()),
-                    ))))
-                    .with_text(&entry.property_display_name)
-                    .build(ctx)
-                    .to_base()
-                })
-                .collect::<Vec<_>>();
+        let groups = context
+            .entries
+            .iter()
+            .map(|entry| {
+                ButtonBuilder::new(
+                    WidgetBuilder::new()
+                        .with_user_data(UserData::new(GroupName(entry.property_tag.clone()))),
+                )
+                .with_text(&entry.property_display_name)
+                .build(ctx)
+                .to_base()
+            })
+            .collect::<Vec<_>>();
         ui.send(self.groups, WidgetMessage::ReplaceChildren(groups));
         ui.send(self.inspector, InspectorMessage::Context(context));
     }

--- a/editor/src/plugins/tilemap/autotile.rs
+++ b/editor/src/plugins/tilemap/autotile.rs
@@ -116,7 +116,7 @@ pub struct AutoTileMacro {
     autotiler: TileSetAutoTiler,
 }
 
-#[derive(Default, Debug, Clone, Reflect)]
+#[derive(Default, Debug, PartialEq, Clone, Reflect)]
 #[reflect(type_uuid = "e50fa366-145d-4491-8126-acdd162031ea")]
 struct CellData {
     terrain_id: TileTerrainId,
@@ -138,7 +138,7 @@ impl Visit for CellData {
     }
 }
 
-#[derive(Debug, Default, Clone, Visit, Reflect)]
+#[derive(Debug, Default, Clone, PartialEq, Visit, Reflect)]
 #[reflect(type_uuid = "b320543d-3df0-43fd-b0d9-60a398f49853")]
 pub(super) struct AutoTileInstance {
     frequency_property: Option<TileSetPropertyF32>,
@@ -151,7 +151,7 @@ pub(super) struct AutoTileInstance {
     widgets: InstanceCellWidgets,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 struct InstanceCellWidgets {
     handle: Handle<UiNode>,
     value_field: MacroPropertyValueField,

--- a/editor/src/plugins/tilemap/brush_macro.rs
+++ b/editor/src/plugins/tilemap/brush_macro.rs
@@ -20,10 +20,11 @@
 
 use super::*;
 use crate::command::{Command, CommandContext, CommandTrait};
+use fyrox::asset::TypedResourceData;
 use fyrox::gui::dropdown_list::DropdownList;
 use fyrox::gui::message::{DeliveryMode, MessageData};
 use fyrox::{
-    asset::{untyped::UntypedResource, Resource, ResourceData, ResourceDataRef},
+    asset::{untyped::UntypedResource, Resource, ResourceDataRef},
     core::{
         futures::executor::block_on,
         log::Log,
@@ -53,6 +54,12 @@ const UNKNOWN_PROPERTY: &str = "UNKNOWN PROPERTY";
 /// the list are the tile map interaction mode and the [`TileSetEditor`].
 #[derive(Default, Clone)]
 pub struct BrushMacroListRef(Arc<Mutex<BrushMacroList>>);
+
+impl PartialEq for BrushMacroListRef {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
 
 impl BrushMacroListRef {
     /// Create a new reference and assign it to point to the given macro list.
@@ -128,7 +135,7 @@ impl BrushMacroInstance {
     /// A typed reference to the configuration resource.
     pub fn settings<T>(&self) -> Option<Resource<T>>
     where
-        T: ResourceData + Default,
+        T: TypedResourceData,
     {
         self.settings.as_ref()?.try_cast()
     }
@@ -211,7 +218,7 @@ impl BrushMacroCellContext {
     /// A typed reference to the configuration resource.
     pub fn settings<T>(&self) -> Option<Resource<T>>
     where
-        T: ResourceData + Default,
+        T: TypedResourceData,
     {
         self.settings.as_ref()?.try_cast()
     }
@@ -651,7 +658,7 @@ impl TileSetPropertyMessage {
 /// A field that allows the user to choose a property value from a [`TileSet`].
 /// The property is represented as a [`TileSetPropertyValueElement`] internally, but the user
 /// is given a dropdown list of value names if possible.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct MacroPropertyValueField {
     handle: Handle<UiNode>,
     textbox: Handle<UiNode>,

--- a/editor/src/plugins/tilemap/handle_editor.rs
+++ b/editor/src/plugins/tilemap/handle_editor.rs
@@ -76,7 +76,7 @@ impl MessageData for TileDefinitionHandleEditorMessage {}
 /// pair is the page coordinates and the second pair is the tile coordinates.
 /// When editing the handle, one need merely type four integers. Whatever
 /// characters separate the integers are ignored, so "1 2 3 4" would be accepted.
-#[derive(Clone, Debug, Visit, Reflect)]
+#[derive(Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "60146cf0-33e3-4757-8e66-e7196324271f")]
 pub struct TileDefinitionHandleEditor {

--- a/editor/src/plugins/tilemap/handle_field.rs
+++ b/editor/src/plugins/tilemap/handle_field.rs
@@ -53,7 +53,7 @@ impl MessageData for TileHandleEditorMessage {}
 /// pair is the page coordinates and the second pair is the tile coordinates.
 /// When editing the handle, one need merely type four integers. Whatever
 /// characters separate the integers are ignored, so "1 2 3 4" would be accepted.
-#[derive(Debug, Default, Clone, Visit, Reflect)]
+#[derive(Debug, Default, Clone, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "86513074-461d-4583-a214-fb84f5aacac1")]
 #[reflect(derived_type = "UiNode")]
 pub struct TileHandleField {

--- a/editor/src/plugins/tilemap/interaction_mode.rs
+++ b/editor/src/plugins/tilemap/interaction_mode.rs
@@ -20,12 +20,14 @@
 
 //! The [`InteractionMode`] for editing a tile map.
 
+use super::*;
 use crate::{
     command::{Command, CommandGroup},
     make_color_material,
 };
 use commands::{MoveMapTileCommand, SetMapTilesCommand};
 use fyrox::gui::button::Button;
+use fyrox::scene::tilemap::{TileMapEffectRef, TileMapEffectRefContainer};
 use fyrox::{
     asset::untyped::UntypedResource,
     core::reflect::prelude::*,
@@ -40,8 +42,6 @@ use fyrox::{
     },
 };
 use std::fmt::Formatter;
-
-use super::*;
 
 const CURSOR_COLOR: Color = Color::from_rgba(255, 255, 255, 30);
 const SELECT_COLOR: Color = Color::from_rgba(255, 255, 0, 200);
@@ -64,6 +64,7 @@ enum MouseMode {
 #[derive(Reflect)]
 #[reflect(
     non_cloneable,
+    non_comparable,
     type_uuid = "33fa8ef9-a29c-45d4-a493-79571edd870a",
     hide_all
 )]
@@ -172,15 +173,15 @@ impl TileMapInteractionMode {
     pub fn on_tile_map_selected(&mut self, tile_map: &mut TileMap) {
         tile_map.before_effects.clear();
         tile_map.before_effects.extend([
-            self.overlay_effect.clone() as TileMapEffectRef,
-            self.update_effect.clone() as TileMapEffectRef,
-            self.erase_effect.clone() as TileMapEffectRef,
+            TileMapEffectRefContainer(self.overlay_effect.clone() as TileMapEffectRef),
+            TileMapEffectRefContainer(self.update_effect.clone() as TileMapEffectRef),
+            TileMapEffectRefContainer(self.erase_effect.clone() as TileMapEffectRef),
         ]);
         tile_map.after_effects.clear();
         tile_map.after_effects.extend([
-            self.cursor_effect.clone() as TileMapEffectRef,
-            self.erase_select_effect.clone() as TileMapEffectRef,
-            self.select_effect.clone() as TileMapEffectRef,
+            TileMapEffectRefContainer(self.cursor_effect.clone() as TileMapEffectRef),
+            TileMapEffectRefContainer(self.erase_select_effect.clone() as TileMapEffectRef),
+            TileMapEffectRefContainer(self.select_effect.clone() as TileMapEffectRef),
         ]);
     }
     fn pick_grid(

--- a/editor/src/plugins/tilemap/macro_inspector.rs
+++ b/editor/src/plugins/tilemap/macro_inspector.rs
@@ -40,7 +40,7 @@ const CELL_WITH_MACRO_COLOR: Color = Color::DARK_SLATE_BLUE;
 const CELL_WITHOUT_MACRO_COLOR: Color = Color::opaque(50, 50, 50);
 
 #[derive(Visit, Clone, Reflect)]
-#[reflect(type_uuid = "b003f118-4dda-4529-a791-ad20860c124d")]
+#[reflect(type_uuid = "b003f118-4dda-4529-a791-ad20860c124d", non_comparable)]
 pub struct MacroInspector {
     handle: Handle<UiNode>,
     content: Handle<UiNode>,

--- a/editor/src/plugins/tilemap/mod.rs
+++ b/editor/src/plugins/tilemap/mod.rs
@@ -59,7 +59,7 @@ use fyrox::gui::text::TextBuilder;
 use fyrox::gui::{message::KeyCode, texture::TextureResource};
 use fyrox::gui::{HorizontalAlignment, VerticalAlignment};
 use fyrox::scene::tilemap::tileset::{TileSetPropertyLayer, ELEMENT_MATCH_HIGHLIGHT_COLOR};
-use fyrox::scene::tilemap::{StampElement, TileMapEffectRef};
+use fyrox::scene::tilemap::StampElement;
 pub use handle_editor::*;
 use handle_field::*;
 use interaction_mode::*;

--- a/editor/src/plugins/tilemap/palette.rs
+++ b/editor/src/plugins/tilemap/palette.rs
@@ -165,8 +165,11 @@ fn calc_slice_coord(position: f32, step: f32) -> usize {
 /// Displays a scrollable grid of till cells, with options to allow the tiles
 /// to be selected, dragged, and edits in various ways.
 #[derive(Clone, Visit, Reflect)]
-#[reflect(type_uuid = "5356a864-c026-4bd7-a4b1-30bacf77d8fa")]
-#[reflect(derived_type = "UiNode")]
+#[reflect(
+    derived_type = "UiNode",
+    type_uuid = "5356a864-c026-4bd7-a4b1-30bacf77d8fa",
+    non_comparable
+)]
 pub struct PaletteWidget {
     widget: Widget,
     #[visit(skip)]
@@ -278,7 +281,7 @@ impl Debug for PaletteWidget {
 
 type PaletteTriangleData = (Vec<Point2<f32>>, Vec<[u32; 3]>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 struct ColliderHighlight {
     position: Vector2<i32>,
     color: Color,

--- a/editor/src/plugins/tilemap/panel_preview.rs
+++ b/editor/src/plugins/tilemap/panel_preview.rs
@@ -50,8 +50,11 @@ use fyrox::material::MaterialResource;
 /// currently selected tile stamp, including whatever transformations have been applied
 /// to the stamp.
 #[derive(Clone, Debug, Visit, Reflect)]
-#[reflect(type_uuid = "5356a864-c026-4bd7-a4b1-30bacf77d8fa")]
-#[reflect(derived_type = "UiNode")]
+#[reflect(
+    non_comparable,
+    derived_type = "UiNode",
+    type_uuid = "5356a864-c026-4bd7-a4b1-30bacf77d8fa"
+)]
 pub struct PanelPreview {
     widget: Widget,
     /// The tile editing state that is shared with palette widgets, the tile map interaction mode,

--- a/editor/src/plugins/tilemap/tile_bounds_editor.rs
+++ b/editor/src/plugins/tilemap/tile_bounds_editor.rs
@@ -46,7 +46,7 @@ pub enum TileBoundsMessage {
 }
 impl MessageData for TileBoundsMessage {}
 
-#[derive(Clone, Default, Debug, Visit, Reflect)]
+#[derive(Clone, Default, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "1e600103-6516-4c5a-a30b-f90f64fc9623")]
 #[reflect(derived_type = "UiNode")]
 pub struct TileBoundsEditor {

--- a/editor/src/plugins/tilemap/tile_inspector.rs
+++ b/editor/src/plugins/tilemap/tile_inspector.rs
@@ -544,7 +544,7 @@ fn find_collider_value(
         .unwrap_or_default()
 }
 
-#[derive(Clone, Default, Debug, Visit, Reflect)]
+#[derive(Clone, Default, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "9c65682b-0160-443c-95fc-0b88f86a497b")]
 struct InspectorField {
     handle: Handle<Grid>,
@@ -572,7 +572,7 @@ impl InspectorField {
 
 /// Object that keeps track of the editors for all the property layers.
 #[derive(Clone, Default, Visit, Reflect)]
-#[reflect(type_uuid = "89171a35-a7e7-4ce7-a017-124e8eec5746")]
+#[reflect(type_uuid = "89171a35-a7e7-4ce7-a017-124e8eec5746", non_comparable)]
 struct PropertyEditors {
     handle: Handle<UiNode>,
     content: Handle<UiNode>,
@@ -646,7 +646,7 @@ impl PropertyEditors {
 
 /// Object that keeps track of the editors for all the collider layers.
 #[derive(Clone, Default, Visit, Reflect)]
-#[reflect(type_uuid = "97acc27d-c6fc-491b-9faa-6ad2f124f126")]
+#[reflect(type_uuid = "97acc27d-c6fc-491b-9faa-6ad2f124f126", non_comparable)]
 struct ColliderEditors {
     handle: Handle<UiNode>,
     content: Handle<UiNode>,
@@ -719,7 +719,7 @@ impl ColliderEditors {
 }
 
 #[derive(Visit, Reflect, Clone)]
-#[reflect(type_uuid = "cd0f6716-3d7c-4c39-a2aa-98274ca6efa2")]
+#[reflect(type_uuid = "cd0f6716-3d7c-4c39-a2aa-98274ca6efa2", non_comparable)]
 pub struct TileInspector {
     handle: Handle<UiNode>,
     /// The shared state that represents the user's currently selected tool and tiles.

--- a/editor/src/plugins/tilemap/wfc.rs
+++ b/editor/src/plugins/tilemap/wfc.rs
@@ -71,7 +71,7 @@ pub struct WfcMacro {
     current_terrain: TileTerrainId,
 }
 
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone, PartialEq, Visit, Reflect)]
 #[reflect(type_uuid = "24f9947e-f58b-4623-ad14-cb21cd09297e")]
 pub(super) struct WfcInstance {
     frequency_property: Option<TileSetPropertyF32>,

--- a/editor/src/scene/commands/mod.rs
+++ b/editor/src/scene/commands/mod.rs
@@ -46,8 +46,11 @@ pub mod sound_context;
 pub mod terrain;
 
 #[derive(Reflect, Debug)]
-#[reflect(non_cloneable)]
-#[reflect(type_uuid = "4dd03d8c-b0c9-43a2-871c-55e5fd603afd")]
+#[reflect(
+    type_uuid = "4dd03d8c-b0c9-43a2-871c-55e5fd603afd",
+    non_cloneable,
+    non_comparable
+)]
 pub struct GameSceneContext {
     pub selection: &'static mut Selection,
     pub scene: &'static mut Scene,

--- a/editor/src/scene/nullscene.rs
+++ b/editor/src/scene/nullscene.rs
@@ -29,7 +29,7 @@ use super::*;
 
 /// The [`CommandContext`] that is used when the current scene is the
 /// null scene.
-#[derive(Reflect, Debug)]
+#[derive(PartialEq, Reflect, Debug)]
 #[reflect(non_cloneable)]
 #[reflect(type_uuid = "09ba866d-db75-46fb-938b-b3cc583f4469")]
 pub struct NullSceneContext {

--- a/editor/src/scene/property.rs
+++ b/editor/src/scene/property.rs
@@ -20,8 +20,8 @@
 
 use crate::fyrox::{
     core::{
-        make_pretty_type_name, parking_lot::Mutex, pool::Handle, reflect::prelude::*,
-        sstorage::ImmutableString, visitor::prelude::*,
+        make_pretty_type_name, pool::Handle, reflect::prelude::*, sstorage::ImmutableString,
+        visitor::prelude::*,
     },
     fxhash::FxHashSet,
     graph::SceneGraph,
@@ -50,10 +50,10 @@ use fyrox::gui::style::resource::StyleResourceExt;
 use fyrox::gui::style::Style;
 use fyrox::gui::text_box::EmptyTextPlaceholder;
 use fyrox::gui::tree::TreeRoot;
+use fyrox::gui::widget::UserData;
 use std::{
     any::TypeId,
     ops::{Deref, DerefMut},
-    sync::Arc,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -140,13 +140,13 @@ impl PropertyDescriptor {
                 make_pretty_type_name(&self.type_name)
             );
 
-            TreeBuilder::new(WidgetBuilder::new().with_user_data(Arc::new(Mutex::new(
+            TreeBuilder::new(WidgetBuilder::new().with_user_data(UserData::new(
                 PropertyDescriptorData {
                     name: name.clone(),
                     path: self.path.clone(),
                     type_id: self.type_id,
                 },
-            ))))
+            )))
             .with_items(items)
             .with_content(
                 TextBuilder::new(WidgetBuilder::new().with_margin(Thickness::uniform(1.0)))
@@ -290,7 +290,7 @@ where
     descriptors
 }
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "8e58e123-48a1-4e18-9e90-fd35a1669bdc"
@@ -480,7 +480,7 @@ impl PropertySelectorBuilder {
     }
 }
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "725e4a10-eca6-4345-9833-d54dae2f20f2"

--- a/editor/src/scene/selector.rs
+++ b/editor/src/scene/selector.rs
@@ -20,10 +20,7 @@
 
 use crate::{
     fyrox::{
-        core::{
-            parking_lot::Mutex, pool::ErasedHandle, pool::Handle, reflect::prelude::*,
-            visitor::prelude::*,
-        },
+        core::{pool::ErasedHandle, pool::Handle, reflect::prelude::*, visitor::prelude::*},
         fxhash::FxHashSet,
         graph::{NodeWrapper, SceneGraph},
         gui::{
@@ -55,12 +52,12 @@ use fyrox::gui::scroll_viewer::ScrollViewer;
 use fyrox::gui::searchbar::SearchBar;
 use fyrox::gui::text_box::EmptyTextPlaceholder;
 use fyrox::gui::tree::TreeRoot;
+use fyrox::gui::widget::UserData;
 use std::hash::{Hash, Hasher};
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
     ops::{Deref, DerefMut},
-    sync::Arc,
 };
 
 #[derive(Eq, Clone, Debug, PartialEq)]
@@ -135,14 +132,12 @@ impl HierarchyNode {
             ctx.style.property(Style::BRUSH_LIGHT)
         };
 
-        TreeBuilder::new(
-            WidgetBuilder::new().with_user_data(Arc::new(Mutex::new(TreeData {
-                name: self.name.clone(),
-                handle: self.handle,
-                inner_type_id: self.inner_type_id,
-                derived_type_ids: self.derived_type_ids.clone(),
-            }))),
-        )
+        TreeBuilder::new(WidgetBuilder::new().with_user_data(UserData::new(TreeData {
+            name: self.name.clone(),
+            handle: self.handle,
+            inner_type_id: self.inner_type_id,
+            derived_type_ids: self.derived_type_ids.clone(),
+        })))
         .with_items(
             self.children
                 .iter()
@@ -207,7 +202,7 @@ struct TreeData {
     pub derived_type_ids: Vec<TypeId>,
 }
 
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone,PartialEq,  Visit, Reflect)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "1d718f90-323c-492d-b057-98d47495900a")]
 pub struct NodeSelector {
@@ -428,7 +423,7 @@ impl NodeSelectorBuilder {
     }
 }
 
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone,PartialEq,  Visit, Reflect)]
 #[reflect(type_uuid = "5bb00f15-d6ec-4f0e-af7e-9472b0e290b4")]
 #[reflect(derived_type = "UiNode")]
 pub struct NodeSelectorWindow {

--- a/editor/src/scene/selector.rs
+++ b/editor/src/scene/selector.rs
@@ -202,7 +202,7 @@ struct TreeData {
     pub derived_type_ids: Vec<TypeId>,
 }
 
-#[derive(Debug, Clone,PartialEq,  Visit, Reflect)]
+#[derive(Debug, Clone, PartialEq, Visit, Reflect)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "1d718f90-323c-492d-b057-98d47495900a")]
 pub struct NodeSelector {
@@ -423,7 +423,7 @@ impl NodeSelectorBuilder {
     }
 }
 
-#[derive(Debug, Clone,PartialEq,  Visit, Reflect)]
+#[derive(Debug, Clone, PartialEq, Visit, Reflect)]
 #[reflect(type_uuid = "5bb00f15-d6ec-4f0e-af7e-9472b0e290b4")]
 #[reflect(derived_type = "UiNode")]
 pub struct NodeSelectorWindow {

--- a/editor/src/scene/settings/mod.rs
+++ b/editor/src/scene/settings/mod.rs
@@ -56,7 +56,7 @@ use crate::{
     GameScene, Message,
 };
 use fyrox::gui::inspector::editors::inspectable::InspectablePropertyEditorDefinition;
-use fyrox::gui::inspector::Inspector;
+use fyrox::gui::inspector::{Inspector, InspectorEnvironmentContainer};
 use std::sync::{mpsc::Sender, Arc};
 
 pub struct SceneSettingsWindow {
@@ -160,7 +160,7 @@ impl SceneSettingsWindow {
             object,
             ctx: &mut ui.build_ctx(),
             definition_container: self.property_definitions.clone(),
-            environment: Some(environment),
+            environment: Some(InspectorEnvironmentContainer(environment)),
             layer_index: 0,
             generate_property_string_values: false,
             filter: PropertyFilter::new(|property| {

--- a/editor/src/ui_scene/commands/mod.rs
+++ b/editor/src/ui_scene/commands/mod.rs
@@ -40,6 +40,15 @@ pub struct UiSceneContext {
     pub clipboard: &'static mut Clipboard,
 }
 
+impl PartialEq for UiSceneContext {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::addr_eq(self.ui, other.ui)
+            && std::ptr::addr_eq(self.selection, other.selection)
+            && std::ptr::addr_eq(self.clipboard, other.clipboard)
+            && self.message_sender == other.message_sender
+    }
+}
+
 impl UiSceneContext {
     pub fn exec<'a, F>(
         ui: &'a mut UserInterface,

--- a/editor/src/ui_scene/interaction/mod.rs
+++ b/editor/src/ui_scene/interaction/mod.rs
@@ -43,7 +43,7 @@ use fyrox::gui::image::Image;
 
 pub mod move_mode;
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(PartialEq, Reflect, Clone, Debug)]
 #[reflect(type_uuid = "12e550dc-0fb2-4a45-8060-fa363db3e197")]
 pub struct UiSelectInteractionMode {
     preview: Handle<Image>,

--- a/editor/src/ui_scene/interaction/move_mode.rs
+++ b/editor/src/ui_scene/interaction/move_mode.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 use fyrox::gui::button::Button;
 
-#[derive(Reflect, Debug, Clone)]
+#[derive(PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "05a1b439-d354-45b1-9014-10393c5ba35d")]
 struct Entry {
     widget: Handle<UiNode>,
@@ -43,13 +43,13 @@ struct Entry {
     delta: Vector2<f32>,
 }
 
-#[derive(Reflect, Debug, Clone)]
+#[derive(PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "c9b6b3d6-ade9-4da2-a5e7-48893f24d97f")]
 struct MoveContext {
     entries: Vec<Entry>,
 }
 
-#[derive(Reflect, Debug, Clone)]
+#[derive(PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "e5c09b04-5c31-4044-ac48-5227ab4a4b83")]
 pub struct MoveWidgetsInteractionMode {
     move_context: Option<MoveContext>,

--- a/editor/src/world/item.rs
+++ b/editor/src/world/item.rs
@@ -62,7 +62,7 @@ pub enum SceneItemMessage {
 }
 impl MessageData for SceneItemMessage {}
 
-#[derive(Copy, Clone)]
+#[derive(Copy, PartialEq, Clone)]
 pub enum DropAnchor {
     Side {
         visual_offset: f32,
@@ -71,7 +71,7 @@ pub enum DropAnchor {
     OnTop,
 }
 
-#[derive(Visit, Reflect)]
+#[derive(Visit, PartialEq, Reflect)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "16f35257-a250-413b-ab51-b1ad086a3a9c")]
 pub struct SceneItem {

--- a/fyrox-autotile/src/auto.rs
+++ b/fyrox-autotile/src/auto.rs
@@ -119,7 +119,7 @@ pub trait PatternSource {
 /// to fit with the new terrain of this cell. This object specifies whether that should
 /// be done. Cells that are added this way keep their current terrain, but their pattern
 /// may change.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, PartialEq, Copy)]
 pub struct ConstraintFillRules {
     /// True if adjacent cells should be automatically added to the autotiling constraint
     /// so that they may be modified.

--- a/fyrox-build-tools/src/export/mod.rs
+++ b/fyrox-build-tools/src/export/mod.rs
@@ -49,7 +49,7 @@ pub struct BuildOutput {
 
 pub type BuildResult = Result<BuildOutput, String>;
 
-#[derive(Reflect, Debug, Clone)]
+#[derive(PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "b1387e05-fb9f-48d8-8776-5b1d2993fa1a")]
 pub struct ExportOptions {
     #[reflect(hidden)]

--- a/fyrox-core-derive/src/reflect.rs
+++ b/fyrox-core-derive/src/reflect.rs
@@ -443,6 +443,18 @@ fn gen_impl(
         }
     };
 
+    let try_compare = if ty_args.non_comparable {
+        quote! {
+            fn try_compare(&self, _other: &dyn Reflect) -> Option<bool> { None }
+        }
+    } else {
+        quote! {
+            fn try_compare(&self, other: &dyn Reflect) -> Option<bool> {
+                (other as &dyn Any).downcast_ref::<Self>().map(|other| other == self)
+            }
+        }
+    };
+
     let type_uuid_str = ty_args.type_uuid.as_str();
     let type_uuid = if ty_args.generics.params.is_empty() {
         quote! { uuid!(#type_uuid_str) }
@@ -493,6 +505,8 @@ fn gen_impl(
             }
 
             #try_clone_box
+
+            #try_compare
 
             fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
                 #metadata_ref

--- a/fyrox-core-derive/src/reflect/args.rs
+++ b/fyrox-core-derive/src/reflect/args.rs
@@ -64,6 +64,9 @@ pub struct TypeArgs {
     pub non_cloneable: bool,
 
     #[darling(default)]
+    pub non_comparable: bool,
+
+    #[darling(default)]
     pub clone_fn: Option<Path>,
 
     pub type_uuid: String,

--- a/fyrox-core-derive/tests/it/reflect.rs
+++ b/fyrox-core-derive/tests/it/reflect.rs
@@ -32,7 +32,7 @@ use fyrox_core::{parking_lot::Mutex, reflect::prelude::*};
 
 /// Struct doc comment.
 #[allow(dead_code)]
-#[derive(Reflect, Debug, Clone)]
+#[derive(Reflect, Debug, PartialEq, Clone)]
 #[reflect(type_uuid = "ad7fce64-1e1d-4751-b7c7-63b0f981443d")]
 pub struct Struct {
     /// This is a
@@ -42,11 +42,11 @@ pub struct Struct {
     hidden: usize,
 }
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(Reflect, Clone, PartialEq, Debug)]
 #[reflect(type_uuid = "56bb558c-3e75-44ed-b249-dfe1dc4ae00d")]
 pub struct Tuple(usize, usize);
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(Reflect, Clone, PartialEq, Debug)]
 #[reflect(type_uuid = "e11dd933-5fe0-4e19-9183-e116c438eb0f")]
 pub enum Enum {
     Named { field: usize },
@@ -126,7 +126,7 @@ fn reflect_field_accessors() {
 
 #[test]
 fn reflect_containers() {
-    #[derive(Debug, Clone)]
+    #[derive(Debug, PartialEq, Clone)]
     struct DerefContainer<T> {
         data: T,
     }
@@ -144,7 +144,7 @@ fn reflect_containers() {
         }
     }
 
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
     #[reflect(type_uuid = "414ec606-65bc-478e-94ea-326f477818aa")]
     struct X {
         #[reflect(deref)]
@@ -166,8 +166,8 @@ fn reflect_containers() {
 
     x.get_resolve_path::<usize>("container.field", &mut |result| assert_eq!(result, Ok(&0)));
 
-    #[derive(Reflect, Clone, Debug)]
-    #[reflect(bounds = "T: Reflect + Clone")]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
+    #[reflect(bounds = "T: Reflect + Clone + PartialEq")]
     #[reflect(type_uuid = "b3120e24-2c01-40ef-9c89-6ca40e713260")]
     struct B<T> {
         #[reflect(deref)]
@@ -187,7 +187,7 @@ fn reflect_containers() {
 
 #[test]
 fn reflect_path() {
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
     #[reflect(type_uuid = "d539b45a-c8be-4009-95ff-3ac0dfeaa47f")]
     struct Hierarchy {
         s: Struct,
@@ -227,13 +227,13 @@ fn reflect_list_path() {
     let data = vec![vec![0usize, 1], vec![2, 3, 4]];
     data.get_resolve_path("[0][1]", &mut |result| assert_eq!(result, Ok(&1usize)));
 
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
     #[reflect(type_uuid = "19d84906-550f-4dcd-82f8-1261ddc86139")]
     struct X {
         data: Vec<usize>,
     }
 
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
     #[reflect(type_uuid = "29da25ee-14ae-42b3-89f7-bca518188600")]
     struct A {
         xs: Vec<X>,
@@ -255,8 +255,8 @@ fn reflect_list_path() {
 
 #[test]
 fn reflect_custom_setter() {
-    #[derive(Reflect, Clone, Debug)]
-    #[reflect(bounds = "T: Reflect + Clone")]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
+    #[reflect(bounds = "T: Reflect + Clone + PartialEq")]
     #[reflect(type_uuid = "9b23adf0-e9dd-4fbc-b410-8f9c0da26a20")]
     pub struct Wrapper<T> {
         #[reflect(setter = "set_value")]
@@ -285,7 +285,7 @@ fn reflect_custom_setter() {
 
 #[test]
 fn reflect_fields_list_of_struct() {
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
     #[reflect(type_uuid = "45204fc1-ca94-4349-a6b8-f8a812545052")]
     struct Foo {
         field_a: f32,
@@ -311,7 +311,7 @@ fn reflect_fields_list_of_struct() {
 
 #[test]
 fn reflect_fields_list_of_enum() {
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
     #[reflect(type_uuid = "ea3d20cf-7f77-40d1-b1f3-38cb9f2ccc06")]
     enum Foo {
         Bar { field_a: f32 },
@@ -359,7 +359,7 @@ fn default_prop_metadata() -> FieldMetadata<'static> {
 
 #[test]
 fn inspect_default() {
-    #[derive(Debug, Default, Clone, Reflect)]
+    #[derive(Debug, Default, Clone, PartialEq, Reflect)]
     #[reflect(type_uuid = "51374579-08e8-4233-930e-239b00938371")]
     pub struct Data {
         the_field: String,
@@ -396,14 +396,14 @@ fn inspect_default() {
 
 #[test]
 fn inspect_attributes() {
-    #[derive(Debug, Default, Clone, Reflect)]
+    #[derive(Debug, Default, Clone, PartialEq, Reflect)]
     #[reflect(type_uuid = "e8bb7752-6ff6-4cbb-87fd-e7c10e5ec970")]
     pub struct AarGee {
         aar: u32,
         gee: u32,
     }
 
-    #[derive(Debug, Default, Clone, Reflect)]
+    #[derive(Debug, Default, Clone, PartialEq, Reflect)]
     #[reflect(type_uuid = "4e0709c6-b89a-47cb-ab06-f19b01b85ec1")]
     pub struct Data {
         // NOTE: Even though this field is skipped, the next field is given index `1` for simplicity
@@ -488,7 +488,7 @@ fn inspect_struct() {
         )
     });
 
-    #[derive(Debug, Default, Clone, Reflect)]
+    #[derive(Debug, Default, Clone, PartialEq, Reflect)]
     #[reflect(type_uuid = "ea0a8630-f6ca-45b1-84f4-e49f523328b5")]
     struct Unit;
 
@@ -498,13 +498,13 @@ fn inspect_struct() {
 
 #[test]
 fn inspect_enum() {
-    #[derive(Debug, Clone, Reflect)]
+    #[derive(Debug, Clone, PartialEq, Reflect)]
     #[reflect(type_uuid = "3c045962-be82-4655-8444-ec5867fc8244")]
     pub struct NonCopy {
         inner: u32,
     }
 
-    #[derive(Debug, Clone, Reflect)]
+    #[derive(Debug, Clone, PartialEq, Reflect)]
     #[reflect(type_uuid = "1948ec80-47d6-4607-ac39-aa92b225e2a8")]
     pub enum Data {
         Named { x: u32, y: u32, z: NonCopy },
@@ -599,7 +599,7 @@ fn inspect_enum() {
 #[test]
 fn inspect_prop_key_constants() {
     #[allow(dead_code)]
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(PartialEq, Reflect, Clone, Debug)]
     #[reflect(type_uuid = "7a97f35b-3919-4ad8-bf7a-72f21c8639c4")]
     pub struct SStruct {
         field: usize,
@@ -613,12 +613,12 @@ fn inspect_prop_key_constants() {
     // hidden properties
     // assert_eq!(SStruct::HIDDEN, "hidden");
 
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(PartialEq, Reflect, Clone, Debug)]
     #[reflect(type_uuid = "16aeb5c7-e3cd-49bd-999f-5d54c159dc20")]
     pub struct STuple(usize);
     assert_eq!(STuple::F_0, "0");
 
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(PartialEq, Reflect, Clone, Debug)]
     #[reflect(type_uuid = "272d8a6f-59dd-412e-a28a-0e9b63df40cc")]
     #[allow(unused)]
     pub enum E {
@@ -690,7 +690,7 @@ fn test_hash_map() {
     }
 
     // Check path resolution.
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(PartialEq, Reflect, Clone, Debug)]
     #[reflect(type_uuid = "89281d16-93d1-4669-8006-f7d371cb28f3")]
     struct Something {
         hash_map: HashMap<String, Struct>,

--- a/fyrox-core-derive/tests/it/reflect.rs
+++ b/fyrox-core-derive/tests/it/reflect.rs
@@ -458,7 +458,7 @@ fn inspect_attributes() {
 
 #[test]
 fn inspect_struct() {
-    #[derive(Debug, Default, Clone, Reflect)]
+    #[derive(Debug, Default, Clone, PartialEq, Reflect)]
     #[reflect(type_uuid = "488c51be-b7d8-4d2b-ad70-fbfd688f372f")]
     struct Tuple(f32, f32);
 

--- a/fyrox-core/src/dyntype.rs
+++ b/fyrox-core/src/dyntype.rs
@@ -156,9 +156,15 @@ impl Clone for DynTypeWrapper {
     }
 }
 
+impl PartialEq for DynTypeWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.try_compare(other.0.deref()).unwrap_or_default()
+    }
+}
+
 /// "Nullable" container for a dyntype. This container is essentially a wrapper for [`Option`] that
 /// supports additional functionality and handles serialization for you.
-#[derive(Default, Reflect, Clone, Debug)]
+#[derive(Default, Reflect, Clone, PartialEq, Debug)]
 #[reflect(type_uuid = "c0510bdd-36cd-451c-975b-9333b18db308")]
 pub struct DynTypeContainer(pub Option<DynTypeWrapper>);
 
@@ -269,6 +275,14 @@ pub struct DynTypeConstructorDefinition {
     pub assembly_name: &'static str,
 }
 
+impl PartialEq for DynTypeConstructorDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && std::ptr::addr_eq(self.constructor.deref(), other.constructor.deref())
+            && self.assembly_name == other.assembly_name
+    }
+}
+
 /// A set of constructors that allows to create a dyntype by its type uuid.
 #[derive(Default, Reflect)]
 #[reflect(
@@ -278,6 +292,12 @@ pub struct DynTypeConstructorDefinition {
 )] // TODO
 pub struct DynTypeConstructorContainer {
     map: Mutex<FxHashMap<Uuid, DynTypeConstructorDefinition>>,
+}
+
+impl PartialEq for DynTypeConstructorContainer {
+    fn eq(&self, other: &Self) -> bool {
+        *self.map.lock() == *other.map.lock()
+    }
 }
 
 impl Debug for DynTypeConstructorContainer {

--- a/fyrox-core/src/math/mod.rs
+++ b/fyrox-core/src/math/mod.rs
@@ -37,7 +37,7 @@ use fyrox_core_derive::{impl_reflect, impl_visit};
 
 impl_reflect!(
     #[reflect(type_uuid = "64ef33b7-d05a-4d8d-b0c7-99bcc919271f")]
-    pub struct Rect<T: Reflect + Copy> {}
+    pub struct Rect<T: Reflect + Copy + PartialEq> {}
 );
 
 impl<T> Visit for Rect<T>

--- a/fyrox-core/src/pool/handle.rs
+++ b/fyrox-core/src/pool/handle.rs
@@ -207,6 +207,12 @@ impl<T: Reflect> Reflect for Handle<T> {
             None
         }
     }
+
+    fn try_compare(&self, other: &dyn Reflect) -> Option<bool> {
+        (other as &dyn std::any::Any)
+            .downcast_ref::<Self>()
+            .map(|other| other == self)
+    }
 }
 
 impl<T> Copy for Handle<T> {}

--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -144,8 +144,8 @@ where
 
 impl<T, P> Reflect for Pool<T, P>
 where
-    T: Reflect,
-    P: PayloadContainer<Element = T> + Reflect,
+    T: Reflect + PartialEq,
+    P: PayloadContainer<Element = T> + Reflect + PartialEq,
     Pool<T, P>: Clone,
 {
     fn type_info() -> TypeInfo {
@@ -213,8 +213,8 @@ where
 
 impl<T, P> ReflectArray for Pool<T, P>
 where
-    T: Reflect,
-    P: PayloadContainer<Element = T> + Reflect,
+    T: Reflect + PartialEq,
+    P: PayloadContainer<Element = T> + Reflect + PartialEq,
     Pool<T, P>: Clone,
 {
     #[inline]

--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -170,6 +170,12 @@ where
         Some(Box::new(self.clone()))
     }
 
+    fn try_compare(&self, other: &dyn Reflect) -> Option<bool> {
+        (other as &dyn std::any::Any)
+            .downcast_ref::<Self>()
+            .map(|other| other == self)
+    }
+
     #[inline]
     fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
         func(&[])

--- a/fyrox-core/src/reflect/array.rs
+++ b/fyrox-core/src/reflect/array.rs
@@ -43,7 +43,7 @@ pub trait ReflectList: ReflectArray {
     ) -> Result<(), Box<dyn Reflect>>;
 }
 
-impl<const N: usize, T: Reflect + Clone> ReflectArray for [T; N] {
+impl<const N: usize, T: Reflect + Clone + PartialEq> ReflectArray for [T; N] {
     fn reflect_index(&self, index: usize) -> Option<&dyn Reflect> {
         if let Some(item) = self.get(index) {
             Some(item)
@@ -65,7 +65,7 @@ impl<const N: usize, T: Reflect + Clone> ReflectArray for [T; N] {
     }
 }
 
-impl<const N: usize, T: Reflect + Clone> Reflect for [T; N] {
+impl<const N: usize, T: Reflect + Clone + PartialEq> Reflect for [T; N] {
     // TODO: combine uuids.
     blank_reflect!("6d2a2f2d-d74e-4125-8840-b4910aa2e0cc");
 
@@ -80,10 +80,10 @@ impl<const N: usize, T: Reflect + Clone> Reflect for [T; N] {
 
 impl_reflect! {
     #[reflect(ReflectList, ReflectArray, type_uuid = "2d704c2b-c87e-4489-b680-aa9699ba2c91")]
-    pub struct Vec<T: Reflect + Clone>;
+    pub struct Vec<T: Reflect + Clone + PartialEq>;
 }
 
-impl<T: Reflect + Clone> ReflectArray for Vec<T> {
+impl<T: Reflect + Clone + PartialEq> ReflectArray for Vec<T> {
     fn reflect_index(&self, index: usize) -> Option<&dyn Reflect> {
         self.get(index).map(|x| x as &dyn Reflect)
     }
@@ -98,7 +98,7 @@ impl<T: Reflect + Clone> ReflectArray for Vec<T> {
 }
 
 /// REMARK: `Reflect` is implemented for `Vec<T>` where `T: Reflect` only.
-impl<T: Reflect + Clone> ReflectList for Vec<T> {
+impl<T: Reflect + Clone + PartialEq> ReflectList for Vec<T> {
     fn reflect_push(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         self.push(*value.downcast::<T>()?);
         Ok(())

--- a/fyrox-core/src/reflect/impls.rs
+++ b/fyrox-core/src/reflect/impls.rs
@@ -47,7 +47,12 @@ impl_reflect! {
 
 impl_reflect! {
     #[reflect(type_uuid = "53ca268f-7f7a-4b1c-bdee-af49f2d89945")]
-    pub struct Matrix<T: Reflect + Copy, R: Dim + Reflect, C: Dim + Reflect, S: Copy + Reflect> {
+    pub struct Matrix<
+        T: Reflect + Copy + PartialEq,
+        R: Dim + Reflect + PartialEq,
+        C: Dim + Reflect + PartialEq,
+        S: Copy + Reflect + PartialEq + RawStorage<T,R,C>
+    > {
         pub data: S,
         // _phantoms: PhantomData<(T, R, C)>,
     }
@@ -55,11 +60,11 @@ impl_reflect! {
 
 impl_reflect! {
     #[reflect(type_uuid = "469986cd-6611-4e61-b6f0-bd2d984913c4")]
-    pub struct ArrayStorage<T: Copy + Reflect, const R: usize, const C: usize>(pub [[T; R]; C]);
+    pub struct ArrayStorage<T: Copy + Reflect + PartialEq, const R: usize, const C: usize>(pub [[T; R]; C]);
 }
 
 impl_reflect! {
-    #[reflect(type_uuid = "470e104b-992f-405f-ba6c-c2634502a668")]
+    #[reflect(type_uuid = "470e104b-992f-405f-ba6c-c2634502a668", non_comparable)]
     pub struct Unit<T: Copy + Reflect> {
         // pub(crate) value: T,
     }
@@ -67,14 +72,14 @@ impl_reflect! {
 
 impl_reflect! {
     #[reflect(type_uuid = "3b45cc6d-6db4-4fa3-9d96-edcc87d47919")]
-    pub struct Quaternion<T: Copy + Debug + Reflect> {
+    pub struct Quaternion<T: Copy + Debug + Reflect + PartialEq> {
         pub coords: Vector4<T>,
     }
 }
 
 impl_reflect! {
     #[reflect(type_uuid = "399bf5fd-e506-4874-9d2f-ca40ed11bc5d")]
-    pub struct Complex<T: Copy + Debug + Reflect> {
+    pub struct Complex<T: Copy + Debug + Reflect + PartialEq> {
         pub re: T,
         pub im: T,
     }
@@ -158,45 +163,45 @@ impl Reflect for ImmutableString {
 
 impl<T0> Reflect for (T0,)
 where
-    T0: Clone + Reflect,
+    T0: Clone + Reflect + PartialEq,
 {
     blank_reflect!("874c2dd7-8e5c-44dd-a4f0-b6e64e07113d");
 }
 
 impl<T0, T1> Reflect for (T0, T1)
 where
-    T0: Clone + Reflect,
-    T1: Clone + Reflect,
+    T0: Clone + Reflect + PartialEq,
+    T1: Clone + Reflect + PartialEq,
 {
     blank_reflect!("2722316a-172e-4c95-8cb6-b75c81454233");
 }
 
 impl<T0, T1, T2> Reflect for (T0, T1, T2)
 where
-    T0: Clone + Reflect,
-    T1: Clone + Reflect,
-    T2: Clone + Reflect,
+    T0: Clone + Reflect + PartialEq,
+    T1: Clone + Reflect + PartialEq,
+    T2: Clone + Reflect + PartialEq,
 {
     blank_reflect!("99983877-3ed7-4e58-aef0-3a5951789900");
 }
 
 impl<T0, T1, T2, T3> Reflect for (T0, T1, T2, T3)
 where
-    T0: Clone + Reflect,
-    T1: Clone + Reflect,
-    T2: Clone + Reflect,
-    T3: Clone + Reflect,
+    T0: Clone + Reflect + PartialEq,
+    T1: Clone + Reflect + PartialEq,
+    T2: Clone + Reflect + PartialEq,
+    T3: Clone + Reflect + PartialEq,
 {
     blank_reflect!("1d9b68be-0bf4-498a-a337-d84960d08049");
 }
 
 impl<T0, T1, T2, T3, T4> Reflect for (T0, T1, T2, T3, T4)
 where
-    T0: Clone + Reflect,
-    T1: Clone + Reflect,
-    T2: Clone + Reflect,
-    T3: Clone + Reflect,
-    T4: Clone + Reflect,
+    T0: Clone + Reflect + PartialEq,
+    T1: Clone + Reflect + PartialEq,
+    T2: Clone + Reflect + PartialEq,
+    T3: Clone + Reflect + PartialEq,
+    T4: Clone + Reflect + PartialEq,
 {
     blank_reflect!("02a92848-9a7b-4bdf-8cc0-0e525a1a8021");
 }
@@ -212,12 +217,12 @@ impl_reflect! {
 
 impl_reflect! {
     #[reflect(type_uuid = "c0112c31-73fb-4457-a851-a15c0bae00e6")]
-    pub struct Cell<T: Reflect + Debug + Copy>;
+    pub struct Cell<T: Reflect + Debug + Copy + PartialEq>;
 }
 
 impl_reflect! {
     #[reflect(type_uuid = "99c30632-b72f-4460-8f3b-c7d3c47b1702")]
-    pub enum Option<T: Clone + Debug + Reflect> {
+    pub enum Option<T: Clone + Debug + Reflect + PartialEq> {
         Some(T),
         None
     }
@@ -225,13 +230,13 @@ impl_reflect! {
 
 impl_reflect! {
     #[reflect(type_uuid = "0e37a8f6-fae7-48a7-b7b4-f824e40d6d7e")]
-    pub struct Range<Idx: Clone + Debug + Reflect> {
+    pub struct Range<Idx: Clone + Debug + Reflect + PartialEq> {
         pub start: Idx,
         pub end: Idx,
     }
 }
 
-impl<T: Reflect + Clone> Reflect for Box<T> {
+impl<T: Reflect + Clone + PartialEq> Reflect for Box<T> {
     fn type_info() -> TypeInfo {
         TypeInfo {
             source_path: file!(),
@@ -277,6 +282,12 @@ impl<T: Reflect + Clone> Reflect for Box<T> {
         Some(Box::new(self.clone()))
     }
 
+    fn try_compare(&self, other: &dyn Reflect) -> Option<bool> {
+        (other as &dyn std::any::Any)
+            .downcast_ref::<Self>()
+            .map(|other| other == self)
+    }
+
     fn field_direct_ref(&self, index: usize) -> Option<FieldRef> {
         if index == 0 {
             Some(FieldRef {
@@ -314,7 +325,7 @@ static CONTENT_METADATA: FieldMetadata = FieldMetadata {
 };
 
 macro_rules! impl_reflect_inner_mutability {
-    ($self:ident, $acquire_lock_guard:block, $clone:block) => {
+    ($self:ident, $acquire_lock_guard:block, $clone:block, $other:ident, $compare:block) => {
         fn type_info() -> TypeInfo {
             TypeInfo {
                 source_path: file!(),
@@ -334,7 +345,9 @@ macro_rules! impl_reflect_inner_mutability {
             Some(Box::new($clone))
         }
 
-
+        fn try_compare(&$self, $other: &dyn Reflect) -> Option<bool> {
+            $compare
+        }
 
         fn fields_ref(&$self, func: &mut dyn FnMut(&[FieldRef])) {
             let guard = $acquire_lock_guard;
@@ -371,63 +384,103 @@ macro_rules! impl_reflect_inner_mutability {
     };
 }
 
-impl<T: Reflect + Clone> Reflect for parking_lot::Mutex<T> {
-    impl_reflect_inner_mutability!(self, { self.safe_lock() }, {
-        parking_lot::Mutex::new(self.safe_lock().clone())
-    });
+impl<T: Reflect + Clone + PartialEq> Reflect for parking_lot::Mutex<T> {
+    impl_reflect_inner_mutability!(
+        self,
+        { self.safe_lock() },
+        { parking_lot::Mutex::new(self.safe_lock().clone()) },
+        other,
+        { Some(*self.safe_lock() == *other.downcast_ref::<Self>()?.safe_lock()) }
+    );
 }
 
-impl<T: Reflect + Clone> Reflect for parking_lot::RwLock<T> {
-    impl_reflect_inner_mutability!(self, { self.write() }, {
-        parking_lot::RwLock::new(self.read().clone())
-    });
+impl<T: Reflect + Clone + PartialEq> Reflect for parking_lot::RwLock<T> {
+    impl_reflect_inner_mutability!(
+        self,
+        { self.write() },
+        { parking_lot::RwLock::new(self.read().clone()) },
+        other,
+        { Some(*self.read() == *other.downcast_ref::<Self>()?.read()) }
+    );
 }
 
 #[allow(clippy::mut_mutex_lock)]
-impl<T: Reflect + Clone> Reflect for std::sync::Mutex<T> {
-    impl_reflect_inner_mutability!(self, { self.safe_lock().unwrap() }, {
-        std::sync::Mutex::new(self.safe_lock().unwrap().clone())
-    });
+impl<T: Reflect + Clone + PartialEq> Reflect for std::sync::Mutex<T> {
+    impl_reflect_inner_mutability!(
+        self,
+        { self.safe_lock().unwrap() },
+        { std::sync::Mutex::new(self.safe_lock().unwrap().clone()) },
+        other,
+        { Some(*self.safe_lock().ok()? == *other.downcast_ref::<Self>()?.safe_lock().ok()?) }
+    );
 }
 
-impl<T: Reflect + Clone> Reflect for std::sync::RwLock<T> {
-    impl_reflect_inner_mutability!(self, { self.write().unwrap() }, {
-        std::sync::RwLock::new(self.read().unwrap().clone())
-    });
+impl<T: Reflect + Clone + PartialEq> Reflect for std::sync::RwLock<T> {
+    impl_reflect_inner_mutability!(
+        self,
+        { self.write().unwrap() },
+        { std::sync::RwLock::new(self.read().unwrap().clone()) },
+        other,
+        { Some(*self.read().ok()? == *other.downcast_ref::<Self>()?.read().ok()?) }
+    );
 }
 
 impl<T: Reflect + Clone> Reflect for Arc<parking_lot::Mutex<T>> {
-    impl_reflect_inner_mutability!(self, { self.safe_lock() }, {
-        Arc::new(parking_lot::Mutex::new(self.safe_lock().clone()))
-    });
+    impl_reflect_inner_mutability!(
+        self,
+        { self.safe_lock() },
+        { Arc::new(parking_lot::Mutex::new(self.safe_lock().clone())) },
+        other,
+        { Some(Arc::ptr_eq(self, other.downcast_ref::<Self>()?)) }
+    );
 }
 
 impl<T: Reflect + Clone> Reflect for Arc<std::sync::Mutex<T>> {
-    impl_reflect_inner_mutability!(self, { self.lock().unwrap() }, {
-        Arc::new(std::sync::Mutex::new(self.safe_lock().unwrap().clone()))
-    });
+    impl_reflect_inner_mutability!(
+        self,
+        { self.lock().unwrap() },
+        { Arc::new(std::sync::Mutex::new(self.safe_lock().unwrap().clone())) },
+        other,
+        { Some(Arc::ptr_eq(self, other.downcast_ref::<Self>()?)) }
+    );
 }
 
 impl<T: Reflect + Clone> Reflect for Arc<std::sync::RwLock<T>> {
-    impl_reflect_inner_mutability!(self, { self.write().unwrap() }, {
-        Arc::new(std::sync::RwLock::new(self.read().unwrap().clone()))
-    });
+    impl_reflect_inner_mutability!(
+        self,
+        { self.write().unwrap() },
+        { Arc::new(std::sync::RwLock::new(self.read().unwrap().clone())) },
+        other,
+        { Some(Arc::ptr_eq(self, other.downcast_ref::<Self>()?)) }
+    );
 }
 
 impl<T: Reflect + Clone> Reflect for Arc<parking_lot::RwLock<T>> {
-    impl_reflect_inner_mutability!(self, { self.write() }, {
-        Arc::new(parking_lot::RwLock::new(self.read().clone()))
-    });
+    impl_reflect_inner_mutability!(
+        self,
+        { self.write() },
+        { Arc::new(parking_lot::RwLock::new(self.read().clone())) },
+        other,
+        { Some(Arc::ptr_eq(self, other.downcast_ref::<Self>()?)) }
+    );
 }
 
-impl<T: Reflect + Clone> Reflect for RefCell<T> {
-    impl_reflect_inner_mutability!(self, { self.borrow_mut() }, {
-        RefCell::new(self.borrow().clone())
-    });
+impl<T: Reflect + Clone + PartialEq> Reflect for RefCell<T> {
+    impl_reflect_inner_mutability!(
+        self,
+        { self.borrow_mut() },
+        { RefCell::new(self.borrow().clone()) },
+        other,
+        { Some(*self.borrow() == *other.downcast_ref::<Self>()?.borrow()) }
+    );
 }
 
 impl<T: Reflect + Clone> Reflect for Rc<RefCell<T>> {
-    impl_reflect_inner_mutability!(self, { self.borrow_mut() }, {
-        Rc::new(RefCell::new(self.borrow().clone()))
-    });
+    impl_reflect_inner_mutability!(
+        self,
+        { self.borrow_mut() },
+        { Rc::new(RefCell::new(self.borrow().clone())) },
+        other,
+        { Some(Rc::ptr_eq(self, other.downcast_ref::<Self>()?)) }
+    );
 }

--- a/fyrox-core/src/reflect/impls.rs
+++ b/fyrox-core/src/reflect/impls.rs
@@ -334,6 +334,8 @@ macro_rules! impl_reflect_inner_mutability {
             Some(Box::new($clone))
         }
 
+
+
         fn fields_ref(&$self, func: &mut dyn FnMut(&[FieldRef])) {
             let guard = $acquire_lock_guard;
             func(&[{

--- a/fyrox-core/src/reflect/macros.rs
+++ b/fyrox-core/src/reflect/macros.rs
@@ -213,6 +213,10 @@ macro_rules! blank_reflect_ref {
             None
         }
 
+        fn try_compare(&self, other: &dyn Reflect) -> Option<bool> {
+            None
+        }
+
         fn fields_ref(&self, func: &mut dyn FnMut(&[$crate::reflect::FieldRef])) {
             func(&[])
         }

--- a/fyrox-core/src/reflect/macros.rs
+++ b/fyrox-core/src/reflect/macros.rs
@@ -158,6 +158,12 @@ macro_rules! blank_reflect {
             Some(Box::new(self.clone()))
         }
 
+        fn try_compare(&self, other: &dyn Reflect) -> Option<bool> {
+            (other as &dyn std::any::Any)
+                .downcast_ref::<Self>()
+                .map(|other| other == self)
+        }
+
         fn fields_ref(&self, func: &mut dyn FnMut(&[$crate::reflect::FieldRef])) {
             func(&[])
         }

--- a/fyrox-core/src/reflect/map.rs
+++ b/fyrox-core/src/reflect/map.rs
@@ -45,8 +45,8 @@ pub trait ReflectHashMap: Reflect {
 
 impl<K, V, S> Reflect for HashMap<K, V, S>
 where
-    K: Reflect + Eq + Hash + Clone + 'static,
-    V: Reflect + Clone,
+    K: Reflect + Eq + Hash + Clone + PartialEq + 'static,
+    V: Reflect + Clone + PartialEq,
     S: BuildHasher + Clone + 'static,
 {
     // TODO: combine uuids
@@ -63,8 +63,8 @@ where
 
 impl<K, V, S> ReflectHashMap for HashMap<K, V, S>
 where
-    K: Reflect + Eq + Hash + Clone + 'static,
-    V: Reflect + Clone,
+    K: Reflect + Eq + Hash + Clone + PartialEq + 'static,
+    V: Reflect + Clone + PartialEq,
     S: BuildHasher + Clone + 'static,
 {
     fn reflect_insert(

--- a/fyrox-core/src/reflect/mod.rs
+++ b/fyrox-core/src/reflect/mod.rs
@@ -53,6 +53,7 @@ pub mod prelude {
         TypeInfo,
     };
     pub use crate::uuid::{uuid, Uuid};
+    pub use std::any::Any;
 }
 
 #[inline]
@@ -174,6 +175,11 @@ pub trait Reflect: Any + Debug {
     /// Tries to clone the object and return it as a boxed trait object. This method can return
     /// [`None`] for non-cloneable objects.
     fn try_clone_box(&self) -> Option<Box<dyn Reflect>>;
+
+    /// Tries to compare this object with some other. The result is `Some(bool)` if the underlying
+    /// type implements [`PartialEq`] trait, `None` - otherwise or if the type is marked with
+    /// `#[reflect(non_comparable)]` attribute.
+    fn try_compare(&self, other: &dyn Reflect) -> Option<bool>;
 
     /// Calls the given closure with the reference to a slice that contains description for all
     /// fields in the object.
@@ -1021,7 +1027,7 @@ mod test {
         },
     }
 
-    #[derive(Reflect, Clone, Default, Debug)]
+    #[derive(Reflect, Clone, Default, Debug, PartialEq)]
     #[reflect(type_uuid = "97718a85-3901-407e-9347-b684c0047743")]
     struct Foo {
         enum_field: InheritableVariable<Enum>,
@@ -1031,13 +1037,13 @@ mod test {
         hash_map: HashMap<String, Item>,
     }
 
-    #[derive(Reflect, Clone, Default, Debug)]
+    #[derive(Reflect, Clone, Default, Debug, PartialEq)]
     #[reflect(type_uuid = "9465ea72-dd27-43f3-8ccf-b634e4b2887f")]
     struct Item {
         payload: u32,
     }
 
-    #[derive(Reflect, Clone, Default, Debug)]
+    #[derive(Reflect, Clone, Default, Debug, PartialEq)]
     #[reflect(type_uuid = "8fb478ac-e4c4-4762-a43a-451147e6e509")]
     struct Bar {
         stuff: String,

--- a/fyrox-core/src/reflect/mod.rs
+++ b/fyrox-core/src/reflect/mod.rs
@@ -1100,7 +1100,7 @@ mod test {
         );
     }
 
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(Reflect, Clone, PartialEq, Debug)]
     #[reflect(
         derived_type = "Derived",
         type_uuid = "8c093dc1-fd18-45ff-97bc-8d2364b7ed30"

--- a/fyrox-core/src/sparse.rs
+++ b/fyrox-core/src/sparse.rs
@@ -28,6 +28,12 @@ pub struct AtomicIndex {
     index: AtomicUsize,
 }
 
+impl PartialEq for AtomicIndex {
+    fn eq(&self, other: &Self) -> bool {
+        self.get() == other.get()
+    }
+}
+
 impl Clone for AtomicIndex {
     fn clone(&self) -> Self {
         Self {

--- a/fyrox-core/src/variable.rs
+++ b/fyrox-core/src/variable.rs
@@ -438,6 +438,12 @@ where
         Some(Box::new(self.clone()))
     }
 
+    fn try_compare(&self, other: &dyn Reflect) -> Option<bool> {
+        (other as &dyn std::any::Any)
+            .downcast_ref::<Self>()
+            .map(|other| other == self)
+    }
+
     fn fields_ref(&self, func: &mut dyn FnMut(&[FieldRef])) {
         func(&[{
             FieldRef {
@@ -800,7 +806,7 @@ mod test {
         assert!(va.value_equals(&vb))
     }
 
-    #[derive(Reflect, Clone, Debug)]
+    #[derive(Reflect, PartialEq, Clone, Debug)]
     #[reflect(type_uuid = "17b55aac-57f2-42e6-82e0-ead9b40a8cce")]
     enum SomeEnum {
         Bar(InheritableVariable<f32>),

--- a/fyrox-graph/src/lib.rs
+++ b/fyrox-graph/src/lib.rs
@@ -1629,7 +1629,7 @@ mod test {
         path::Path,
     };
 
-    #[derive(Visit, Reflect, Debug, Clone)]
+    #[derive(Visit, Reflect, PartialEq, Debug, Clone)]
     #[reflect(type_uuid = "34f5e3ea-3008-45e9-9e6e-0b8fbff1ac28")]
     pub struct Base {
         name: String,
@@ -1699,6 +1699,12 @@ mod test {
         }
     }
 
+    impl PartialEq for Node {
+        fn eq(&self, other: &Self) -> bool {
+            self.0.try_compare(other.0.deref()).unwrap_or_default()
+        }
+    }
+
     impl Node {
         fn new(node: impl NodeTrait) -> Self {
             Self(Box::new(node))
@@ -1733,7 +1739,7 @@ mod test {
 
     /// A wrapper for node pool record that allows to define custom visit method to have full
     /// control over instantiation process at deserialization.
-    #[derive(Debug, Default, Clone, Reflect)]
+    #[derive(Debug, Default, Clone, PartialEq, Reflect)]
     #[reflect(type_uuid = "08052dac-c0c0-4df3-8005-1330827bf9c2")]
     pub struct NodeContainer(Option<Node>);
 
@@ -1835,7 +1841,7 @@ mod test {
         }
     }
 
-    #[derive(Default, Clone, Visit, Reflect, Debug)]
+    #[derive(Default, Clone, Visit, Reflect, PartialEq, Debug)]
     #[reflect(type_uuid = "fc887063-7780-44af-8710-5e0bcf9a83fd")]
     pub struct Graph {
         root: Handle<Node>,
@@ -2091,7 +2097,7 @@ mod test {
         }
     }
 
-    #[derive(Clone, Reflect, Visit, Default, Debug)]
+    #[derive(Clone, Reflect, Visit, PartialEq, Default, Debug)]
     #[reflect(derived_type = "Node")]
     #[reflect(type_uuid = "c7452fb6-78c1-4e77-a2f9-d9ae31f50327")]
     pub struct Pivot {
@@ -2114,7 +2120,7 @@ mod test {
         }
     }
 
-    #[derive(Clone, Reflect, Visit, Default, Debug)]
+    #[derive(Clone, Reflect, Visit, PartialEq, Default, Debug)]
     #[reflect(derived_type = "Node")]
     #[reflect(type_uuid = "17cc2d25-6ba4-4e2d-a31e-867e429bc659")]
     pub struct RigidBody {
@@ -2137,7 +2143,7 @@ mod test {
         }
     }
 
-    #[derive(Clone, Reflect, Visit, Default, Debug)]
+    #[derive(Clone, Reflect, Visit, PartialEq, Default, Debug)]
     #[reflect(derived_type = "Node")]
     #[reflect(type_uuid = "1f869298-37b1-4153-a2a9-6576daa0e8b3")]
     pub struct Joint {

--- a/fyrox-impl/Cargo.toml
+++ b/fyrox-impl/Cargo.toml
@@ -43,7 +43,7 @@ clap = { version = "4", features = ["derive"] }
 winit = { version = "0.30", features = ["serde"] }
 half = { version = "2.2.1", features = ["bytemuck"] }
 base64 = "0.22.1"
-uvgen = "0.3.0"
+uvgen = "0.4.0"
 lightmap = "0.6.0"
 libloading = "0.9"
 gltf = { version = "1.4.0", default-features = false, features = ["names", "utils", "extras", "KHR_materials_emissive_strength"] }

--- a/fyrox-impl/src/engine/mod.rs
+++ b/fyrox-impl/src/engine/mod.rs
@@ -149,8 +149,9 @@ use winit::{
 #[reflect(
     hide_all,
     non_cloneable,
+    non_comparable,
     type_uuid = "1973a8c9-6ac6-48a2-bca1-9b4f3cce0774"
-)] // TODO
+)]
 pub struct SerializationContext {
     /// A node constructor container.
     pub node_constructors: NodeConstructorContainer,
@@ -2926,7 +2927,7 @@ mod test {
     }
 
     #[derive(Debug, Clone, Reflect, Visit)]
-    #[reflect(type_uuid = "2569de84-d4b2-427d-969b-d5c7b31a0ba6")]
+    #[reflect(type_uuid = "2569de84-d4b2-427d-969b-d5c7b31a0ba6", non_comparable)]
     struct MyScript {
         #[reflect(hidden)]
         #[visit(skip)]
@@ -2993,7 +2994,7 @@ mod test {
     }
 
     #[derive(Debug, Clone, Reflect, Visit)]
-    #[reflect(type_uuid = "1cebacd9-b500-4753-93be-39db344add21")]
+    #[reflect(type_uuid = "1cebacd9-b500-4753-93be-39db344add21", non_comparable)]
     struct MySubScript {
         #[reflect(hidden)]
         #[visit(skip)]
@@ -3152,7 +3153,7 @@ mod test {
     }
 
     #[derive(Debug, Clone, Reflect, Visit)]
-    #[reflect(type_uuid = "bf2976ad-f41d-4de6-9a32-b1a293956058")]
+    #[reflect(type_uuid = "bf2976ad-f41d-4de6-9a32-b1a293956058", non_comparable)]
     struct ScriptListeningToMessages {
         index: u32,
         #[reflect(hidden)]
@@ -3202,7 +3203,7 @@ mod test {
         }
     }
 
-    #[derive(Debug, Clone, Reflect, Visit)]
+    #[derive(Debug, Clone, PartialEq, Reflect, Visit)]
     #[reflect(type_uuid = "6bcbf9b4-9546-42d3-965a-de055ab85475")]
     struct ScriptSendingMessages {
         index: u32,
@@ -3392,7 +3393,7 @@ mod test {
     }
 
     #[derive(Clone, Debug, Reflect, Visit)]
-    #[reflect(type_uuid = "9bcbf9b4-9546-42d3-965a-de055ab85475")]
+    #[reflect(type_uuid = "9bcbf9b4-9546-42d3-965a-de055ab85475", non_comparable)]
     pub struct ScriptThatDeletesItself {
         #[reflect(hidden)]
         #[visit(skip)]
@@ -3433,7 +3434,7 @@ mod test {
     }
 
     #[derive(Clone, Debug, Reflect, Visit)]
-    #[reflect(type_uuid = "9bcbf9b4-9546-42d3-965a-de055ab85475")]
+    #[reflect(type_uuid = "9bcbf9b4-9546-42d3-965a-de055ab85475", non_comparable)]
     pub struct ScriptThatAddsScripts {
         num: usize,
         #[reflect(hidden)]
@@ -3482,7 +3483,7 @@ mod test {
     }
 
     #[derive(Clone, Debug, Reflect, Visit)]
-    #[reflect(type_uuid = "9bcbf9b4-9546-42d3-965a-de055ab85475")]
+    #[reflect(type_uuid = "9bcbf9b4-9546-42d3-965a-de055ab85475", non_comparable)]
     pub struct SimpleScript {
         stuff: usize,
         #[reflect(hidden)]

--- a/fyrox-impl/src/resource/curve/mod.rs
+++ b/fyrox-impl/src/resource/curve/mod.rs
@@ -72,7 +72,7 @@ impl From<VisitError> for CurveResourceError {
 }
 
 /// State of the [`CurveResource`]
-#[derive(Debug, Clone, Visit, Default, Reflect)]
+#[derive(Debug, Clone, Visit, Default, PartialEq, Reflect)]
 #[reflect(type_uuid = "f28b949f-28a2-4b68-9089-59c234f58b6b")]
 pub struct CurveResourceState {
     /// Actual curve.

--- a/fyrox-impl/src/resource/model/mod.rs
+++ b/fyrox-impl/src/resource/model/mod.rs
@@ -81,7 +81,7 @@ use uuid::uuid;
 pub mod loader;
 
 /// See module docs.
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, PartialEq, Clone, Visit, Reflect)]
 #[reflect(type_uuid = "44cd768f-b4ca-4804-a98c-0adf85577ada")]
 pub struct Model {
     #[visit(skip)]

--- a/fyrox-impl/src/scene/animation/absm.rs
+++ b/fyrox-impl/src/scene/animation/absm.rs
@@ -219,7 +219,7 @@ type AnimationPlayerHandle = InheritableVariable<Handle<AnimationPlayer>>;
 ///         .build(graph)
 /// }
 /// ```
-#[derive(Visit, Reflect, Clone, Debug, Default)]
+#[derive(Visit, PartialEq, Reflect, Clone, Debug, Default)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "4b08c753-2a10-41e3-8fb2-4fd0517e86bc"

--- a/fyrox-impl/src/scene/animation/mod.rs
+++ b/fyrox-impl/src/scene/animation/mod.rs
@@ -242,7 +242,7 @@ impl BoundValueCollectionExt for BoundValueCollection {
 /// The example creates a bounce animation first - it is a simple animation that animates position of a given node
 /// (`animated_node`). Only then it creates an animation player node with an animation container with a single animation.
 /// To understand why this is so complicated, see the docs of [`Animation`].
-#[derive(Visit, Reflect, Clone, Debug)]
+#[derive(Visit, PartialEq, Reflect, Clone, Debug)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "44d1c94e-354f-4f9a-b918-9d31c28aa16a"

--- a/fyrox-impl/src/scene/base.rs
+++ b/fyrox-impl/src/scene/base.rs
@@ -237,7 +237,7 @@ impl Visit for SceneNodeId {
 }
 
 /// A script container record.
-#[derive(Clone, Reflect, Debug, Default)]
+#[derive(Clone, Reflect, Debug, PartialEq, Default)]
 #[reflect(type_uuid = "51bc577b-5a50-4a97-9b31-eda2f3d46c9d")]
 pub struct ScriptRecord {
     // Script is wrapped into `Option` to be able to do take-return trick to bypass borrow checker
@@ -326,6 +326,12 @@ impl<T: Visit> Visit for TrackedProperty<T> {
     }
 }
 
+impl<T: PartialEq> PartialEq for TrackedProperty<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.property == other.property
+    }
+}
+
 impl<T> Deref for TrackedProperty<T> {
     type Target = T;
 
@@ -343,6 +349,18 @@ impl<T> DerefMut for TrackedProperty<T> {
             }))
         }
         &mut self.property
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MessageSenders {
+    script_message_sender: Sender<NodeScriptMessage>,
+    message_sender: Sender<NodeMessage>,
+}
+
+impl PartialEq for MessageSenders {
+    fn eq(&self, _other: &Self) -> bool {
+        true
     }
 }
 
@@ -366,17 +384,14 @@ impl<T> DerefMut for TrackedProperty<T> {
 ///         .build(graph)
 /// }
 /// ```
-#[derive(Debug, Reflect, Clone)]
+#[derive(Debug, Reflect, PartialEq, Clone)]
 #[reflect(type_uuid = "5bf7fb77-fd50-4b92-83d7-27153b7da531")]
 pub struct Base {
     #[reflect(hidden)]
     self_handle: Handle<Node>,
 
     #[reflect(hidden)]
-    script_message_sender: Option<Sender<NodeScriptMessage>>,
-
-    #[reflect(hidden)]
-    message_sender: Option<Sender<NodeMessage>>,
+    senders: Option<MessageSenders>,
 
     // Name is not inheritable, because property inheritance works bad with external 3D models.
     // They use names to search "original" nodes.
@@ -509,8 +524,10 @@ impl Base {
         script_message_sender: Sender<NodeScriptMessage>,
     ) {
         self.self_handle = self_handle;
-        self.message_sender = Some(message_sender.clone());
-        self.script_message_sender = Some(script_message_sender);
+        self.senders = Some(MessageSenders {
+            message_sender: message_sender.clone(),
+            script_message_sender,
+        });
         self.local_transform
             .set_message_data(message_sender.clone(), self_handle);
         self.visibility
@@ -523,10 +540,10 @@ impl Base {
     }
 
     fn notify(&self, node: Handle<Node>, kind: NodeMessageKind) {
-        let Some(sender) = self.message_sender.as_ref() else {
+        let Some(senders) = self.senders.as_ref() else {
             return;
         };
-        Log::verify(sender.send(NodeMessage::new(node, kind)));
+        Log::verify(senders.message_sender.send(NodeMessage::new(node, kind)));
     }
 
     /// Returns shared reference to local transform of a node, can be used to fetch
@@ -866,12 +883,14 @@ impl Base {
             // We might be in a middle of a script method execution, where script is temporarily
             // extracted from the array.
             if let Some(script) = entry.take() {
-                if let Some(sender) = self.script_message_sender.as_ref() {
-                    Log::verify(sender.send(NodeScriptMessage::DestroyScript {
-                        script,
-                        handle: self.self_handle,
-                        script_index: index,
-                    }));
+                if let Some(senders) = self.senders.as_ref() {
+                    Log::verify(senders.script_message_sender.send(
+                        NodeScriptMessage::DestroyScript {
+                            script,
+                            handle: self.self_handle,
+                            script_index: index,
+                        },
+                    ));
                 } else {
                     Log::warn(format!(
                         "There is a script instance on a node {}, but no message sender. \
@@ -901,12 +920,14 @@ impl Base {
 
         if let Some(entry) = self.scripts.get_mut(index) {
             entry.script = script;
-            if let Some(sender) = self.script_message_sender.as_ref() {
+            if let Some(senders) = self.senders.as_ref() {
                 if entry.script.is_some() {
-                    Log::verify(sender.send(NodeScriptMessage::InitializeScript {
-                        handle: self.self_handle,
-                        script_index: index,
-                    }));
+                    Log::verify(senders.script_message_sender.send(
+                        NodeScriptMessage::InitializeScript {
+                            handle: self.self_handle,
+                            script_index: index,
+                        },
+                    ));
                 }
             }
         }
@@ -922,11 +943,15 @@ impl Base {
     {
         let script_index = self.scripts.len();
         self.scripts.push(ScriptRecord::new(Script::new(script)));
-        if let Some(sender) = self.script_message_sender.as_ref() {
-            Log::verify(sender.send(NodeScriptMessage::InitializeScript {
-                handle: self.self_handle,
-                script_index,
-            }));
+        if let Some(senders) = self.senders.as_ref() {
+            Log::verify(
+                senders
+                    .script_message_sender
+                    .send(NodeScriptMessage::InitializeScript {
+                        handle: self.self_handle,
+                        script_index,
+                    }),
+            );
         }
     }
 
@@ -1344,8 +1369,7 @@ impl BaseBuilder {
     pub fn build_base(self) -> Base {
         Base {
             self_handle: Default::default(),
-            script_message_sender: None,
-            message_sender: None,
+            senders: None,
             name: self.name.into(),
             children: self.children,
             local_transform: TrackedProperty::unbound(

--- a/fyrox-impl/src/scene/camera.rs
+++ b/fyrox-impl/src/scene/camera.rs
@@ -351,7 +351,7 @@ impl Default for Exposure {
 ///
 /// Each camera forces engine to re-render same scene one more time, which may cause almost double load
 /// of your GPU.
-#[derive(Debug, Visit, Reflect, Clone)]
+#[derive(Debug, Visit, PartialEq, Reflect, Clone)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "198d3aca-433c-4ce1-bb25-3190699b757f"

--- a/fyrox-impl/src/scene/collider.rs
+++ b/fyrox-impl/src/scene/collider.rs
@@ -617,7 +617,7 @@ impl ColliderShape {
 
 /// Collider is a geometric entity that can be attached to a rigid body to allow participate it
 /// participate in contact generation, collision response and proximity queries.
-#[derive(Reflect, Visit, Debug)]
+#[derive(PartialEq, Reflect, Visit, Debug)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "bfaa2e82-9c19-4b99-983b-3bc115744a1d"

--- a/fyrox-impl/src/scene/debug.rs
+++ b/fyrox-impl/src/scene/debug.rs
@@ -32,7 +32,7 @@ use rapier2d::pipeline::{DebugColor, DebugRenderObject};
 use std::ops::Range;
 
 /// Colored line between two points.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Line {
     /// Beginning of the line.
     pub begin: Vector3<f32>,
@@ -86,7 +86,7 @@ pub struct Line {
 ///
 /// The engine renders the entire set of lines in a single draw call, so it very fast - you should be able to draw
 /// up to few millions of lines without any significant performance issues.
-#[derive(Default, Clone, Debug)]
+#[derive(Default, PartialEq, Clone, Debug)]
 pub struct SceneDrawingContext {
     /// List of lines to draw.
     pub lines: Vec<Line>,

--- a/fyrox-impl/src/scene/decal.rs
+++ b/fyrox-impl/src/scene/decal.rs
@@ -107,7 +107,7 @@ use std::ops::{Deref, DerefMut};
 ///         .build(graph)
 /// }
 /// ```
-#[derive(Debug, Visit, Default, Clone, Reflect)]
+#[derive(Debug, Visit, Default, Clone, PartialEq, Reflect)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "c4d24e48-edd1-4fb2-ad82-4b3d3ea985d8"

--- a/fyrox-impl/src/scene/dim2/collider.rs
+++ b/fyrox-impl/src/scene/dim2/collider.rs
@@ -273,7 +273,7 @@ impl ColliderShape {
 
 /// Collider is a geometric entity that can be attached to a rigid body to allow to participate in
 /// contact generation, collision response and proximity queries.
-#[derive(Reflect, Visit, Debug)]
+#[derive(PartialEq, Reflect, Visit, Debug)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "2b1659ea-a116-4224-bcd4-7931e3ae3b40"
@@ -865,7 +865,6 @@ impl ColliderBuilder {
 
 #[cfg(test)]
 mod test {
-
     use crate::core::algebra::Vector2;
     use crate::scene::{
         base::BaseBuilder,

--- a/fyrox-impl/src/scene/dim2/joint.rs
+++ b/fyrox-impl/src/scene/dim2/joint.rs
@@ -133,7 +133,7 @@ impl Default for JointParams {
     }
 }
 
-#[derive(Visit, Reflect, Debug, Clone, Default)]
+#[derive(Visit, PartialEq, Reflect, Debug, Clone, Default)]
 #[reflect(type_uuid = "d22556ef-f011-4b85-ac67-c1ff4d43d59e")]
 pub(crate) struct LocalFrame {
     pub position: Vector2<f32>,
@@ -149,7 +149,7 @@ impl LocalFrame {
     }
 }
 
-#[derive(Visit, Reflect, Debug, Clone, Default)]
+#[derive(Visit, PartialEq, Reflect, Debug, Clone, Default)]
 #[reflect(type_uuid = "448ce88b-1c89-4a66-b909-6835aff07d12")]
 pub(crate) struct JointLocalFrames {
     pub body1: LocalFrame,
@@ -167,7 +167,7 @@ impl JointLocalFrames {
 
 /// Joint is used to restrict motion of two rigid bodies. There are numerous examples of joints in
 /// real life: door hinge, ball joints in human arms, etc.
-#[derive(Visit, Reflect, Debug)]
+#[derive(Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "b8d66eda-b69f-4c57-80ba-d76665573565"

--- a/fyrox-impl/src/scene/dim2/physics.rs
+++ b/fyrox-impl/src/scene/dim2/physics.rs
@@ -520,6 +520,15 @@ pub struct PhysicsWorld {
     debug_render_pipeline: Mutex<DebugRenderPipeline>,
 }
 
+impl PartialEq for PhysicsWorld {
+    fn eq(&self, other: &Self) -> bool {
+        // Silly impl because Rapier does not really leave any other option.
+        self.bodies.len() == other.bodies.len()
+            && self.joints.set.len() == other.joints.set.len()
+            && self.colliders.len() == other.colliders.len()
+    }
+}
+
 impl Clone for PhysicsWorld {
     fn clone(&self) -> Self {
         PhysicsWorld {
@@ -984,7 +993,7 @@ impl PhysicsWorld {
         // 1) `get_mut` is **very** expensive because it forces physics engine to recalculate contacts
         //    and a lot of other stuff, this is why we need `anything_changed` flag.
         if rigid_body_node.native.get() != RigidBodyHandle::invalid() {
-            let mut actions = rigid_body_node.actions.safe_lock();
+            let mut actions = rigid_body_node.actions.inner();
             if rigid_body_node.need_sync_model() || !actions.is_empty() {
                 if let Some(native) = self.bodies.get_mut(rigid_body_node.native.get()) {
                     // Sync native rigid body's properties with scene node's in case if they

--- a/fyrox-impl/src/scene/dim2/rectangle.rs
+++ b/fyrox-impl/src/scene/dim2/rectangle.rs
@@ -170,7 +170,7 @@ impl Hash for RectangleVertex {
 /// image, but just changing portion for rendering. Keep in mind that the coordinates are normalized
 /// which means `[0; 0]` corresponds to top-left corner of the texture and `[1; 1]` corresponds to
 /// right-bottom corner.
-#[derive(Reflect, Debug, Clone, Visit)]
+#[derive(PartialEq, Reflect, Debug, Clone, Visit)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "bb57b5e0-367a-4490-bf30-7f547407d5b5"

--- a/fyrox-impl/src/scene/dim2/rigidbody.rs
+++ b/fyrox-impl/src/scene/dim2/rigidbody.rs
@@ -34,7 +34,6 @@ use crate::{
         algebra::{Isometry2, Matrix4, UnitComplex, Vector2},
         log::Log,
         math::{aabb::AxisAlignedBoundingBox, m4x4_approx_eq},
-        parking_lot::Mutex,
         pool::Handle,
         reflect::prelude::*,
         uuid::{uuid, Uuid},
@@ -52,17 +51,17 @@ use crate::{
 };
 
 use crate::scene::dim2::collider::ColliderShape;
+use crate::utils::ThreadSafeQueue;
 use fyrox_graph::constructor::ConstructorProvider;
 use fyrox_graph::SceneGraph;
 use rapier2d::prelude::RigidBodyHandle;
 use std::{
     cell::Cell,
-    collections::VecDeque,
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
 };
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum ApplyAction {
     Force(Vector2<f32>),
     Torque(f32),
@@ -82,6 +81,8 @@ pub(crate) enum ApplyAction {
     NextPosition(Isometry2<f32>),
 }
 
+pub(crate) type ActionsQueue = ThreadSafeQueue<ApplyAction>;
+
 /// Rigid body is a physics entity that responsible for the dynamics and kinematics of the solid.
 /// Use this node when you need to simulate real-world physics in your game.
 ///
@@ -89,7 +90,7 @@ pub(crate) enum ApplyAction {
 ///
 /// Rigid body that does not move for some time will go asleep. This means that the body will not
 /// move unless it is woken up by some other moving body. This feature allows to save CPU resources.
-#[derive(Visit, Reflect)]
+#[derive(Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "0b242335-75a4-4c65-9685-3e82a8979047"
@@ -148,7 +149,7 @@ pub struct RigidBody {
 
     #[visit(skip)]
     #[reflect(hidden)]
-    pub(crate) actions: Mutex<VecDeque<ApplyAction>>,
+    pub(crate) actions: ActionsQueue,
 }
 
 impl Debug for RigidBody {
@@ -361,39 +362,33 @@ impl RigidBody {
     /// Applies a force at the center-of-mass of this rigid-body. The force will be applied in the
     /// next simulation step. This does nothing on non-dynamic bodies.
     pub fn apply_force(&mut self, force: Vector2<f32>) {
-        self.actions.get_mut().push_back(ApplyAction::Force(force))
+        self.actions.push(ApplyAction::Force(force))
     }
 
     /// Applies a torque at the center-of-mass of this rigid-body. The torque will be applied in
     /// the next simulation step. This does nothing on non-dynamic bodies.
     pub fn apply_torque(&mut self, torque: f32) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::Torque(torque))
+        self.actions.push(ApplyAction::Torque(torque))
     }
 
     /// Applies a force at the given world-space point of this rigid-body. The force will be applied
     /// in the next simulation step. This does nothing on non-dynamic bodies.
     pub fn apply_force_at_point(&mut self, force: Vector2<f32>, point: Vector2<f32>) {
         self.actions
-            .get_mut()
-            .push_back(ApplyAction::ForceAtPoint { force, point })
+            .push(ApplyAction::ForceAtPoint { force, point })
     }
 
     /// Applies an impulse at the center-of-mass of this rigid-body. The impulse is applied right
     /// away, changing the linear velocity. This does nothing on non-dynamic bodies.
     pub fn apply_impulse(&mut self, impulse: Vector2<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::Impulse(impulse))
+        self.actions.push(ApplyAction::Impulse(impulse))
     }
 
     /// Applies an angular impulse at the center-of-mass of this rigid-body. The impulse is applied
     /// right away, changing the angular velocity. This does nothing on non-dynamic bodies.
     pub fn apply_torque_impulse(&mut self, torque_impulse: f32) {
         self.actions
-            .get_mut()
-            .push_back(ApplyAction::TorqueImpulse(torque_impulse))
+            .push(ApplyAction::TorqueImpulse(torque_impulse))
     }
 
     /// Applies an impulse at the given world-space point of this rigid-body. The impulse is applied
@@ -401,32 +396,25 @@ impl RigidBody {
     /// bodies.
     pub fn apply_impulse_at_point(&mut self, impulse: Vector2<f32>, point: Vector2<f32>) {
         self.actions
-            .get_mut()
-            .push_back(ApplyAction::ImpulseAtPoint { impulse, point })
+            .push(ApplyAction::ImpulseAtPoint { impulse, point })
     }
 
     /// If this rigid body is kinematic, sets its future translation after
     /// the next timestep integration.
     pub fn set_next_kinematic_translation(&mut self, translation: Vector2<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::NextTranslation(translation));
+        self.actions.push(ApplyAction::NextTranslation(translation));
     }
 
     /// If this rigid body is kinematic, sets its future orientation after
     /// the next timestep integration.
     pub fn set_next_kinematic_rotation(&mut self, rotation: UnitComplex<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::NextRotation(rotation));
+        self.actions.push(ApplyAction::NextRotation(rotation));
     }
 
     /// If this rigid body is kinematic, sets its future position (translation and orientation) after
     /// the next timestep integration.
     pub fn set_next_kinematic_position(&mut self, position: Isometry2<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::NextPosition(position));
+        self.actions.push(ApplyAction::NextPosition(position));
     }
 
     /// Sets whether the rigid body can sleep or not. If `false` is passed, it _automatically_ wake
@@ -442,7 +430,7 @@ impl RigidBody {
 
     /// Wakes up rigid body, forcing it to return to participate in the simulation.
     pub fn wake_up(&mut self) {
-        self.actions.get_mut().push_back(ApplyAction::WakeUp)
+        self.actions.push(ApplyAction::WakeUp)
     }
 
     pub(crate) fn need_sync_model(&self) -> bool {

--- a/fyrox-impl/src/scene/graph/mod.rs
+++ b/fyrox-impl/src/scene/graph/mod.rs
@@ -90,7 +90,7 @@ pub mod physics;
 
 /// Graph performance statistics. Allows you to find out "hot" parts of the scene graph, which
 /// parts takes the most time to update.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, PartialEq, Default, Debug)]
 pub struct GraphPerformanceStatistics {
     /// Amount of time that was needed to update global transform, visibility, and every other
     /// property of every object which depends on the state of a parent node.
@@ -172,6 +172,12 @@ pub struct Graph {
 
     #[reflect(read_only)]
     instance_id_map: FxHashMap<SceneNodeId, Handle<Node>>,
+}
+
+impl PartialEq for Graph {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root && self.pool == other.pool
+    }
 }
 
 impl Debug for Graph {

--- a/fyrox-impl/src/scene/graph/physics.rs
+++ b/fyrox-impl/src/scene/graph/physics.rs
@@ -193,7 +193,7 @@ impl Into<rapier2d::dynamics::CoefficientCombineRule> for CoefficientCombineRule
 }
 
 /// Performance statistics for the physics part of the engine.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct PhysicsPerformanceStatistics {
     /// A time that was needed to perform a single simulation step.
     pub step_time: Duration,
@@ -912,7 +912,7 @@ impl Default for IntegrationParameters {
 /// methods, mostly for ray casting. You should add physical entities using scene graph nodes, such
 /// as RigidBody, Collider, Joint.
 #[derive(Visit, Reflect)]
-#[reflect(type_uuid = "17e663b8-98a4-46db-be71-a336246f571a")]
+#[reflect(type_uuid = "17e663b8-98a4-46db-be71-a336246f571a", non_comparable)]
 pub struct PhysicsWorld {
     /// A flag that defines whether physics simulation is enabled or not.
     pub enabled: InheritableVariable<bool>,
@@ -1441,7 +1441,7 @@ impl PhysicsWorld {
         // 1) `get_mut` is **very** expensive because it forces physics engine to recalculate contacts
         //    and a lot of other stuff, this is why we need `anything_changed` flag.
         if rigid_body_node.native.get() != RigidBodyHandle::invalid() {
-            let mut actions = rigid_body_node.actions.safe_lock();
+            let mut actions = rigid_body_node.actions.inner();
             if rigid_body_node.need_sync_model() || !actions.is_empty() {
                 if let Some(native) = self.bodies.get_mut(rigid_body_node.native.get()) {
                     // Sync native rigid body's properties with scene node's in case if they

--- a/fyrox-impl/src/scene/joint.rs
+++ b/fyrox-impl/src/scene/joint.rs
@@ -176,7 +176,7 @@ impl Default for JointParams {
     }
 }
 
-#[derive(Visit, Reflect, Debug, Clone, Default)]
+#[derive(Visit, PartialEq, Reflect, Debug, Clone, Default)]
 #[reflect(type_uuid = "1be0b82e-d05e-4b93-808a-41895c5a1627")]
 pub(crate) struct LocalFrame {
     pub position: Vector3<f32>,
@@ -192,7 +192,7 @@ impl LocalFrame {
     }
 }
 
-#[derive(Visit, Reflect, Debug, Clone, Default)]
+#[derive(Visit, PartialEq, Reflect, Debug, Clone, Default)]
 #[reflect(type_uuid = "2a8e0d9c-4c14-454e-967b-920a032bbafb")]
 pub(crate) struct JointLocalFrames {
     pub body1: LocalFrame,
@@ -210,7 +210,7 @@ impl JointLocalFrames {
 
 /// Joint is used to restrict motion of two rigid bodies. There are numerous examples of joints in
 /// real life: door hinge, ball joints in human arms, etc.
-#[derive(Visit, Reflect, Debug)]
+#[derive(Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "439d48f5-e3a3-4255-aa08-353c1ca42e3b"

--- a/fyrox-impl/src/scene/light/directional.rs
+++ b/fyrox-impl/src/scene/light/directional.rs
@@ -125,7 +125,7 @@ impl CsmOptions {
 }
 
 /// See module docs.
-#[derive(Default, Debug, Visit, Reflect, Clone)]
+#[derive(Default, Debug, Visit, PartialEq, Reflect, Clone)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "8b8248e1-1cdf-42a3-9abe-0691de82c519"

--- a/fyrox-impl/src/scene/light/mod.rs
+++ b/fyrox-impl/src/scene/light/mod.rs
@@ -67,7 +67,7 @@ pub const DEFAULT_SCATTER_B: f32 = 0.03;
 /// Light scene node. It contains common properties of light such as color,
 /// scattering factor (per color channel) and other useful properties. Exact
 /// behavior defined by specific light kind.
-#[derive(Debug, Reflect, Clone, Visit)]
+#[derive(Debug, PartialEq, Reflect, Clone, Visit)]
 #[reflect(type_uuid = "5c9486ed-5f3b-4225-bed5-95f9bde6360e")]
 pub struct BaseLight {
     base: Base,

--- a/fyrox-impl/src/scene/light/point.rs
+++ b/fyrox-impl/src/scene/light/point.rs
@@ -62,7 +62,7 @@ use fyrox_graph::SceneGraph;
 use std::ops::{Deref, DerefMut};
 
 /// See module docs.
-#[derive(Debug, Reflect, Clone, Visit)]
+#[derive(Debug, PartialEq, Reflect, Clone, Visit)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "c81dcc31-7cb9-465f-abd9-b385ac6f4d37"

--- a/fyrox-impl/src/scene/light/spot.rs
+++ b/fyrox-impl/src/scene/light/spot.rs
@@ -69,7 +69,7 @@ use fyrox_graph::SceneGraph;
 use std::ops::{Deref, DerefMut};
 
 /// See module docs.
-#[derive(Debug, Reflect, Clone, Visit)]
+#[derive(Debug, PartialEq, Reflect, Clone, Visit)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "9856a3c1-ced7-47ec-b682-4dc4dea89d8f"

--- a/fyrox-impl/src/scene/mesh/buffer.rs
+++ b/fyrox-impl/src/scene/mesh/buffer.rs
@@ -170,7 +170,7 @@ pub struct VertexAttributeDescriptor {
 
 /// Vertex attribute is a simple "bridge" between raw data and its interpretation. In
 /// other words it defines how to treat raw data in vertex shader.
-#[derive(Reflect, Visit, Copy, Clone, Default, Debug, Hash)]
+#[derive(Reflect, Visit, Copy, PartialEq, Clone, Default, Debug, Hash)]
 #[reflect(type_uuid = "705f8ad3-69b4-4b39-99aa-a3f97e319202")]
 pub struct VertexAttribute {
     /// Claimed usage of the attribute. It could be Position, Normal, etc.
@@ -219,7 +219,7 @@ impl Display for VertexAttribute {
 }
 
 /// Bytes storage of a vertex buffer.
-#[derive(Reflect, Clone, Debug)]
+#[derive(Reflect, Clone, PartialEq, Debug)]
 #[reflect(type_uuid = "493045ee-fba2-4c5f-a5cd-c27034d1ec71")]
 pub struct BytesStorage {
     bytes: Vec<u8>,
@@ -399,7 +399,7 @@ impl Deref for BytesStorage {
 ///
 /// Vertex size cannot be more than 256 bytes, this limitation shouldn't be a problem because almost every GPU supports up to
 /// 16 vertex attributes with 16 bytes of size each, which gives exactly 256 bytes.
-#[derive(Reflect, Clone, Visit, Default, Debug)]
+#[derive(Reflect, Clone, Visit, PartialEq, Default, Debug)]
 #[reflect(type_uuid = "edab7161-6695-4e2a-b947-13305709d451")]
 pub struct VertexBuffer {
     dense_layout: Vec<VertexAttribute>,
@@ -1468,7 +1468,7 @@ impl VertexWriteTrait for VertexViewMut<'_> {
 }
 
 /// A buffer for data that defines connections between vertices.
-#[derive(Reflect, Default, Clone, Debug)]
+#[derive(Reflect, Default, PartialEq, Clone, Debug)]
 #[reflect(type_uuid = "ed9f9aa9-e1fb-4f58-b1cb-162d51dbc9e7")]
 pub struct TriangleBuffer {
     triangles: Vec<TriangleDefinition>,

--- a/fyrox-impl/src/scene/mesh/mod.rs
+++ b/fyrox-impl/src/scene/mesh/mod.rs
@@ -157,13 +157,13 @@ pub enum BatchingMode {
     Dynamic,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 struct Batch {
     data: SurfaceResource,
     material: MaterialResource,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 struct BatchContainer {
     batches: FxHashMap<u64, Batch>,
 }
@@ -191,6 +191,12 @@ impl BatchContainer {
 
 #[derive(Debug, Default)]
 struct BatchContainerWrapper(Mutex<BatchContainer>);
+
+impl PartialEq for BatchContainerWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0.safe_lock() == *other.0.safe_lock()
+    }
+}
 
 impl Clone for BatchContainerWrapper {
     fn clone(&self) -> Self {
@@ -314,7 +320,7 @@ impl RenderDataBundleStorageTrait for BatchContainer {
 ///
 /// This example creates a unit cube surface with default material and then creates a mesh with this surface. If you need to create
 /// custom surface, see [`crate::scene::mesh::surface::SurfaceData`] docs for more info.
-#[derive(Debug, Reflect, Clone, Visit)]
+#[derive(Debug, PartialEq, Reflect, Clone, Visit)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "caaf9d7b-bd74-48ce-b7cc-57e9dc65c2e6"

--- a/fyrox-impl/src/scene/mesh/surface.rs
+++ b/fyrox-impl/src/scene/mesh/surface.rs
@@ -87,7 +87,7 @@ impl Default for BlendShape {
 }
 
 /// A container for multiple blend shapes/
-#[derive(Reflect, Debug, Clone, Default)]
+#[derive(Reflect, Debug, Clone, PartialEq, Default)]
 #[reflect(type_uuid = "bd60343b-4a27-42aa-959e-b0d1bc8682db")]
 pub struct BlendShapesContainer {
     /// A list of blend shapes.
@@ -220,7 +220,7 @@ impl BlendShapesContainer {
 /// Data source of a surface. Each surface can share same data source, this is used
 /// in instancing technique to render multiple instances of same model at different
 /// places.
-#[derive(Debug, Clone, Default, Reflect)]
+#[derive(Debug, Clone, Default, PartialEq, Reflect)]
 #[reflect(type_uuid = "8a23a414-e66d-4e12-9628-92c6ab49c2f0")]
 pub struct SurfaceData {
     /// Current vertex buffer.

--- a/fyrox-impl/src/scene/mod.rs
+++ b/fyrox-impl/src/scene/mod.rs
@@ -240,7 +240,7 @@ impl Clone for SceneRenderingOptions {
 }
 
 /// See module docs.
-#[derive(Debug, Reflect)]
+#[derive(Debug, PartialEq, Reflect)]
 #[reflect(type_uuid = "03b3f812-3518-429b-befe-3f7a160503fa")]
 pub struct Scene {
     /// Graph is main container for all scene nodes. It calculates global transforms for nodes,
@@ -296,7 +296,7 @@ impl Default for Scene {
 }
 
 /// A structure that holds times that specific update step took.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, PartialEq, Default, Debug)]
 pub struct PerformanceStatistics {
     /// Graph performance statistics.
     pub graph: GraphPerformanceStatistics,

--- a/fyrox-impl/src/scene/navmesh.rs
+++ b/fyrox-impl/src/scene/navmesh.rs
@@ -156,7 +156,7 @@ impl Visit for Container {
 ///     scene.graph[handle].as_navigational_mesh_mut()
 /// }
 /// ```
-#[derive(Debug, Clone, Visit, Reflect, Default)]
+#[derive(Debug, Clone, Visit, PartialEq, Reflect, Default)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "d0ce963c-b50a-4707-bd21-af6dc0d1c668"

--- a/fyrox-impl/src/scene/node/container.rs
+++ b/fyrox-impl/src/scene/node/container.rs
@@ -35,7 +35,7 @@ use fyrox_core::visitor::error::VisitError;
 
 /// A wrapper for node pool record that allows to define custom visit method to have full
 /// control over instantiation process at deserialization.
-#[derive(Debug, Clone, Default, Reflect)]
+#[derive(Debug, Clone, Default, PartialEq, Reflect)]
 #[reflect(type_uuid = "be27db20-c0b0-491e-9421-8b1ebc357b9a")]
 pub struct NodeContainer(Option<Node>);
 

--- a/fyrox-impl/src/scene/node/mod.rs
+++ b/fyrox-impl/src/scene/node/mod.rs
@@ -362,6 +362,12 @@ impl<T: NodeTrait> ObjectOrVariantHelper<Node, T> for PhantomData<T> {
 #[reflect(type_uuid = "a9bc5231-155c-4564-b0ca-f23972673925")]
 pub struct Node(#[reflect(deref, display_name = "Node")] pub(crate) Box<dyn NodeTrait>);
 
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.try_compare(&*other.0).unwrap_or_default()
+    }
+}
+
 impl<T: NodeTrait> From<T> for Node {
     fn from(value: T) -> Self {
         Self(Box::new(value))
@@ -608,7 +614,7 @@ mod test {
     use fyrox_resource::untyped::ResourceKind;
     use std::{fs, path::Path, sync::Arc};
 
-    #[derive(Debug, Clone, Reflect, Visit, Default)]
+    #[derive(Debug, Clone, PartialEq, Reflect, Visit, Default)]
     #[reflect(type_uuid = "d3f66902-803f-4ace-8170-0aa485d98b40")]
     struct MyScript {
         some_field: InheritableVariable<String>,

--- a/fyrox-impl/src/scene/particle_system/mod.rs
+++ b/fyrox-impl/src/scene/particle_system/mod.rs
@@ -63,7 +63,7 @@ pub mod emitter;
 pub mod particle;
 
 /// Pseudo-random numbers generator for particle systems.
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, PartialEq, Reflect)]
 #[reflect(type_uuid = "13d58184-e65c-41a3-9986-fc8d31231636")]
 pub struct ParticleSystemRng {
     rng_seed: u64,
@@ -218,7 +218,7 @@ impl Visit for ParticleSystemRng {
 ///     .build(graph);
 /// }
 /// ```
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, PartialEq, Reflect)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "8b210eff-97a4-494f-ba7a-a581d3f4a442"

--- a/fyrox-impl/src/scene/particle_system/particle.rs
+++ b/fyrox-impl/src/scene/particle_system/particle.rs
@@ -25,7 +25,7 @@ use crate::core::{algebra::Vector3, color::Color, visitor::prelude::*};
 use std::cell::Cell;
 
 /// See module docs.
-#[derive(Clone, Debug, Visit)]
+#[derive(Clone, Debug, PartialEq, Visit)]
 pub struct Particle {
     /// Position of particle in local coordinates.
     #[visit(rename = "Pos")]

--- a/fyrox-impl/src/scene/pivot.rs
+++ b/fyrox-impl/src/scene/pivot.rs
@@ -39,7 +39,7 @@ use fyrox_graph::SceneGraph;
 use std::ops::{Deref, DerefMut};
 
 /// A simplest possible node which represents point in space.
-#[derive(Clone, Reflect, Default, Debug)]
+#[derive(Clone, PartialEq, Reflect, Default, Debug)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "dd2ecb96-b1f4-4ee0-943b-2a4d1844e3bb"

--- a/fyrox-impl/src/scene/probe.rs
+++ b/fyrox-impl/src/scene/probe.rs
@@ -128,7 +128,7 @@ pub enum UpdateMode {
 ///     .build(graph)
 /// }
 /// ```
-#[derive(Clone, Reflect, Debug, Visit)]
+#[derive(Clone, PartialEq, Reflect, Debug, Visit)]
 #[reflect(type_uuid = "7e0c138f-e371-4045-bd2c-ff5b165c7ee6")]
 #[reflect(derived_type = "Node")]
 #[visit(optional, post_visit_method = "on_visited")]

--- a/fyrox-impl/src/scene/ragdoll.rs
+++ b/fyrox-impl/src/scene/ragdoll.rs
@@ -85,7 +85,7 @@ impl Limb {
 /// to create a ragdoll is to use the editor, and the ragdoll wizard in particular. However, if
 /// you're brave enough you can read this code <https://github.com/FyroxEngine/Fyrox/blob/master/editor/src/utils/ragdoll.rs> -
 /// it creates a ragdoll using a humanoid skeleton.  
-#[derive(Clone, Reflect, Visit, Debug, Default)]
+#[derive(Clone, PartialEq, Reflect, Visit, Debug, Default)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "f4441683-dcef-472d-9d7d-4adca4579107"

--- a/fyrox-impl/src/scene/rigidbody.rs
+++ b/fyrox-impl/src/scene/rigidbody.rs
@@ -35,7 +35,6 @@ use crate::{
         algebra::{Isometry3, Matrix4, UnitQuaternion, Vector3},
         log::Log,
         math::{aabb::AxisAlignedBoundingBox, m4x4_approx_eq},
-        parking_lot::Mutex,
         pool::Handle,
         reflect::prelude::*,
         uuid::{uuid, Uuid},
@@ -51,12 +50,12 @@ use crate::{
     },
 };
 
+use crate::utils::ThreadSafeQueue;
 use fyrox_graph::constructor::ConstructorProvider;
 use fyrox_graph::SceneGraph;
 use rapier3d::{dynamics, prelude::RigidBodyHandle};
 use std::{
     cell::Cell,
-    collections::VecDeque,
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
 };
@@ -124,7 +123,7 @@ impl From<RigidBodyType> for rapier2d::dynamics::RigidBodyType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum ApplyAction {
     Force(Vector3<f32>),
     Torque(Vector3<f32>),
@@ -143,6 +142,8 @@ pub(crate) enum ApplyAction {
     NextRotation(UnitQuaternion<f32>),
     NextPosition(Isometry3<f32>),
 }
+
+pub(crate) type ActionsQueue = ThreadSafeQueue<ApplyAction>;
 
 /// Possible types of rigidbody mass properties
 #[derive(Copy, Clone, Debug, Reflect, Visit, PartialEq, AsRefStr, EnumString, VariantNames)]
@@ -166,7 +167,7 @@ pub enum RigidBodyMassPropertiesType {
 ///
 /// Rigid body that does not move for some time will go asleep. This means that the body will not
 /// move unless it is woken up by some other moving body. This feature allows to save CPU resources.
-#[derive(Visit, Reflect)]
+#[derive(Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "4be15a7c-3566-49c4-bba8-2f4ccc57ffed"
@@ -232,7 +233,7 @@ pub struct RigidBody {
     pub(crate) native: Cell<RigidBodyHandle>,
     #[visit(skip)]
     #[reflect(hidden)]
-    pub(crate) actions: Mutex<VecDeque<ApplyAction>>,
+    pub(crate) actions: ActionsQueue,
 }
 
 impl Debug for RigidBody {
@@ -500,39 +501,33 @@ impl RigidBody {
     /// Applies a force at the center-of-mass of this rigid-body. The force will be applied in the
     /// next simulation step. This does nothing on non-dynamic bodies.
     pub fn apply_force(&mut self, force: Vector3<f32>) {
-        self.actions.get_mut().push_back(ApplyAction::Force(force))
+        self.actions.push(ApplyAction::Force(force))
     }
 
     /// Applies a torque at the center-of-mass of this rigid-body. The torque will be applied in
     /// the next simulation step. This does nothing on non-dynamic bodies.
     pub fn apply_torque(&mut self, torque: Vector3<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::Torque(torque))
+        self.actions.push(ApplyAction::Torque(torque))
     }
 
     /// Applies a force at the given world-space point of this rigid-body. The force will be applied
     /// in the next simulation step. This does nothing on non-dynamic bodies.
     pub fn apply_force_at_point(&mut self, force: Vector3<f32>, point: Vector3<f32>) {
         self.actions
-            .get_mut()
-            .push_back(ApplyAction::ForceAtPoint { force, point })
+            .push(ApplyAction::ForceAtPoint { force, point })
     }
 
     /// Applies an impulse at the center-of-mass of this rigid-body. The impulse is applied right
     /// away, changing the linear velocity. This does nothing on non-dynamic bodies.
     pub fn apply_impulse(&mut self, impulse: Vector3<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::Impulse(impulse))
+        self.actions.push(ApplyAction::Impulse(impulse))
     }
 
     /// Applies an angular impulse at the center-of-mass of this rigid-body. The impulse is applied
     /// right away, changing the angular velocity. This does nothing on non-dynamic bodies.
     pub fn apply_torque_impulse(&mut self, torque_impulse: Vector3<f32>) {
         self.actions
-            .get_mut()
-            .push_back(ApplyAction::TorqueImpulse(torque_impulse))
+            .push(ApplyAction::TorqueImpulse(torque_impulse))
     }
 
     /// Applies an impulse at the given world-space point of this rigid-body. The impulse is applied
@@ -540,32 +535,25 @@ impl RigidBody {
     /// bodies.
     pub fn apply_impulse_at_point(&mut self, impulse: Vector3<f32>, point: Vector3<f32>) {
         self.actions
-            .get_mut()
-            .push_back(ApplyAction::ImpulseAtPoint { impulse, point })
+            .push(ApplyAction::ImpulseAtPoint { impulse, point })
     }
 
     /// If this rigid body is kinematic, sets its future translation after
     /// the next timestep integration.
     pub fn set_next_kinematic_translation(&mut self, translation: Vector3<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::NextTranslation(translation));
+        self.actions.push(ApplyAction::NextTranslation(translation));
     }
 
     /// If this rigid body is kinematic, sets its future orientation after
     /// the next timestep integration.
     pub fn set_next_kinematic_rotation(&mut self, rotation: UnitQuaternion<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::NextRotation(rotation));
+        self.actions.push(ApplyAction::NextRotation(rotation));
     }
 
     /// If this rigid body is kinematic, sets its future position (translation and orientation) after
     /// the next timestep integration.
     pub fn set_next_kinematic_position(&mut self, position: Isometry3<f32>) {
-        self.actions
-            .get_mut()
-            .push_back(ApplyAction::NextPosition(position));
+        self.actions.push(ApplyAction::NextPosition(position));
     }
 
     /// Sets whether the rigid body can sleep or not. If `false` is passed, it _automatically_ wake
@@ -581,7 +569,7 @@ impl RigidBody {
 
     /// Wakes up rigid body, forcing it to return to participate in the simulation.
     pub fn wake_up(&mut self) {
-        self.actions.get_mut().push_back(ApplyAction::WakeUp)
+        self.actions.push(ApplyAction::WakeUp)
     }
 
     pub(crate) fn need_sync_model(&self) -> bool {

--- a/fyrox-impl/src/scene/sound/listener.rs
+++ b/fyrox-impl/src/scene/sound/listener.rs
@@ -56,7 +56,7 @@ use std::ops::{Deref, DerefMut};
 ///
 /// 2D sound sources (with spatial blend == 0.0) are not influenced by listener's position and
 /// orientation.
-#[derive(Visit, Reflect, Default, Clone, Debug)]
+#[derive(Visit, PartialEq, Reflect, Default, Clone, Debug)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "2c7dabc1-5666-4256-b020-01532701e4c6"

--- a/fyrox-impl/src/scene/sound/mod.rs
+++ b/fyrox-impl/src/scene/sound/mod.rs
@@ -72,7 +72,7 @@ pub mod context;
 pub mod listener;
 
 /// Sound source.
-#[derive(Visit, Reflect, Debug)]
+#[derive(Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "28621735-8cd1-4fad-8faf-ecd24bf8aa99"

--- a/fyrox-impl/src/scene/sprite.rs
+++ b/fyrox-impl/src/scene/sprite.rs
@@ -153,7 +153,7 @@ impl VertexTrait for SpriteVertex {
 /// **does not** reuse it. Ideally, you should reuse the shared material across multiple instances
 /// to get the best possible performance. Otherwise, each your sprite will be put in a separate batch
 /// which will force your GPU to render a single sprite in dedicated draw call which is quite slow.
-#[derive(Debug, Reflect, Clone, Visit)]
+#[derive(Debug, PartialEq, Reflect, Clone, Visit)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "60fd7e34-46c1-4ae9-8803-1f5f4c341518"

--- a/fyrox-impl/src/scene/terrain/brushstroke/mod.rs
+++ b/fyrox-impl/src/scene/terrain/brushstroke/mod.rs
@@ -185,6 +185,12 @@ pub enum TerrainTextureKind {
 /// Sender with methods for sending the messages which control a brush painting thread.
 pub struct BrushSender(Sender<BrushThreadMessage>);
 
+impl PartialEq for BrushSender {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
 impl BrushSender {
     /// Create a new BrushSender using the given Sender.
     pub fn new(sender: Sender<BrushThreadMessage>) -> Self {
@@ -684,7 +690,7 @@ impl<V> StrokeData<V> {
 }
 
 /// Shape of a brush.
-#[derive(Copy, Clone, Reflect, Debug)]
+#[derive(Copy, Clone, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "a4dbfba0-077c-4658-9972-38384a8432f9")]
 pub enum BrushShape {
     /// Circle with given radius.
@@ -773,7 +779,7 @@ pub enum BrushTarget {
 }
 
 /// Brush is used to modify terrain. It supports multiple shapes and modes.
-#[derive(Clone, Reflect, Debug)]
+#[derive(Clone, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "dcc4c17b-dad6-42ba-accf-8b88aa2ad31b")]
 pub struct Brush {
     /// Shape of the brush.

--- a/fyrox-impl/src/scene/terrain/geometry.rs
+++ b/fyrox-impl/src/scene/terrain/geometry.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 
 /// The [SurfaceSharedData](crate::scene::mesh::surface::SurfaceResource) of a grid mesh for use
 /// in rendering a terrain.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct TerrainGeometry {
     pub data: SurfaceResource,
     /// Triangle ranges for each quadrant (in clockwise order; left-top -> right-top -> right-bottom -> left-bottom).

--- a/fyrox-impl/src/scene/terrain/mod.rs
+++ b/fyrox-impl/src/scene/terrain/mod.rs
@@ -1029,7 +1029,7 @@ impl BrushContext {
 /// count the number of pixels needed to render the vertices of that part of the terrain, which means that they
 /// overlap with their neighbors just as chunks overlap. Two adjacent blocks share vertices along their edge,
 /// so they also share pixels in the height map data.
-#[derive(Debug, Reflect, Clone)]
+#[derive(Debug, PartialEq, Reflect, Clone)]
 #[reflect(
     derived_type = "Node",
     type_uuid = "4b0a7927-bcd8-41a3-949a-dd10fba8e16a"

--- a/fyrox-impl/src/scene/tilemap/brush.rs
+++ b/fyrox-impl/src/scene/tilemap/brush.rs
@@ -98,7 +98,7 @@ impl From<VisitError> for TileMapBrushResourceError {
 /// of tile map macros. The meaning of the data is determined by matching the UUID
 /// with the UUID of some macro or other user, and it is up to the user to determine
 /// the type of the resource.
-#[derive(Debug, Clone, Default, Reflect)]
+#[derive(Debug, Clone, Default, PartialEq, Reflect)]
 #[reflect(type_uuid = "a3427eef-8d8e-4573-a328-ab06e1d56e25")]
 pub struct BrushMacroInstanceList(Vec<BrushMacroData>);
 
@@ -159,7 +159,7 @@ impl Visit for BrushMacroInstanceList {
 
 /// A brush can have zero or more instances of a macro, and each instance
 /// has its own configuration data.
-#[derive(Debug, Default, Clone, Visit, Reflect)]
+#[derive(Debug, Default, Clone, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "3aa87ac2-c05f-4e9b-86eb-ee846a364585")]
 pub struct BrushMacroData {
     /// The UUID of the macro that owns this instance data.
@@ -178,7 +178,7 @@ pub struct BrushMacroData {
 
 /// A page of tiles within a brush. Having multiple pages allows a brush to be optimized
 /// for use in multiple contexts.
-#[derive(Default, Debug, Clone, Visit, Reflect)]
+#[derive(Default, Debug, Clone, PartialEq, Visit, Reflect)]
 #[reflect(type_uuid = "1e3de522-678b-4922-b959-76a6045de788")]
 pub struct TileMapBrushPage {
     /// The tile that represents this page in the editor
@@ -242,7 +242,7 @@ fn draw_tile_outline(
 
 /// Tile map brush is a set of tiles arranged in arbitrary shape, that can be used to draw on a tile
 /// map.
-#[derive(Default, Debug, Clone, Visit, Reflect)]
+#[derive(Default, Debug, Clone, PartialEq, Visit, Reflect)]
 #[reflect(type_uuid = "23ed39da-cb01-4181-a058-94dc77ecb4b2")]
 pub struct TileMapBrush {
     /// The tile set used by this brush. This must match the tile set of any tile map that this

--- a/fyrox-impl/src/scene/tilemap/data.rs
+++ b/fyrox-impl/src/scene/tilemap/data.rs
@@ -50,7 +50,7 @@ fn tile_position_to_chunk_position(position: Vector2<i32>) -> (Vector2<i32>, Vec
     )
 }
 
-#[derive(Clone, Debug, Reflect)]
+#[derive(Clone, Debug, PartialEq, Reflect)]
 #[reflect(type_uuid = "dad649ae-eb5f-4328-832a-891edd79aff5")]
 struct Chunk([TileDefinitionHandle; CHUNK_WIDTH * CHUNK_HEIGHT]);
 
@@ -176,7 +176,7 @@ impl<'a, P: FnMut(Vector2<i32>) -> bool> TileMapDataIterator<'a, P> {
 }
 
 /// Asset containing the tile handles of a tile map.
-#[derive(Clone, Default, Debug, Reflect)]
+#[derive(Clone, Default, Debug, PartialEq, Reflect)]
 #[reflect(type_uuid = "a8e4b6b4-c1bd-4ed9-a753-0d5a3dfe1729")]
 pub struct TileMapData {
     content: FxHashMap<Vector2<i32>, Chunk>,

--- a/fyrox-impl/src/scene/tilemap/effect.rs
+++ b/fyrox-impl/src/scene/tilemap/effect.rs
@@ -42,6 +42,24 @@ use super::*;
 /// rendered specially.
 pub type TileMapEffectRef = Arc<Mutex<dyn TileMapEffect>>;
 
+/// A reference to [`TileMapEffect`]. A TileMap keeps some of these if it needs to be
+/// rendered specially.
+#[derive(Clone, Debug)]
+pub struct TileMapEffectRefContainer(pub TileMapEffectRef);
+
+impl TileMapEffectRefContainer {
+    /// Returns a reference to the actual tile map effect.
+    pub fn inner(&self) -> MutexGuard<dyn TileMapEffect> {
+        self.0.safe_lock()
+    }
+}
+
+impl PartialEq for TileMapEffectRefContainer {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
 /// A trait for objects that can perform specialized rendering for a tile map by
 /// adding them to [`TileMap::before_effects`] or [`TileMap::after_effects`],
 /// depending on whether the effect should render before the tile map renders

--- a/fyrox-impl/src/scene/tilemap/mod.rs
+++ b/fyrox-impl/src/scene/tilemap/mod.rs
@@ -81,6 +81,7 @@ use crate::{
     },
 };
 use bytemuck::{Pod, Zeroable};
+use fyrox_core::parking_lot::MutexGuard;
 use fyrox_resource::manager::ResourceManager;
 use std::{
     error::Error,
@@ -295,7 +296,7 @@ fn make_tile_vertex(
 }
 
 /// A record whether a change has happened since the most recent save.
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, PartialEq, Copy, Clone)]
 pub struct ChangeFlag(bool);
 
 impl ChangeFlag {
@@ -945,6 +946,21 @@ impl OrthoTransform for TileRenderData {
     }
 }
 
+#[derive(Default, Debug)]
+struct HiddenTilesContainer(Mutex<FxHashSet<Vector2<i32>>>);
+
+impl HiddenTilesContainer {
+    fn inner(&self) -> MutexGuard<FxHashSet<Vector2<i32>>> {
+        self.0.safe_lock()
+    }
+}
+
+impl PartialEq for HiddenTilesContainer {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0.safe_lock() == *other.0.safe_lock()
+    }
+}
+
 /// Tile map is a 2D "image", made out of a small blocks called tiles. Tile maps used in 2D games to
 /// build game worlds quickly and easily. Each tile is represented by a [`TileDefinitionHandle`] which
 /// contains the position of a page and the position of a tile within that page.
@@ -953,7 +969,7 @@ impl OrthoTransform for TileRenderData {
 /// which contains all the pages that may be referenced by the tile map's handles.
 ///
 /// Optional [`TileMapEffect`] objects may be included in the `TileMap` to change how it renders.
-#[derive(Reflect, Debug)]
+#[derive(Reflect, PartialEq, Debug)]
 #[reflect(derived_type = "Node")]
 #[reflect(type_uuid = "aa9a3385-a4af-4faf-a69a-8d3af1a3aa67")]
 pub struct TileMap {
@@ -968,19 +984,19 @@ pub struct TileMap {
     /// Temporary space to store which tiles are invisible during `collect_render_data`.
     /// This is part of how [`TileMapEffect`] can prevent a tile from being rendered.
     #[reflect(hidden)]
-    hidden_tiles: Mutex<FxHashSet<Vector2<i32>>>,
+    hidden_tiles: HiddenTilesContainer,
     /// Special rendering effects that may change how the tile map renders.
     /// These effects are processed in order before the tile map performs the
     /// normal rendering of tiles, and they can prevent some times from being
     /// rendered and render other tiles in place of what would normally be
     /// rendered.
     #[reflect(hidden)]
-    pub before_effects: Vec<TileMapEffectRef>,
+    pub before_effects: Vec<TileMapEffectRefContainer>,
     /// Special rendering effects that may change how the tile map renders.
     /// These effects are processed in order after the tile map performs the
     /// normal rendering of tiles.
     #[reflect(hidden)]
-    pub after_effects: Vec<TileMapEffectRef>,
+    pub after_effects: Vec<TileMapEffectRefContainer>,
 }
 
 impl Visit for TileMap {
@@ -1326,7 +1342,7 @@ impl Default for TileMap {
             tiles: Default::default(),
             tile_scale: Vector2::repeat(1.0).into(),
             active_brush: Default::default(),
-            hidden_tiles: Mutex::default(),
+            hidden_tiles: Default::default(),
             before_effects: Vec::default(),
             after_effects: Vec::default(),
         }
@@ -1341,7 +1357,7 @@ impl Clone for TileMap {
             tiles: self.tiles.clone(),
             tile_scale: self.tile_scale.clone(),
             active_brush: self.active_brush.clone(),
-            hidden_tiles: Mutex::default(),
+            hidden_tiles: Default::default(),
             before_effects: self.before_effects.clone(),
             after_effects: self.after_effects.clone(),
         }
@@ -1414,7 +1430,7 @@ impl NodeTrait for TileMap {
         let mut tile_set_lock = TileSetRef::new(tile_set_resource);
         let tile_set = tile_set_lock.as_loaded();
 
-        let mut hidden_tiles = self.hidden_tiles.safe_lock();
+        let mut hidden_tiles = self.hidden_tiles.inner();
         hidden_tiles.clear();
 
         let bounds = ctx
@@ -1434,7 +1450,7 @@ impl NodeTrait for TileMap {
 
         for effect in self.before_effects.iter() {
             effect
-                .safe_lock()
+                .inner()
                 .render_special_tiles(&mut tile_render_context);
         }
         let bounds = tile_render_context.visible_bounds();
@@ -1461,7 +1477,7 @@ impl NodeTrait for TileMap {
         }
         for effect in self.after_effects.iter() {
             effect
-                .safe_lock()
+                .inner()
                 .render_special_tiles(&mut tile_render_context);
         }
         RdcControlFlow::Continue
@@ -1485,8 +1501,8 @@ pub struct TileMapBuilder {
     tile_set: Option<TileSetResource>,
     tiles: TileMapData,
     tile_scale: Vector2<f32>,
-    before_effects: Vec<TileMapEffectRef>,
-    after_effects: Vec<TileMapEffectRef>,
+    before_effects: Vec<TileMapEffectRefContainer>,
+    after_effects: Vec<TileMapEffectRefContainer>,
 }
 
 impl TileMapBuilder {
@@ -1523,13 +1539,13 @@ impl TileMapBuilder {
     }
 
     /// Adds an effect to the tile map which will run before the tiles render.
-    pub fn with_before_effect(mut self, effect: TileMapEffectRef) -> Self {
+    pub fn with_before_effect(mut self, effect: TileMapEffectRefContainer) -> Self {
         self.before_effects.push(effect);
         self
     }
 
     /// Adds an effect to the tile map which will run after the tiles render.
-    pub fn with_after_effect(mut self, effect: TileMapEffectRef) -> Self {
+    pub fn with_after_effect(mut self, effect: TileMapEffectRefContainer) -> Self {
         self.after_effects.push(effect);
         self
     }
@@ -1547,7 +1563,7 @@ impl TileMapBuilder {
             .into(),
             tile_scale: self.tile_scale.into(),
             active_brush: Default::default(),
-            hidden_tiles: Mutex::default(),
+            hidden_tiles: Default::default(),
             before_effects: self.before_effects,
             after_effects: self.after_effects,
         })

--- a/fyrox-impl/src/scene/tilemap/property.rs
+++ b/fyrox-impl/src/scene/tilemap/property.rs
@@ -115,7 +115,7 @@ impl TileSetPropertyId for TileSetPropertyNine {
 /// Since a tile map may require multiple colliders to represent the diverse ways that physics objects may interact with the tiles,
 /// tile set data must allow each tile to include multiple values for its collider information.
 /// These multiple collider values are associated with their collider objects by a UUID and a name.
-#[derive(Clone, Default, Debug, Reflect, Visit)]
+#[derive(Clone, Default, Debug, PartialEq, Reflect, Visit)]
 #[reflect(type_uuid = "f61cca93-6df4-44d6-a9da-902d82e0c401")]
 pub struct TileSetColliderLayer {
     /// The id number that identifies the collider
@@ -129,7 +129,7 @@ pub struct TileSetColliderLayer {
 /// In order to allow tile properties to be easily edited, properties need to have consistent names and data types
 /// across all tiles in a tile set. A tile property layer represents the association between a property name
 /// and its data type, along with other information.
-#[derive(Clone, Default, Debug, Reflect, Visit)]
+#[derive(Clone, Default, Debug, PartialEq, Reflect, Visit)]
 #[reflect(type_uuid = "99967dc1-b358-4480-8cd6-e519d6deecb5")]
 pub struct TileSetPropertyLayer {
     /// The id number that identifies this property
@@ -145,7 +145,7 @@ pub struct TileSetPropertyLayer {
 /// A value with an associated name. Often certain property values will have special meanings
 /// for the game that is using the values, so it is useful to be able to label those values
 /// so their special meaning can be visible in the editor.
-#[derive(Clone, Default, Debug, Reflect, Visit)]
+#[derive(Clone, Default, Debug, PartialEq, Reflect, Visit)]
 #[reflect(type_uuid = "43913556-aebd-45ae-8d2a-c9ecc8e98e70")]
 pub struct NamedValue {
     /// The label associated with the value.

--- a/fyrox-impl/src/scene/tilemap/tile_source.rs
+++ b/fyrox-impl/src/scene/tilemap/tile_source.rs
@@ -59,22 +59,22 @@ fn position_to_vector(source: PalettePosition) -> Vector2<i32> {
 /// A 2D grid that contains tile data.
 #[derive(Default, Debug, Clone, PartialEq, Reflect)]
 #[reflect(type_uuid = "161e38e6-197c-41ed-aa87-de293662cd3d")]
-pub struct TileGridMap<V: Debug + Clone + Reflect>(FxHashMap<Vector2<i32>, V>);
+pub struct TileGridMap<V: Debug + Clone + Reflect + PartialEq>(FxHashMap<Vector2<i32>, V>);
 
-impl<V: Visit + Default + Debug + Clone + Reflect> Visit for TileGridMap<V> {
+impl<V: Visit + Default + Debug + Clone + Reflect + PartialEq> Visit for TileGridMap<V> {
     fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
         self.0.visit(name, visitor)
     }
 }
 
-impl<V: Debug + Clone + Reflect> Deref for TileGridMap<V> {
+impl<V: Debug + Clone + Reflect + PartialEq> Deref for TileGridMap<V> {
     type Target = FxHashMap<Vector2<i32>, V>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<V: Debug + Clone + Reflect> DerefMut for TileGridMap<V> {
+impl<V: Debug + Clone + Reflect + PartialEq> DerefMut for TileGridMap<V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -372,7 +372,7 @@ pub struct Tiles(TileGridMap<TileDefinitionHandle>);
 
 /// A set of tiles and a transformation, which represents the tiles that the user has selected
 /// to draw with.
-#[derive(Clone, Debug, Default, Visit)]
+#[derive(Clone, Debug, PartialEq, Default, Visit)]
 pub struct Stamp {
     transform: OrthoTransformation,
     #[visit(skip)]
@@ -383,7 +383,7 @@ pub struct Stamp {
 
 /// Each cell of a stamp must have a tile handle and it may optionally have
 /// the handle of a brush cell where the tile was taken from.
-#[derive(Clone, Debug, Reflect, Visit, Default)]
+#[derive(Clone, Debug, Reflect, PartialEq, Visit, Default)]
 #[reflect(type_uuid = "40f40b03-0061-4221-909f-d8590f15efd9")]
 pub struct StampElement {
     /// The stamp cell's tile handle

--- a/fyrox-impl/src/scene/tilemap/tileset.rs
+++ b/fyrox-impl/src/scene/tilemap/tileset.rs
@@ -292,7 +292,7 @@ impl OrthoTransform for TileBounds {
 
 /// A tile set can contain multiple pages of tiles, and each page may have its own
 /// independent source of tile data.
-#[derive(Clone, Default, Debug, Visit, Reflect)]
+#[derive(Clone, Default, Debug, PartialEq, Visit, Reflect)]
 #[reflect(type_uuid = "d781e98c-802a-4e0a-b228-77b13368c24d")]
 pub struct TileSetPage {
     /// The tile that represents this page in the editor
@@ -1256,14 +1256,14 @@ impl<'a> OptionTileSet<'a> {
 
 /// The index of an animation within the animation list, and an offset
 /// to indicate where we should start playing within the animation.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 struct AnimationRef {
     index: usize,
     offset: i32,
 }
 
 /// The position and length of an animation within some animation page.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 struct Animation {
     start: TileDefinitionHandle,
     length: i32,
@@ -1289,7 +1289,7 @@ impl Animation {
 }
 
 /// A lookup table to locate animations within a tile set.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 struct AnimationCache {
     handle_to_animation: FxHashMap<TileDefinitionHandle, AnimationRef>,
     animations: Vec<Animation>,
@@ -1332,7 +1332,7 @@ impl AnimationCache {
 /// Each layer has a name and a color. The color is used to allow the user to quickly
 /// identify which shapes correspond to which layers while in the tile set editor.
 /// See [`TileSetColliderLayer`] for more information.
-#[derive(Clone, Default, Debug, Visit, Reflect)]
+#[derive(Clone, Default, PartialEq, Debug, Visit, Reflect)]
 #[reflect(type_uuid = "7b7e057b-a41e-4150-ab3b-0ae99f4024f0")]
 pub struct TileSet {
     /// A mapping from animated tiles to the corresponding cells on animation pages.

--- a/fyrox-impl/src/scene/tilemap/transform.rs
+++ b/fyrox-impl/src/scene/tilemap/transform.rs
@@ -54,7 +54,7 @@ use super::OptionTileRect;
 pub struct OrthoTransformation(i8);
 
 /// A map from `Vector2<i32>` to values. It can be transformed to flip and rotate the positions of the values.
-#[derive(Clone, Debug, Visit)]
+#[derive(Clone, Debug, PartialEq, Visit)]
 pub struct OrthoTransformMap<V: Visit + Default> {
     transform: OrthoTransformation,
     map: FxHashMap<Vector2<i32>, V>,

--- a/fyrox-impl/src/scene/tilemap/update.rs
+++ b/fyrox-impl/src/scene/tilemap/update.rs
@@ -585,7 +585,7 @@ impl TileSetUpdate {
 /// A stamp element plus the transformation of the [`Stamp`] where the element is taken from,
 /// allowing the stamp element itself to be later transformed before it is applied to a tile map,
 /// tile set, or brush.
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, PartialEq, Reflect)]
 #[reflect(type_uuid = "276857c4-1104-496e-8878-f3fd4368afe9")]
 pub struct RotTileHandle {
     /// The transformation of the element.

--- a/fyrox-impl/src/scene/transform.rs
+++ b/fyrox-impl/src/scene/transform.rs
@@ -74,7 +74,7 @@ use crate::core::{
 use std::cell::Cell;
 
 /// See module docs.
-#[derive(Clone, Debug, Reflect)]
+#[derive(Clone, Debug, PartialEq, Reflect)]
 #[reflect(type_uuid = "16c75838-4a4f-4880-acf5-7e612fc54f01")]
 pub struct Transform {
     // Indicates that some property has changed and matrix must be

--- a/fyrox-impl/src/script/mod.rs
+++ b/fyrox-impl/src/script/mod.rs
@@ -704,6 +704,14 @@ pub struct Script {
     pub(crate) started: bool,
 }
 
+impl PartialEq for Script {
+    fn eq(&self, other: &Self) -> bool {
+        self.instance
+            .try_compare(&*other.instance)
+            .unwrap_or_default()
+    }
+}
+
 impl Deref for Script {
     type Target = dyn ScriptTrait;
 
@@ -823,7 +831,7 @@ mod test {
         script::{Script, ScriptTrait},
     };
 
-    #[derive(Reflect, Visit, Debug, Clone, Default)]
+    #[derive(PartialEq, Reflect, Visit, Debug, Clone, Default)]
     #[reflect(type_uuid = "eed9bf56-7d71-44a0-ba8e-0f3163c59669")]
     struct MyScript {
         field: InheritableVariable<f32>,

--- a/fyrox-impl/src/utils/lightmap.rs
+++ b/fyrox-impl/src/utils/lightmap.rs
@@ -124,7 +124,7 @@ pub fn apply_surface_data_patch(
 }
 
 /// Lightmap entry.
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "17c570ce-0e98-42c0-b93f-ddc97012380d")]
 pub struct LightmapEntry {
     /// Lightmap texture.
@@ -140,7 +140,7 @@ pub struct LightmapEntry {
 }
 
 #[doc(hidden)]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct SurfaceDataPatchWrapper(pub SurfaceDataPatch);
 
 impl Visit for SurfaceDataPatchWrapper {
@@ -166,7 +166,7 @@ impl Visit for SurfaceDataPatchWrapper {
 }
 
 /// Lightmap is a texture with precomputed lighting.
-#[derive(Clone, Debug, Visit, Reflect)]
+#[derive(Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "931d2ee2-f8f0-42e7-9d9b-3c429ca75128")]
 pub struct Lightmap {
     /// Name of the property this light map is bound to in all materials across all

--- a/fyrox-impl/src/utils/mod.rs
+++ b/fyrox-impl/src/utils/mod.rs
@@ -38,8 +38,11 @@ use crate::{
     },
     keyboard::{KeyCode, ModifiersState},
 };
+use fyrox_core::parking_lot::{Mutex, MutexGuard};
+use fyrox_core::SafeLock;
 use fyrox_ui::message::CursorIcon;
 use half::f16;
+use std::collections::VecDeque;
 use std::{any::Any, sync::Arc};
 use winit::{event::Touch, keyboard::PhysicalKey};
 
@@ -823,4 +826,32 @@ pub fn vec3_f16_from_f32(v: Vector3<f32>) -> Vector3<f16> {
 /// Converts `Vector3<f16>` -> `Vector3<f32>`.
 pub fn vec3_f32_from_f16(v: Vector3<f16>) -> Vector3<f32> {
     v.map(|v| v.to_f32())
+}
+
+/// A [`VecDeque`] wrapped into a mutex.
+#[derive(Debug)]
+pub struct ThreadSafeQueue<T>(Mutex<VecDeque<T>>);
+
+impl<T> Default for ThreadSafeQueue<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T> ThreadSafeQueue<T> {
+    /// Pushes a new item at the back of the queue.
+    pub fn push(&mut self, action: T) {
+        self.0.get_mut().push_back(action)
+    }
+
+    /// Returns the locked inner queue.
+    pub fn inner(&self) -> MutexGuard<VecDeque<T>> {
+        self.0.safe_lock()
+    }
+}
+
+impl<T: PartialEq> PartialEq for ThreadSafeQueue<T> {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0.safe_lock() == *other.0.safe_lock()
+    }
 }

--- a/fyrox-impl/src/utils/navmesh.rs
+++ b/fyrox-impl/src/utils/navmesh.rs
@@ -637,7 +637,7 @@ impl Navmesh {
 
 /// Navmesh agent is a "pathfinding unit" that performs navigation on a mesh. It is designed to
 /// cover most of simple use cases when you need to build and follow some path from point A to point B.
-#[derive(Visit, Clone, Debug)]
+#[derive(Visit, PartialEq, Clone, Debug)]
 #[visit(optional)]
 pub struct NavmeshAgent {
     path: Vec<Vector3<f32>>,

--- a/fyrox-material/src/lib.rs
+++ b/fyrox-material/src/lib.rs
@@ -36,7 +36,7 @@ pub mod loader;
 pub mod shader;
 
 /// A texture binding.
-#[derive(Default, Debug, Visit, Clone, Reflect)]
+#[derive(Default, Debug, Visit, PartialEq, Clone, Reflect)]
 #[reflect(type_uuid = "e1642a47-d372-4840-a8eb-f16350f436f8")]
 pub struct MaterialTextureBinding {
     /// Actual value of the texture binding. Could be [`None`], in this case fallback value of the
@@ -50,7 +50,7 @@ pub struct MaterialTextureBinding {
 ///
 /// There is a limited set of possible types that can be passed to a shader, most of them are
 /// just simple data types.
-#[derive(Debug, Visit, Clone, Reflect, AsRefStr, EnumString, VariantNames)]
+#[derive(Debug, Visit, Clone, PartialEq, Reflect, AsRefStr, EnumString, VariantNames)]
 #[reflect(type_uuid = "2df8f1e5-0075-4d0d-9860-70fc27d3e165")]
 pub enum MaterialResourceBinding {
     /// A texture.
@@ -78,7 +78,7 @@ impl MaterialResourceBinding {
 
 /// Property group stores a bunch of named values of a fixed set of types, that will be used for
 /// rendering with some shader.
-#[derive(Default, Debug, Visit, Clone, Reflect)]
+#[derive(Default, Debug, Visit, Clone, PartialEq, Reflect)]
 #[reflect(type_uuid = "f7bfc838-f115-463d-a714-ab48d309058a")]
 pub struct MaterialPropertyGroup {
     properties: FxHashMap<ImmutableString, MaterialProperty>,
@@ -166,7 +166,7 @@ impl MaterialPropertyGroup {
 }
 
 /// A set of possible material property types.
-#[derive(Debug, Visit, Clone, Reflect, AsRefStr, EnumString, VariantNames)]
+#[derive(Debug, Visit, Clone, PartialEq, Reflect, AsRefStr, EnumString, VariantNames)]
 #[reflect(type_uuid = "1c25018d-ab6e-4dca-99a6-e3d9639bc33c")]
 pub enum MaterialProperty {
     /// Real number.
@@ -600,7 +600,7 @@ impl Default for MaterialProperty {
 /// As you can see it is slightly more complex that with the standard shader. The main difference here is
 /// that we using resource manager to get shader instance, and then we just use the instance to create
 /// material instance. Then we populate properties as usual.
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, PartialEq, Reflect)]
 #[reflect(type_uuid = "0e54fe44-0c58-4108-a681-d6eefc88c234")]
 pub struct Material {
     shader: ShaderResource,

--- a/fyrox-material/src/shader/mod.rs
+++ b/fyrox-material/src/shader/mod.rs
@@ -515,7 +515,7 @@ pub const STANDARD_WIDGET_SHADER_NAME: &str = "Widget Shader";
 ///
 /// Usually you don't need to access internals of the shader, but there sometimes could be a need to
 /// read shader definition, to get supported passes and properties.
-#[derive(Default, Debug, Clone, Reflect, Visit)]
+#[derive(Default, Debug, Clone, Reflect, PartialEq, Visit)]
 #[reflect(type_uuid = "f1346417-b726-492a-b80f-c02096c6c019")]
 pub struct Shader {
     /// Shader definition contains description of properties and render passes.

--- a/fyrox-math/Cargo.toml
+++ b/fyrox-math/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/FyroxEngine/Fyrox"
 rust-version = "1.87"
 
 [dependencies]
-rectutils = "0.5.0"
+rectutils = "0.6.0"
 nalgebra = { version = "0.34", features = ["bytemuck", "convert-glam030"] }
 arrayvec = "0.7.4"
 num-traits = "0.2.18"

--- a/fyrox-math/src/aabb.rs
+++ b/fyrox-math/src/aabb.rs
@@ -22,7 +22,7 @@ use crate::Matrix4Ext;
 use nalgebra::{Matrix4, Vector2, Vector3, Vector4};
 use rectutils::{OptionRect, Rect};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct AxisAlignedBoundingBox {
     pub min: Vector3<f32>,
     pub max: Vector3<f32>,

--- a/fyrox-resource/src/constructor.rs
+++ b/fyrox-resource/src/constructor.rs
@@ -113,7 +113,7 @@ mod test {
 
     use super::*;
 
-    #[derive(Debug, Default, Clone, Reflect, Visit)]
+    #[derive(Debug, Default, Clone, PartialEq, Reflect, Visit)]
     #[reflect(type_uuid = "ba5f1e9b-557f-4565-bbb1-c299a6510bb7")]
     struct Stub {}
 

--- a/fyrox-resource/src/lib.rs
+++ b/fyrox-resource/src/lib.rs
@@ -91,9 +91,9 @@ pub trait ResourceData: Debug + Visit + Send + Reflect {
 /// such as: a way to get default state of the data (`Default` impl), a way to get data's type uuid.
 /// The trait has automatic implementation for any type that implements
 /// ` ResourceData + Default ` traits.
-pub trait TypedResourceData: ResourceData + Default {}
+pub trait TypedResourceData: ResourceData + Default + PartialEq {}
 
-impl<T> TypedResourceData for T where T: ResourceData + Default {}
+impl<T> TypedResourceData for T where T: ResourceData + Default + PartialEq {}
 
 /// A trait for resource load error.
 pub trait ResourceLoadError: 'static + Debug + Display + Send + Sync {}
@@ -185,13 +185,13 @@ where
     into = "UntypedResource"
 )]
 #[reflect(type_uuid = "790b1a1c-a997-46c4-ac3b-8565501f0052")]
-pub struct Resource<T: Reflect + Debug> {
+pub struct Resource<T: TypedResourceData> {
     untyped: UntypedResource,
     #[reflect(hidden)]
     phantom: PhantomData<T>,
 }
 
-impl<T: Reflect> Debug for Resource<T> {
+impl<T: TypedResourceData> Debug for Resource<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -404,7 +404,7 @@ where
     }
 }
 
-impl<T: Reflect> Clone for Resource<T> {
+impl<T: TypedResourceData> Clone for Resource<T> {
     #[inline]
     fn clone(&self) -> Self {
         Self {
@@ -702,7 +702,7 @@ mod tests {
         sync::Arc,
     };
 
-    #[derive(Serialize, Deserialize, Default, Debug, Clone, Visit, Reflect)]
+    #[derive(Serialize, Deserialize, Default, Debug, Clone, Visit, PartialEq, Reflect)]
     #[reflect(type_uuid = "241d14c7-079e-4395-a63c-364f0fc3e6ea")]
     struct MyData {
         data: u32,

--- a/fyrox-resource/src/manager.rs
+++ b/fyrox-resource/src/manager.rs
@@ -124,6 +124,12 @@ pub struct ResourceManager {
     state: Arc<Mutex<ResourceManagerState>>,
 }
 
+impl PartialEq for ResourceManager {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
+}
+
 impl Debug for ResourceManager {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "ResourceManager")
@@ -2090,7 +2096,7 @@ mod test {
     };
     use std::{error::Error, fs::File, time::Duration};
 
-    #[derive(Debug, Default, Clone, Reflect, Visit)]
+    #[derive(Debug, Default, Clone, PartialEq, Reflect, Visit)]
     #[reflect(type_uuid = "2c729b8e-93d3-4bcc-a3a7-2d89e77947e5")]
     struct Stub {}
 

--- a/fyrox-resource/src/state.rs
+++ b/fyrox-resource/src/state.rs
@@ -35,6 +35,12 @@ use std::{
 #[reflect(hide_all, type_uuid = "238a5490-6627-48ef-8035-4b589497293b")]
 pub struct WakersList(Vec<Waker>);
 
+impl PartialEq for WakersList {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.len() == other.0.len()
+    }
+}
+
 impl Deref for WakersList {
     type Target = Vec<Waker>;
 
@@ -63,6 +69,16 @@ impl DerefMut for WakersList {
 #[derive(Reflect, Debug, Clone, Default)]
 #[reflect(hide_all, type_uuid = "cb2257dc-b344-49e6-972e-cd99be4c3615")]
 pub struct LoadError(pub Option<Arc<dyn ResourceLoadError>>);
+
+impl PartialEq for LoadError {
+    fn eq(&self, other: &Self) -> bool {
+        if let (Some(a), Some(b)) = (&self.0, &other.0) {
+            Arc::ptr_eq(a, b)
+        } else {
+            false
+        }
+    }
+}
 
 impl std::error::Error for LoadError {}
 
@@ -99,6 +115,14 @@ impl ResourceDataWrapper {
     }
 }
 
+impl PartialEq for ResourceDataWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        self.0
+            .try_compare(other.0.deref() as &dyn Reflect)
+            .unwrap_or_default()
+    }
+}
+
 impl Clone for ResourceDataWrapper {
     fn clone(&self) -> Self {
         Self(ResourceData::try_clone_box(&*self.0).unwrap())
@@ -131,7 +155,7 @@ impl Clone for ResourceDataWrapper {
 /// to get the UUID earlier: the UUID is stored in a metadata file which exists only if the resource
 /// is present. It is somewhat possible to get a UUID when a resource is failed to load, but not in
 /// 100% cases.
-#[derive(Clone, Reflect)]
+#[derive(Clone, PartialEq, Reflect)]
 #[reflect(type_uuid = "3d49c715-4a48-4b41-b8c6-45bcb8b3fd17")]
 pub enum ResourceState {
     /// Resource is not loaded. In some situations, having a handle to a resource
@@ -337,7 +361,7 @@ mod test {
 
     use super::*;
 
-    #[derive(Debug, Default, Clone, Reflect, Visit)]
+    #[derive(Debug, Default, Clone, Reflect, PartialEq, Visit)]
     #[reflect(type_uuid = "96a59120-b174-4b2c-9069-1770ec495011")]
     struct Stub {}
 

--- a/fyrox-resource/src/untyped.rs
+++ b/fyrox-resource/src/untyped.rs
@@ -110,7 +110,7 @@ impl Display for ResourceKind {
 
 /// Header of a resource, it contains a common data about the resource, such as its data type uuid,
 /// its kind, etc.
-#[derive(Reflect, Clone, Debug)]
+#[derive(Reflect, PartialEq, Clone, Debug)]
 #[reflect(type_uuid = "2a41dd3e-bb8f-4654-ad0b-d8b7ca0cc9f2")]
 pub struct ResourceHeader {
     /// The unique identifier of this resource.
@@ -641,7 +641,7 @@ mod test {
 
     use super::*;
 
-    #[derive(Debug, Default, Reflect, Visit, Clone, Copy)]
+    #[derive(Debug, Default, PartialEq, Reflect, Visit, Clone, Copy)]
     #[reflect(type_uuid = "7130e63a-8aa3-44f7-b264-bc19072a70ba")]
     struct Stub {}
 

--- a/fyrox-scripts/src/camera.rs
+++ b/fyrox-scripts/src/camera.rs
@@ -42,7 +42,7 @@ use std::ops::Range;
 /// Flying camera controller script is used to create flying cameras, that can be rotated via mouse and moved via keyboard keys.
 /// Use it, if you need to create a sort of "spectator" camera. To use it, all you need to do is to assign it to your camera
 /// node (or one if its parent nodes).
-#[derive(Visit, Reflect, Debug, Clone)]
+#[derive(Visit, PartialEq, Reflect, Debug, Clone)]
 #[reflect(type_uuid = "8d9e2feb-8c61-482c-8ba4-b0b13b201113")]
 pub struct FlyingCameraController {
     /// Current yaw of the camera pivot (in radians).

--- a/fyrox-sound/src/buffer/generic.rs
+++ b/fyrox-sound/src/buffer/generic.rs
@@ -51,7 +51,7 @@ use std::time::Duration;
 use super::SoundBufferResourceLoadError;
 
 /// Samples container.
-#[derive(Debug, Default,  PartialEq, Visit, Clone, Reflect)]
+#[derive(Debug, Default, PartialEq, Visit, Clone, Reflect)]
 #[reflect(type_uuid = "7b0ba106-9ed5-41e1-a8c7-82c609d6f74e")]
 pub struct Samples(pub Vec<f32>);
 
@@ -70,7 +70,7 @@ impl DerefMut for Samples {
 }
 
 /// Generic sound buffer that contains decoded samples and allows random access.
-#[derive(Debug, Clone, Default,  PartialEq, Visit, Reflect)]
+#[derive(Debug, Clone, Default, PartialEq, Visit, Reflect)]
 #[reflect(type_uuid = "e5bf74a5-13d9-4518-96f2-0e4f3413966e")]
 pub struct GenericBuffer {
     /// Interleaved decoded samples (mono sounds: L..., stereo sounds: LR...)

--- a/fyrox-sound/src/buffer/generic.rs
+++ b/fyrox-sound/src/buffer/generic.rs
@@ -51,7 +51,7 @@ use std::time::Duration;
 use super::SoundBufferResourceLoadError;
 
 /// Samples container.
-#[derive(Debug, Default, Visit, Clone, Reflect)]
+#[derive(Debug, Default,  PartialEq, Visit, Clone, Reflect)]
 #[reflect(type_uuid = "7b0ba106-9ed5-41e1-a8c7-82c609d6f74e")]
 pub struct Samples(pub Vec<f32>);
 
@@ -70,7 +70,7 @@ impl DerefMut for Samples {
 }
 
 /// Generic sound buffer that contains decoded samples and allows random access.
-#[derive(Debug, Clone, Default, Visit, Reflect)]
+#[derive(Debug, Clone, Default,  PartialEq, Visit, Reflect)]
 #[reflect(type_uuid = "e5bf74a5-13d9-4518-96f2-0e4f3413966e")]
 pub struct GenericBuffer {
     /// Interleaved decoded samples (mono sounds: L..., stereo sounds: LR...)

--- a/fyrox-sound/src/buffer/loader.rs
+++ b/fyrox-sound/src/buffer/loader.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, sync::Arc};
 
 /// Defines sound buffer resource import options.
-#[derive(Clone, Deserialize, Serialize, Default, Debug, Reflect)]
+#[derive(Clone, Deserialize, Serialize, Default, Debug, PartialEq, Reflect)]
 #[reflect(type_uuid = "032e333a-f0bd-41f2-a7e5-79207f6064ce")]
 pub struct SoundBufferImportOptions {
     /// Whether the buffer is streaming or not.

--- a/fyrox-sound/src/buffer/mod.rs
+++ b/fyrox-sound/src/buffer/mod.rs
@@ -236,7 +236,7 @@ impl std::fmt::Display for SoundBufferResourceLoadError {
 impl std::error::Error for SoundBufferResourceLoadError {}
 
 /// Sound buffer is a data source for sound sources. See module documentation for more info.
-#[derive(Debug, Visit,  PartialEq, Reflect)]
+#[derive(Debug, Visit, PartialEq, Reflect)]
 #[reflect(non_cloneable)]
 #[reflect(type_uuid = "f6a077b7-c8ff-4473-a95b-0289441ea9d8")]
 pub enum SoundBuffer {

--- a/fyrox-sound/src/buffer/mod.rs
+++ b/fyrox-sound/src/buffer/mod.rs
@@ -236,7 +236,7 @@ impl std::fmt::Display for SoundBufferResourceLoadError {
 impl std::error::Error for SoundBufferResourceLoadError {}
 
 /// Sound buffer is a data source for sound sources. See module documentation for more info.
-#[derive(Debug, Visit, Reflect)]
+#[derive(Debug, Visit,  PartialEq, Reflect)]
 #[reflect(non_cloneable)]
 #[reflect(type_uuid = "f6a077b7-c8ff-4473-a95b-0289441ea9d8")]
 pub enum SoundBuffer {

--- a/fyrox-sound/src/buffer/streaming.rs
+++ b/fyrox-sound/src/buffer/streaming.rs
@@ -75,6 +75,12 @@ pub struct StreamingBuffer {
     streaming_source: StreamingSource,
 }
 
+impl PartialEq for StreamingBuffer {
+    fn eq(&self, other: &Self) -> bool {
+        self.generic == other.generic
+    }
+}
+
 #[derive(Debug, Default)]
 enum StreamingSource {
     #[default]

--- a/fyrox-sound/src/bus.rs
+++ b/fyrox-sound/src/bus.rs
@@ -30,7 +30,7 @@ use fyrox_core::{
 };
 use std::fmt::{Debug, Formatter};
 
-#[derive(Default, Clone)]
+#[derive(Default, PartialEq, Clone)]
 struct PingPongBuffer {
     buffer1: Vec<(f32, f32)>,
     buffer2: Vec<(f32, f32)>,
@@ -101,7 +101,7 @@ impl PingPongBuffer {
 /// samples through a chain of effects. Output signal is then can be either sent to an audio playback device or
 /// to some other audio bus and be processed again, but with different sound effects (this can be done via
 /// [`AudioBusGraph`].
-#[derive(Debug, Reflect, Visit, Clone)]
+#[derive(Debug, PartialEq, Reflect, Visit, Clone)]
 #[reflect(type_uuid = "de4c1709-c9ac-4823-8f77-22199bb53645")]
 pub struct AudioBus {
     pub(crate) name: String,
@@ -309,7 +309,7 @@ impl AudioBus {
 /// ```
 ///
 /// If you delete an audio bus to which a bunch of sound sources is bound, then they will simply stop playing.
-#[derive(Default, Debug, Clone, Visit, Reflect)]
+#[derive(Default, Debug, PartialEq, Clone, Visit, Reflect)]
 #[reflect(type_uuid = "417d2cff-e699-4396-bd90-a57b5564372a")]
 pub struct AudioBusGraph {
     buses: Pool<AudioBus>,

--- a/fyrox-sound/src/context.rs
+++ b/fyrox-sound/src/context.rs
@@ -113,7 +113,7 @@ impl PartialEq for SoundContext {
 
 /// A set of flags, that can be used to define what should be skipped during the
 /// serialization of a sound context.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct SerializationOptions {
     /// All sources won't be serialized, if set.
     pub skip_sources: bool,
@@ -122,7 +122,7 @@ pub struct SerializationOptions {
 }
 
 /// Internal state of context.
-#[derive(Default, Debug, Clone, Reflect)]
+#[derive(Default, Debug, Clone, PartialEq, Reflect)]
 #[reflect(type_uuid = "10f5a7ce-efe4-4bcc-aabc-c399e8fd1a3c")]
 pub struct State {
     sources: Pool<SoundSource>,

--- a/fyrox-sound/src/listener.rs
+++ b/fyrox-sound/src/listener.rs
@@ -33,7 +33,7 @@ use fyrox_core::{
 };
 
 /// See module docs.
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "fc52e441-d1ec-4881-937c-9e2e53a6d621")]
 pub struct Listener {
     basis: Matrix3<f32>,

--- a/fyrox-sound/src/renderer/hrtf.rs
+++ b/fyrox-sound/src/renderer/hrtf.rs
@@ -142,11 +142,17 @@ impl Display for HrtfError {
 
 /// See module docs.
 #[derive(Clone, Debug, Default, Reflect)]
-#[reflect(type_uuid = "c6149a3b-7992-44a8-9b9f-16651a5d2b15")]
+#[reflect(type_uuid = "c6149a3b-7992-44a8-9b9f-16651a5d2b15", non_comparable)]
 pub struct HrtfRenderer {
     hrir_resource: Option<HrirSphereResource>,
     #[reflect(hidden)]
     processor: Option<hrtf::HrtfProcessor>,
+}
+
+impl PartialEq for HrtfRenderer {
+    fn eq(&self, other: &Self) -> bool {
+        self.hrir_resource == other.hrir_resource
+    }
 }
 
 impl Visit for HrtfRenderer {
@@ -243,6 +249,16 @@ enum HrirSource {
     RawData(Vec<u8>),
 }
 
+impl PartialEq for HrirSource {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Preloaded(a), Self::Preloaded(b)) => a.source() == b.source(),
+            (Self::RawData(a), Self::RawData(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
 impl Default for HrirSource {
     fn default() -> Self {
         Self::RawData(Default::default())
@@ -251,8 +267,8 @@ impl Default for HrirSource {
 
 /// Wrapper for [`HrirSphere`] to be able to use it in the resource manager, that will handle async resource
 /// loading automatically.
-#[derive(Reflect, Default, Clone, Visit)]
-#[reflect(type_uuid = "c92a0fa3-0ed3-49a9-be44-8f06271c6be2")]
+#[derive(Reflect, Default, PartialEq, Clone, Visit)]
+#[reflect(type_uuid = "c92a0fa3-0ed3-49a9-be44-8f06271c6be2", non_comparable)]
 pub struct HrirSphereResourceData {
     #[reflect(hidden)]
     #[visit(skip)]

--- a/fyrox-sound/src/renderer/mod.rs
+++ b/fyrox-sound/src/renderer/mod.rs
@@ -44,7 +44,7 @@ pub mod hrtf;
 // This "large size difference" is not a problem because renderer
 // can be only one at a time on context.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, AsRefStr, EnumString, VariantNames, Visit, Reflect, Default)]
+#[derive(Debug, Clone, AsRefStr, EnumString, VariantNames, Visit, PartialEq, Reflect, Default)]
 #[reflect(type_uuid = "13bf8432-987a-4216-b6aa-f5c0e8914a31")]
 pub enum Renderer {
     /// Stateless default renderer.

--- a/fyrox-sound/src/source.rs
+++ b/fyrox-sound/src/source.rs
@@ -81,7 +81,7 @@ pub enum Status {
 }
 
 /// See module info.
-#[derive(Debug, Clone, Reflect, Visit)]
+#[derive(Debug, Clone, PartialEq, Reflect, Visit)]
 #[reflect(type_uuid = "1beb0bbc-72fb-42a1-9e78-5d246c84fdfe")]
 pub struct SoundSource {
     name: String,

--- a/fyrox-texture/src/lib.rs
+++ b/fyrox-texture/src/lib.rs
@@ -76,7 +76,7 @@ use strum_macros::{AsRefStr, EnumString, VariantNames};
 pub mod loader;
 
 /// Texture kind.
-#[derive(Copy, Clone, Debug, Reflect, AsRefStr, EnumString, VariantNames)]
+#[derive(Copy, Clone, Debug, PartialEq, Reflect, AsRefStr, EnumString, VariantNames)]
 #[reflect(type_uuid = "542eb785-875b-43ce-b73a-a25024535f48")]
 pub enum TextureKind {
     /// 1D texture.
@@ -222,7 +222,7 @@ impl Visit for TextureKind {
 }
 
 /// Data storage of a texture.
-#[derive(Default, Clone, Reflect)]
+#[derive(Default, PartialEq, Clone, Reflect)]
 #[reflect(type_uuid = "4b9c2b23-46cd-4f7f-bf13-07b0bebe5538")]
 pub struct TextureBytes(Vec<u8>);
 
@@ -253,7 +253,7 @@ impl DerefMut for TextureBytes {
 }
 
 /// Actual texture data.
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, PartialEq, Reflect)]
 #[reflect(type_uuid = "02c23a44-55fa-411a-bc39-eb7a5eadf15c")]
 pub struct Texture {
     kind: TextureKind,
@@ -396,7 +396,17 @@ impl Default for Texture {
 
 /// A filter for mip-map generation.
 #[derive(
-    Default, Copy, Clone, Deserialize, Serialize, Debug, Reflect, AsRefStr, EnumString, VariantNames,
+    Default,
+    Copy,
+    Clone,
+    Deserialize,
+    Serialize,
+    PartialEq,
+    Debug,
+    Reflect,
+    AsRefStr,
+    EnumString,
+    VariantNames,
 )]
 #[reflect(type_uuid = "8fa17c0e-6889-4540-b396-97db4dc952aa")]
 pub enum MipFilter {
@@ -446,7 +456,7 @@ impl MipFilter {
 ///     compression: NoCompression,
 /// )
 /// ```
-#[derive(Clone, Deserialize, Serialize, Debug, Reflect)]
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Reflect)]
 #[reflect(type_uuid = "c70e89c9-2245-4736-99d9-f3fe9c1c5d3c")]
 pub struct TextureImportOptions {
     #[serde(default)]

--- a/fyrox-ui/src/absm.rs
+++ b/fyrox-ui/src/absm.rs
@@ -118,7 +118,7 @@ pub mod prelude {
 ///
 /// The node does **not** contain any animations, instead it just takes animations from an animation
 /// player node and mixes them.
-#[derive(Visit, Reflect, Clone, Debug, Default)]
+#[derive(Visit, PartialEq, Reflect, Clone, Debug, Default)]
 #[reflect(type_uuid = "4b08c753-2a10-41e3-8fb2-4fd0517e86bc")]
 #[reflect(derived_type = "UiNode")]
 pub struct AnimationBlendingStateMachine {
@@ -276,7 +276,7 @@ pub struct EventAction {
 }
 
 /// A widget that listens for particular events and sets parameters in an ABSM accordingly.
-#[derive(Visit, Reflect, Clone, Debug, Default)]
+#[derive(Visit, PartialEq, Reflect, Clone, Debug, Default)]
 #[reflect(type_uuid = "15f306b8-3bb8-4b35-87bd-6e9e5d748455")]
 #[reflect(derived_type = "UiNode")]
 pub struct AbsmEventProvider {

--- a/fyrox-ui/src/animation.rs
+++ b/fyrox-ui/src/animation.rs
@@ -142,7 +142,7 @@ impl BoundValueCollectionExt for BoundValueCollection {
 /// Animation player is a node that contains multiple animations. It updates and plays all the animations.
 /// The node could be a source of animations for animation blending state machines. To learn more about
 /// animations, see [`Animation`] docs.
-#[derive(Visit, Reflect, Clone, Debug)]
+#[derive(Visit, PartialEq, Reflect, Clone, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "44d1c94e-354f-4f9a-b918-9d31c28aa16a"

--- a/fyrox-ui/src/bit.rs
+++ b/fyrox-ui/src/bit.rs
@@ -113,7 +113,7 @@ impl<T: BitContainer> ConstructorProvider<UiNode, UserInterface> for BitField<T>
     }
 }
 
-#[derive(Default, Clone, Reflect, Visit, Debug)]
+#[derive(Default, Clone, PartialEq, Reflect, Visit, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "6c19b266-18be-46d2-bfd3-f1dc9cb3f36c"

--- a/fyrox-ui/src/border.rs
+++ b/fyrox-ui/src/border.rs
@@ -99,7 +99,7 @@ use fyrox_graph::constructor::{ConstructorProvider, GraphNodeConstructor};
 /// .with_stroke_thickness(Thickness {left: 2.0, right: 2.0, top: 2.0, bottom: 2.0}.into())
 /// .build(&mut ui.build_ctx());
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "6aba3dc5-831d-481a-bc83-ec10b2b2bf12")]
 #[reflect(derived_type = "UiNode")]
 pub struct Border {

--- a/fyrox-ui/src/button.rs
+++ b/fyrox-ui/src/button.rs
@@ -90,7 +90,7 @@ impl MessageData for ButtonMessage {}
 ///     }
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "2abcf12b-2f19-46da-b900-ae8890f7c9c6")]
 #[reflect(derived_type = "UiNode")]
 pub struct Button {

--- a/fyrox-ui/src/canvas.rs
+++ b/fyrox-ui/src/canvas.rs
@@ -66,7 +66,7 @@ use fyrox_graph::constructor::{ConstructorProvider, GraphNodeConstructor};
 ///     .build(ctx)
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "6b843a36-53da-467b-b85e-2380fe891ca1")]
 #[reflect(derived_type = "UiNode")]
 pub struct Canvas {

--- a/fyrox-ui/src/check_box.rs
+++ b/fyrox-ui/src/check_box.rs
@@ -148,7 +148,7 @@ impl MessageData for CheckBoxMessage {}
 /// 2) [`CheckBoxBuilder::with_check_mark`] - sets the widget that will be used as checked icon.
 /// 3) [`CheckBoxBuilder::with_uncheck_mark`] - sets the widget that will be used as unchecked icon.
 /// 4) [`CheckBoxBuilder::with_undefined_mark`] - sets the widget that will be used as undefined icon.
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "3a866ba8-7682-4ce7-954a-46360f5837dc")]
 #[reflect(derived_type = "UiNode")]
 pub struct CheckBox {

--- a/fyrox-ui/src/color/gradient.rs
+++ b/fyrox-ui/src/color/gradient.rs
@@ -56,7 +56,7 @@ pub enum ColorGradientEditorMessage {
 }
 impl MessageData for ColorGradientEditorMessage {}
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "50d00eb7-f30b-4973-8a36-03d6b8f007ec")]
 #[reflect(derived_type = "UiNode")]
 pub struct ColorGradientField {
@@ -182,7 +182,7 @@ impl ColorGradientFieldBuilder {
     }
 }
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "82843d8b-1972-46e6-897c-9619b74059cc")]
 #[reflect(derived_type = "UiNode")]
 pub struct ColorGradientEditor {
@@ -469,7 +469,7 @@ pub enum ColorPointMessage {
 }
 impl MessageData for ColorPointMessage {}
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "a493a603-3451-4005-8c80-559707729e70")]
 #[reflect(derived_type = "UiNode")]
 pub struct ColorPoint {
@@ -602,7 +602,7 @@ impl ColorPointBuilder {
     }
 }
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "2608955a-4095-4fd1-af71-99bcdf2600f0")]
 #[reflect(derived_type = "UiNode")]
 pub struct ColorPointsCanvas {

--- a/fyrox-ui/src/color/mod.rs
+++ b/fyrox-ui/src/color/mod.rs
@@ -103,7 +103,7 @@ pub enum ColorFieldMessage {
 }
 impl MessageData for ColorFieldMessage {}
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "956d4cae-7953-486b-99da-a9b852c2e144"
@@ -384,7 +384,7 @@ impl AlphaBarBuilder {
     }
 }
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "af28f977-85e7-4c9e-9a61-7f208844acb5"
@@ -547,7 +547,7 @@ impl HueBarBuilder {
     }
 }
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "ab6bfad5-0c4b-42a5-8da5-fc5687b1afc7"
@@ -764,7 +764,7 @@ impl SaturationBrightnessFieldBuilder {
     }
 }
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "b7a5d650-5b77-4938-83c1-37f3fe107885"
@@ -1154,7 +1154,7 @@ impl ColorPickerBuilder {
     }
 }
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "68dec1ac-23c6-41df-bc85-499f2a82e908"

--- a/fyrox-ui/src/curve/key.rs
+++ b/fyrox-ui/src/curve/key.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use std::cmp::Ordering;
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "ae6110cd-f1dd-45b5-98e1-d8ae8bf3d0cc")]
 pub struct CurveKeyView {
     pub position: Vector2<f32>,
@@ -48,7 +48,7 @@ impl From<&CurveKey> for CurveKeyView {
     }
 }
 
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "866c6360-2c6a-4218-aebc-530036b59a87")]
 pub struct CurveKeyViewContainer {
     id: Uuid,

--- a/fyrox-ui/src/curve/mod.rs
+++ b/fyrox-ui/src/curve/mod.rs
@@ -110,6 +110,12 @@ pub struct HighlightZone {
 #[derive(Debug, Default)]
 pub struct CurveTransformCell(Mutex<CurveTransform>);
 
+impl PartialEq for CurveTransformCell {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0.safe_lock() == *other.0.safe_lock()
+    }
+}
+
 impl Clone for CurveTransformCell {
     fn clone(&self) -> Self {
         Self(Mutex::new(self.0.safe_lock().clone()))
@@ -211,7 +217,7 @@ fn standardize_step(step: f32) -> f32 {
 ///
 /// Since widgets are not mutable during layout and rendering, a CurveTransform
 /// is intended to be used within a [CurveTransformCell] which provides interior mutability.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct CurveTransform {
     /// Position of the center of the curve editor in the curve coordinate space.
     pub position: Vector2<f32>,
@@ -358,7 +364,7 @@ impl Iterator for StepIterator {
     }
 }
 
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "4b640057-639e-4f47-9a08-c08d94eca68e")]
 pub struct CurvesContainer {
     curves: Vec<CurveKeyViewContainer>,
@@ -412,7 +418,7 @@ impl CurvesContainer {
     }
 }
 
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "5c7b087e-871e-498d-b064-187b604a37d8"
@@ -471,7 +477,7 @@ impl ConstructorProvider<UiNode, UserInterface> for CurveEditor {
 
 crate::define_widget_deref!(CurveEditor);
 
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "c81d942c-394d-498d-b460-1dc508288ed3")]
 struct ContextMenu {
     widget: RcUiNodeHandle,
@@ -495,7 +501,7 @@ struct DragEntry {
     initial_position: Vector2<f32>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 enum OperationContext {
     DragKeys {
         // In local coordinates.
@@ -527,7 +533,7 @@ impl OperationContext {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone,PartialEq,  Debug)]
 enum Selection {
     Keys { keys: FxHashSet<Uuid> },
     LeftTangent { key_id: Uuid },

--- a/fyrox-ui/src/curve/mod.rs
+++ b/fyrox-ui/src/curve/mod.rs
@@ -495,7 +495,7 @@ struct ContextMenu {
     paste_keys: Handle<MenuItem>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 struct DragEntry {
     key_id: Uuid,
     initial_position: Vector2<f32>,
@@ -533,7 +533,7 @@ impl OperationContext {
     }
 }
 
-#[derive(Clone,PartialEq,  Debug)]
+#[derive(Clone, PartialEq, Debug)]
 enum Selection {
     Keys { keys: FxHashSet<Uuid> },
     LeftTangent { key_id: Uuid },
@@ -952,7 +952,7 @@ impl Control for CurveEditor {
                             // but when it works, who cares.
                             self.zoom_to_fit_timer = Some(10);
                         } else {
-                            self.zoom_to_fit(&ui.sender);
+                            self.zoom_to_fit(&ui.ui_message_channel.sender);
                         }
 
                         self.invalidate_visual();
@@ -1088,7 +1088,7 @@ impl Control for CurveEditor {
         if let Some(timer) = self.zoom_to_fit_timer.as_mut() {
             *timer = timer.saturating_sub(1);
             if *timer == 0 {
-                self.zoom_to_fit(&ui.sender);
+                self.zoom_to_fit(&ui.ui_message_channel.sender);
                 self.zoom_to_fit_timer = None;
             }
         }

--- a/fyrox-ui/src/decorator.rs
+++ b/fyrox-ui/src/decorator.rs
@@ -86,7 +86,7 @@ impl MessageData for DecoratorMessage {}
 ///         .build(ctx)
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "bb4b60aa-c657-4ed6-8db6-d7f374397c73"

--- a/fyrox-ui/src/dock/mod.rs
+++ b/fyrox-ui/src/dock/mod.rs
@@ -160,7 +160,7 @@ impl MessageData for DockingManagerMessage {}
 /// To be able to restore the layout to its defaults, just create a desired layout from code,
 /// save the layout and use the returned layout descriptor when you need to restore the layout
 /// to its defaults.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "b04299f7-3f6b-45f1-89a6-0dce4ad929e1"

--- a/fyrox-ui/src/dock/tile.rs
+++ b/fyrox-ui/src/dock/tile.rs
@@ -256,7 +256,7 @@ fn deminimize_other_window(
     }
 }
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "8ed17fa9-890e-4dd7-b4f9-a24660882234"

--- a/fyrox-ui/src/draw.rs
+++ b/fyrox-ui/src/draw.rs
@@ -873,7 +873,7 @@ impl RenderData {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct DrawingContext {
     pub render_data: RenderData,
     pub transform_stack: TransformStack,

--- a/fyrox-ui/src/draw.rs
+++ b/fyrox-ui/src/draw.rs
@@ -40,7 +40,7 @@ use fyrox_texture::TextureResource;
 use std::fmt::{Display, Formatter};
 use std::ops::Range;
 
-#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
 #[repr(C)]
 pub struct Vertex {
     pub pos: Vector2<f32>,
@@ -58,7 +58,7 @@ impl Vertex {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum CommandTexture {
     None,
     Texture(TextureResource),
@@ -70,7 +70,7 @@ pub enum CommandTexture {
 }
 
 /// A set of triangles that will be used for clipping.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct ClippingGeometry {
     pub vertex_buffer: Vec<Vertex>,
     pub triangle_buffer: Vec<TriangleDefinition>,
@@ -126,7 +126,7 @@ impl ClippingGeometry {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Command {
     /// Clipping bounds, should be used for scissor-test. Screen-space.
     pub clip_bounds: Rect<f32>,
@@ -753,7 +753,7 @@ pub trait Draw {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct TransformStack {
     transform: Matrix3<f32>,
     stack: Vec<Matrix3<f32>>,
@@ -806,7 +806,7 @@ impl TransformStack {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct RenderData {
     pub vertex_buffer: Vec<Vertex>,
     pub triangle_buffer: Vec<TriangleDefinition>,

--- a/fyrox-ui/src/dropdown_list.rs
+++ b/fyrox-ui/src/dropdown_list.rs
@@ -167,7 +167,7 @@ impl MessageData for DropdownListMessage {}
 ///
 /// A dropdown list could be opened and closed manually using [`DropdownListMessage::Open`] and
 /// [`DropdownListMessage::Close`] messages.  
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "1da2f69a-c8b4-4ae2-a2ad-4afe61ee2a32"

--- a/fyrox-ui/src/dropdown_menu.rs
+++ b/fyrox-ui/src/dropdown_menu.rs
@@ -34,7 +34,7 @@ use std::sync::mpsc::Sender;
 
 /// A simple widget that opens a popup when clicked. It could be used to create dropdown menus that
 /// consolidates content of a group.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "c0a4c51b-f041-453b-a89d-7ceb5394e321")]
 #[reflect(derived_type = "UiNode")]
 pub struct DropdownMenu {

--- a/fyrox-ui/src/expander.rs
+++ b/fyrox-ui/src/expander.rs
@@ -151,7 +151,7 @@ impl MessageData for ExpanderMessage {}
 ///
 /// To switch expander state at runtime, send [`ExpanderMessage::Expand`] to your Expander widget instance with
 /// [`crate::message::MessageDirection::ToWidget`].
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "24976179-b338-4c55-84c3-72d21663efd2"

--- a/fyrox-ui/src/file_browser/dialog.rs
+++ b/fyrox-ui/src/file_browser/dialog.rs
@@ -41,7 +41,7 @@ pub enum FolderNameDialogMessage {
 }
 impl MessageData for FolderNameDialogMessage {}
 
-#[derive(Clone, Visit, Reflect, Default, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Default, Debug)]
 #[reflect(type_uuid = "832f63b8-1372-49b8-8ce5-7564920343a8")]
 #[reflect(derived_type = "UiNode")]
 pub struct FolderNameDialog {

--- a/fyrox-ui/src/file_browser/field.rs
+++ b/fyrox-ui/src/file_browser/field.rs
@@ -46,7 +46,7 @@ impl MessageData for FileSelectorFieldMessage {}
 
 define_widget_deref!(FileSelectorField);
 
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "2dbda730-8a60-4f62-aee8-2ff0ccd15bf2"

--- a/fyrox-ui/src/file_browser/menu.rs
+++ b/fyrox-ui/src/file_browser/menu.rs
@@ -43,7 +43,7 @@ use std::{
     sync::mpsc::Sender,
 };
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "6a9d597f-6a9f-4bad-b569-4cff1a6deff7"

--- a/fyrox-ui/src/file_browser/mod.rs
+++ b/fyrox-ui/src/file_browser/mod.rs
@@ -100,7 +100,7 @@ enum FsEventMessage {
 }
 impl MessageData for FsEventMessage {}
 
-#[derive(Default, Visit, Reflect)]
+#[derive(Default, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "b7f4610e-4b0c-4671-9b4a-60bb45268928")]
 #[reflect(derived_type = "UiNode")]
 pub struct FileBrowser {
@@ -120,7 +120,6 @@ pub struct FileBrowser {
     #[visit(skip)]
     #[reflect(hidden)]
     pub item_context_menu: RcUiNodeHandle,
-    #[allow(clippy::type_complexity)]
     #[visit(skip)]
     #[reflect(hidden)]
     pub watcher: Option<notify::RecommendedWatcher>,

--- a/fyrox-ui/src/file_browser/mod.rs
+++ b/fyrox-ui/src/file_browser/mod.rs
@@ -26,8 +26,8 @@
 use crate::{
     button::{ButtonBuilder, ButtonMessage},
     core::{
-        err, log::Log, ok_or_continue, ok_or_return, parking_lot::Mutex, pool::Handle,
-        reflect::prelude::*, some_or_return, visitor::prelude::*, SafeLock,
+        err, log::Log, ok_or_continue, ok_or_return, pool::Handle, reflect::prelude::*,
+        some_or_return, visitor::prelude::*,
     },
     file_browser::{
         fs_tree::{sanitize_path, TreeItemPath},
@@ -52,11 +52,12 @@ use fyrox_graph::{
     SceneGraph,
 };
 use notify::{Event, Watcher};
+use std::ops::{Deref, DerefMut};
 use std::{
     collections::VecDeque,
     fmt::{Debug, Formatter},
     path::{Path, PathBuf},
-    sync::{mpsc::Sender, Arc},
+    sync::mpsc::Sender,
 };
 
 mod dialog;
@@ -72,6 +73,7 @@ use crate::button::Button;
 use crate::scroll_viewer::ScrollViewer;
 use crate::text::Text;
 use crate::text_box::TextBox;
+use crate::widget::UserData;
 pub use field::*;
 pub use filter::*;
 pub use selector::*;
@@ -100,6 +102,29 @@ enum FsEventMessage {
 }
 impl MessageData for FsEventMessage {}
 
+#[derive(Debug)]
+pub struct FsWatcher(notify::RecommendedWatcher);
+
+impl PartialEq for FsWatcher {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Deref for FsWatcher {
+    type Target = notify::RecommendedWatcher;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for FsWatcher {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 #[derive(Default, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "b7f4610e-4b0c-4671-9b4a-60bb45268928")]
 #[reflect(derived_type = "UiNode")]
@@ -122,7 +147,7 @@ pub struct FileBrowser {
     pub item_context_menu: RcUiNodeHandle,
     #[visit(skip)]
     #[reflect(hidden)]
-    pub watcher: Option<notify::RecommendedWatcher>,
+    pub watcher: Option<FsWatcher>,
 }
 
 impl ConstructorProvider<UiNode, UserInterface> for FileBrowser {
@@ -282,7 +307,7 @@ impl FileBrowser {
         };
         if let Some(root) = self.root.clone() {
             self.set_path(&root, ui);
-            let tree_item_path = Arc::new(Mutex::new(TreeItemPath::root(root.clone())));
+            let tree_item_path = UserData::new(TreeItemPath::root(root.clone()));
             ui[self.tree_root].user_data = Some(tree_item_path.clone());
             self.user_data = Some(tree_item_path);
         }
@@ -558,7 +583,7 @@ impl Control for FileBrowser {
         ui.node(widget)
             .user_data
             .as_ref()
-            .is_some_and(|data| data.safe_lock().downcast_ref::<TreeItemPath>().is_some())
+            .is_some_and(|data| data.downcast::<TreeItemPath>().is_some())
     }
 }
 
@@ -819,7 +844,7 @@ fn setup_file_browser_fs_watcher(
     sender: Sender<UiMessage>,
     file_browser_handle: Handle<FileBrowser>,
     the_path: PathBuf,
-) -> Option<notify::RecommendedWatcher> {
+) -> Option<FsWatcher> {
     let handler = EventReceiver {
         file_browser_handle,
         sender,
@@ -828,7 +853,7 @@ fn setup_file_browser_fs_watcher(
     match notify::RecommendedWatcher::new(handler, config) {
         Ok(mut watcher) => {
             Log::verify(watcher.watch(&the_path, notify::RecursiveMode::Recursive));
-            Some(watcher)
+            Some(FsWatcher(watcher))
         }
         Err(_) => None,
     }

--- a/fyrox-ui/src/file_browser/selector.rs
+++ b/fyrox-ui/src/file_browser/selector.rs
@@ -73,7 +73,7 @@ impl MessageData for FileSelectorMessage {}
 
 /// File selector is a modal window that allows you to select a file (or directory) and commit or
 /// cancel selection.
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "878b2220-03e6-4a50-a97d-3a8e5397b6cb"

--- a/fyrox-ui/src/file_browser/test.rs
+++ b/fyrox-ui/src/file_browser/test.rs
@@ -20,8 +20,9 @@
 
 use crate::file_browser::fs_tree::{sanitize_path, TreeItemPath};
 use crate::file_browser::{FileType, PathFilter};
+use crate::widget::UserData;
 use crate::{
-    core::{algebra::Vector2, parking_lot::Mutex, pool::Handle},
+    core::{algebra::Vector2, pool::Handle},
     file_browser::{
         fs_tree::{self, read_dir_entries, DisksProvider},
         FileBrowserBuilder, FileBrowserMessage,
@@ -35,7 +36,6 @@ use fyrox_graph::SceneGraph;
 use std::{
     fs::File,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 fn create_dir(path: impl AsRef<Path>) {
@@ -124,7 +124,7 @@ fn test_find_tree() {
     let mut ui = UserInterface::new(Vector2::new(100.0, 100.0));
 
     let root = TreeRootBuilder::new(
-        WidgetBuilder::new().with_user_data(Arc::new(Mutex::new(PathBuf::from("test")))),
+        WidgetBuilder::new().with_user_data(UserData::new(PathBuf::from("test"))),
     )
     .build(&mut ui.build_ctx())
     .to_base();

--- a/fyrox-ui/src/font/mod.rs
+++ b/fyrox-ui/src/font/mod.rs
@@ -62,7 +62,7 @@ enum FontError {
 
 /// The geometric data specifying where to find a glyph on a font atlas
 /// texture for rendering text.
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FontGlyph {
     /// The vertical position of the glyph relative to other glyphs on the line, measured in font pixels.
     /// This would be 0 for a glyph with its bottom directly on the baseline, but may be
@@ -92,7 +92,7 @@ pub struct FontGlyph {
 }
 
 /// Page is a storage for rasterized glyphs.
-#[derive(Clone)]
+#[derive(PartialEq, Clone)]
 pub struct Page {
     /// The texture data for rendering some glyphs.
     /// When new glyphs are required, this data may be modified if space
@@ -123,7 +123,7 @@ impl Debug for Page {
 
 /// Atlas is a storage for glyphs of a particular size, each atlas could have any number of pages to
 /// store the rasterized glyphs.
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, PartialEq, Debug)]
 pub struct Atlas {
     /// The geometric data used for rendering glyphs from the pages of this atlas,
     /// such as the size of each glyph, the index of its page, and the UVs of the corners
@@ -330,7 +330,7 @@ impl Atlas {
 }
 
 /// A font resource and the associated data required for rendering glyphs from the font.
-#[derive(Default, Clone, Debug, Reflect, Visit)]
+#[derive(Default, Clone, Debug, Reflect, PartialEq, Visit)]
 #[reflect(type_uuid = "692fec79-103a-483c-bb0b-9fc3a349cb48")]
 pub struct Font {
     /// The source font data, such as might come from a ttf file.

--- a/fyrox-ui/src/font/mod.rs
+++ b/fyrox-ui/src/font/mod.rs
@@ -330,7 +330,7 @@ impl Atlas {
 }
 
 /// A font resource and the associated data required for rendering glyphs from the font.
-#[derive(Default, Clone, Debug, Reflect, PartialEq, Visit)]
+#[derive(Default, Clone, Debug, Reflect, Visit)]
 #[reflect(type_uuid = "692fec79-103a-483c-bb0b-9fc3a349cb48")]
 pub struct Font {
     /// The source font data, such as might come from a ttf file.
@@ -359,6 +359,17 @@ pub struct Font {
     /// font.
     #[visit(skip)]
     pub fallbacks: Vec<Option<FontResource>>,
+}
+
+impl PartialEq for Font {
+    fn eq(&self, other: &Self) -> bool {
+        self.atlases == other.atlases
+            && self.page_size == other.page_size
+            && self.bold == other.bold
+            && self.italic == other.italic
+            && self.bold_italic == other.bold_italic
+            && self.fallbacks == other.fallbacks
+    }
 }
 
 impl ResourceData for Font {

--- a/fyrox-ui/src/formatted_text.rs
+++ b/fyrox-ui/src/formatted_text.rs
@@ -55,7 +55,7 @@ pub struct Position {
     pub offset: usize,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub struct TextGlyph {
     pub bounds: Rect<f32>,
     pub tex_coords: [Vector2<f32>; 4],
@@ -63,7 +63,7 @@ pub struct TextGlyph {
     pub source_char_index: usize,
 }
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub struct TextLine {
     /// Index of starting symbol in text array.
     pub begin: usize,
@@ -256,7 +256,7 @@ impl LineSink for WrapSink<'_> {
     }
 }
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "a48f1f1d-24ce-4a84-a45d-706ac541cf0a")]
 pub struct FormattedText {
     font: InheritableVariable<Option<FontResource>>,

--- a/fyrox-ui/src/grid.rs
+++ b/fyrox-ui/src/grid.rs
@@ -217,7 +217,7 @@ pub type Row = GridDimension;
 /// You can add any number of rows and columns to a grid widget, and each grid cell does **not** need to have a UI widget
 /// in it to be valid. For example, you can add a column and set it to a specific size via strict to provide spacing between
 /// two other columns.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "98ce15e2-bd62-497d-a37b-9b1cb4a1918c"
@@ -262,7 +262,7 @@ crate::define_widget_deref!(Grid);
 
 /// Cell of the grid, that contains additional information for layout purposes. It does not have any
 /// particular use outside of grid's internals.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Cell {
     /// A set of nodes of the cell.
     pub nodes: Vec<Handle<UiNode>>,

--- a/fyrox-ui/src/image.rs
+++ b/fyrox-ui/src/image.rs
@@ -157,7 +157,7 @@ impl MessageData for ImageMessage {}
 /// It is useful if you have many custom UI elements packed in a single texture atlas. Drawing using atlases is much more
 /// efficient and faster. This could also be used for animations when you have multiple frames packed in a single atlas
 /// and changing texture coordinates over time.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "18e18d0f-cb84-4ac1-8050-3480a2ec3de5")]
 #[visit(optional)]
 #[reflect(derived_type = "UiNode")]

--- a/fyrox-ui/src/input.rs
+++ b/fyrox-ui/src/input.rs
@@ -88,7 +88,7 @@ pub enum InputBoxResult {
 /// There's no way to change the style of the input box, nor add some widgets to it. If you need a
 /// custom input box, then you need to create your own widget. This input box is meant to be used as
 /// a standard dialog box for standard situations in the UI.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "6b7b6b82-939b-4f98-9bb9-9bd19ce68b21")]
 #[reflect(derived_type = "UiNode")]
 pub struct InputBox {

--- a/fyrox-ui/src/inspector/editors/array.rs
+++ b/fyrox-ui/src/inspector/editors/array.rs
@@ -26,8 +26,7 @@ use crate::{
             PropertyEditorDefinitionContainer, PropertyEditorInstance,
             PropertyEditorMessageContext, PropertyEditorTranslationContext,
         },
-        make_expander_container, CollectionAction, FieldAction, InspectorEnvironment,
-        InspectorError, PropertyChanged,
+        make_expander_container, CollectionAction, FieldAction, InspectorError, PropertyChanged,
     },
     inspector::{make_property_margin, PropertyFilter},
     message::{MessageDirection, UiMessage},
@@ -36,6 +35,7 @@ use crate::{
     BuildContext, Control, Thickness, UiNode, UserInterface,
 };
 
+use crate::inspector::InspectorEnvironmentContainer;
 use crate::message::{DeliveryMode, MessageData};
 use fyrox_graph::SceneGraph;
 use std::sync::Arc;
@@ -92,7 +92,7 @@ where
 {
     widget_builder: WidgetBuilder,
     collection: Option<I>,
-    environment: Option<Arc<dyn InspectorEnvironment>>,
+    environment: Option<InspectorEnvironmentContainer>,
     definition_container: Option<Arc<PropertyEditorDefinitionContainer>>,
     layer_index: usize,
     generate_property_string_values: bool,
@@ -111,7 +111,7 @@ fn create_item_views(items: &[Item]) -> Vec<Handle<UiNode>> {
 
 fn create_items<'a, 'b, T, I>(
     iter: I,
-    environment: Option<Arc<dyn InspectorEnvironment>>,
+    environment: Option<InspectorEnvironmentContainer>,
     definition_container: Arc<PropertyEditorDefinitionContainer>,
     property_info: &FieldRef<'a, 'b>,
     ctx: &mut BuildContext,
@@ -209,7 +209,7 @@ where
         self
     }
 
-    pub fn with_environment(mut self, environment: Option<Arc<dyn InspectorEnvironment>>) -> Self {
+    pub fn with_environment(mut self, environment: Option<InspectorEnvironmentContainer>) -> Self {
         self.environment = environment;
         self
     }
@@ -317,7 +317,7 @@ where
 
 impl<T, const N: usize> PropertyEditorDefinition for ArrayPropertyEditorDefinition<T, N>
 where
-    T: Reflect + Clone,
+    T: Reflect + Clone + PartialEq,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<[T; N]>()

--- a/fyrox-ui/src/inspector/editors/array.rs
+++ b/fyrox-ui/src/inspector/editors/array.rs
@@ -53,7 +53,7 @@ pub enum ArrayEditorMessage {
 }
 impl MessageData for ArrayEditorMessage {}
 
-#[derive(Clone, Debug, Visit, Reflect)]
+#[derive(Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "5c6e4785-8e2d-441f-8478-523900394b93"

--- a/fyrox-ui/src/inspector/editors/cell.rs
+++ b/fyrox-ui/src/inspector/editors/cell.rs
@@ -66,7 +66,7 @@ where
 
 impl<T> PropertyEditorDefinition for CellPropertyEditorDefinition<T>
 where
-    T: Reflect + Copy,
+    T: Reflect + Copy + PartialEq,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<Cell<T>>()

--- a/fyrox-ui/src/inspector/editors/collection.rs
+++ b/fyrox-ui/src/inspector/editors/collection.rs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use crate::inspector::InspectorEnvironmentContainer;
 use crate::{
     button::{Button, ButtonMessage},
     core::{
@@ -31,7 +32,7 @@ use crate::{
             PropertyEditorMessageContext, PropertyEditorTranslationContext,
         },
         make_expander_container, make_property_margin, CollectionAction, FieldAction,
-        InspectorEnvironment, InspectorError, ObjectValue, PropertyChanged, PropertyFilter,
+        InspectorError, ObjectValue, PropertyChanged, PropertyFilter,
     },
     message::{DeliveryMode, MessageData, MessageDirection, UiMessage},
     resources,
@@ -177,7 +178,7 @@ where
 {
     widget_builder: WidgetBuilder,
     collection: Option<I>,
-    environment: Option<Arc<dyn InspectorEnvironment>>,
+    environment: Option<InspectorEnvironmentContainer>,
     definition_container: Option<Arc<PropertyEditorDefinitionContainer>>,
     add: Handle<Button>,
     layer_index: usize,
@@ -209,7 +210,7 @@ fn create_item_views(items: &[Item], ctx: &mut BuildContext) -> Vec<Handle<UiNod
 
 fn create_items<'a, 'b, T, I>(
     iter: I,
-    environment: Option<Arc<dyn InspectorEnvironment>>,
+    environment: Option<InspectorEnvironmentContainer>,
     definition_container: Arc<PropertyEditorDefinitionContainer>,
     property_info: &FieldRef<'a, 'b>,
     ctx: &mut BuildContext,
@@ -321,7 +322,7 @@ where
         self
     }
 
-    pub fn with_environment(mut self, environment: Option<Arc<dyn InspectorEnvironment>>) -> Self {
+    pub fn with_environment(mut self, environment: Option<InspectorEnvironmentContainer>) -> Self {
         self.environment = environment;
         self
     }

--- a/fyrox-ui/src/inspector/editors/collection.rs
+++ b/fyrox-ui/src/inspector/editors/collection.rs
@@ -57,11 +57,11 @@ pub struct Item {
     remove: Handle<Button>,
 }
 
-pub trait CollectionItem: Clone + Reflect + Default + Send + 'static {}
+pub trait CollectionItem: Clone + PartialEq + Reflect + Default + Send + 'static {}
 
-impl<T> CollectionItem for T where T: Clone + Reflect + Default + Send + 'static {}
+impl<T> CollectionItem for T where T: Clone + PartialEq + Reflect + Default + Send + 'static {}
 
-#[derive(Debug, Visit, Reflect)]
+#[derive(Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "316b0319-f8ee-4b63-9ed9-3f59a857e2bc"

--- a/fyrox-ui/src/inspector/editors/enumeration.rs
+++ b/fyrox-ui/src/inspector/editors/enumeration.rs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use crate::inspector::InspectorEnvironmentContainer;
 use crate::{
     core::{pool::Handle, reflect::prelude::*, visitor::prelude::*},
     dropdown_list::{DropdownList, DropdownListBuilder, DropdownListMessage},
@@ -28,8 +29,7 @@ use crate::{
             PropertyEditorMessageContext, PropertyEditorTranslationContext,
         },
         make_expander_container, FieldAction, Inspector, InspectorBuilder, InspectorContext,
-        InspectorContextArgs, InspectorEnvironment, InspectorError, InspectorMessage,
-        PropertyChanged, PropertyFilter,
+        InspectorContextArgs, InspectorError, InspectorMessage, PropertyChanged, PropertyFilter,
     },
     message::{MessageData, UiMessage},
     utils::make_dropdown_list_option,
@@ -76,7 +76,7 @@ pub struct EnumPropertyEditor<T: InspectableEnum> {
     pub definition_container: Arc<PropertyEditorDefinitionContainer>,
     #[visit(skip)]
     #[reflect(hidden)]
-    pub environment: Option<Arc<dyn InspectorEnvironment>>,
+    pub environment: Option<InspectorEnvironmentContainer>,
     #[visit(skip)]
     #[reflect(hidden)]
     pub layer_index: usize,
@@ -183,7 +183,7 @@ impl<T: InspectableEnum> Control for EnumPropertyEditor<T> {
 pub struct EnumPropertyEditorBuilder {
     widget_builder: WidgetBuilder,
     definition_container: Option<Arc<PropertyEditorDefinitionContainer>>,
-    environment: Option<Arc<dyn InspectorEnvironment>>,
+    environment: Option<InspectorEnvironmentContainer>,
     variant_selector: Handle<UiNode>,
     layer_index: usize,
     generate_property_string_values: bool,
@@ -211,7 +211,7 @@ impl EnumPropertyEditorBuilder {
         self
     }
 
-    pub fn with_environment(mut self, environment: Option<Arc<dyn InspectorEnvironment>>) -> Self {
+    pub fn with_environment(mut self, environment: Option<InspectorEnvironmentContainer>) -> Self {
         self.environment = environment;
         self
     }
@@ -293,6 +293,7 @@ impl EnumPropertyEditorBuilder {
     }
 }
 
+#[derive(PartialEq)]
 pub struct EnumPropertyEditorDefinition<T: InspectableEnum> {
     pub variant_generator: fn(usize) -> T,
     pub index_generator: fn(&T) -> usize,

--- a/fyrox-ui/src/inspector/editors/enumeration.rs
+++ b/fyrox-ui/src/inspector/editors/enumeration.rs
@@ -294,6 +294,7 @@ impl EnumPropertyEditorBuilder {
 }
 
 #[derive(PartialEq)]
+#[allow(unpredictable_function_pointer_comparisons)]
 pub struct EnumPropertyEditorDefinition<T: InspectableEnum> {
     pub variant_generator: fn(usize) -> T,
     pub index_generator: fn(&T) -> usize,

--- a/fyrox-ui/src/inspector/editors/enumeration.rs
+++ b/fyrox-ui/src/inspector/editors/enumeration.rs
@@ -48,9 +48,9 @@ use strum::VariantNames;
 
 const LOCAL_SYNC_FLAG: u64 = 0xFF;
 
-pub trait InspectableEnum: Debug + Reflect + Clone + Send + 'static {}
+pub trait InspectableEnum: Debug + Reflect + PartialEq + Clone + Send + 'static {}
 
-impl<T: Debug + Reflect + Clone + Send + 'static> InspectableEnum for T {}
+impl<T: Debug + Reflect + PartialEq + Clone + Send + 'static> InspectableEnum for T {}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum EnumPropertyEditorMessage {
@@ -59,7 +59,7 @@ pub enum EnumPropertyEditorMessage {
 }
 impl MessageData for EnumPropertyEditorMessage {}
 
-#[derive(Visit, Reflect)]
+#[derive(Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "0dbefddc-70fa-45a9-96f0-8fe25f6c1669"

--- a/fyrox-ui/src/inspector/editors/inherit.rs
+++ b/fyrox-ui/src/inspector/editors/inherit.rs
@@ -60,7 +60,7 @@ pub enum InheritablePropertyEditorMessage {
 }
 impl MessageData for InheritablePropertyEditorMessage {}
 
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "d5dce72c-a54b-4754-96a3-2e923eaa802f")]
 #[reflect(derived_type = "UiNode")]
 pub struct InheritablePropertyEditor {

--- a/fyrox-ui/src/inspector/editors/mod.rs
+++ b/fyrox-ui/src/inspector/editors/mod.rs
@@ -21,6 +21,7 @@
 //! A collection of [PropertyEditorDefinition] objects for a wide variety of types,
 //! including standard Rust types and Fyrox core types.
 
+use crate::inspector::InspectorEnvironmentContainer;
 use crate::style::{StyleProperty, StylePropertyContainer};
 use crate::{
     absm::{EventAction, EventKind},
@@ -80,7 +81,7 @@ use crate::{
                 Vec4PropertyEditorDefinition,
             },
         },
-        InspectorEnvironment, InspectorError, PropertyChanged, PropertyFilter,
+        InspectorError, PropertyChanged, PropertyFilter,
     },
     key::{HotKeyEditor, KeyBinding, KeyBindingEditor},
     list_view::{ListView, ListViewItem},
@@ -166,7 +167,7 @@ pub struct PropertyEditorBuildContext<'a, 'b, 'c, 'd> {
     /// [fyroxed_base::inspector::EditorEnvironment](https://docs.rs/fyroxed_base/latest/fyroxed_base/inspector/struct.EditorEnvironment.html)
     /// when the Inspector is being used in Fyroxed, but Inspector widgets can be used in other applications,
     /// and we can access those applications by casting the environment to the appropriate type.
-    pub environment: Option<Arc<dyn InspectorEnvironment>>,
+    pub environment: Option<InspectorEnvironmentContainer>,
     /// The list of the Inspectors property editors.
     /// This allows one property editor to make use of other property editors.
     pub definition_container: Arc<PropertyEditorDefinitionContainer>,
@@ -215,7 +216,7 @@ pub struct PropertyEditorMessageContext<'a, 'b, 'c> {
     /// this property is being translated. This allows the created message to
     /// adapt to the situation if we can successfully cast the given
     /// [InspectorEnvironment] into a specific type.
-    pub environment: Option<Arc<dyn InspectorEnvironment>>,
+    pub environment: Option<InspectorEnvironmentContainer>,
     /// When true, this indicates that an Inspector should generate strings from `format!("{:?}", field)`, for each field.
     /// Having this in the property editor build context indicates how any Inspectors that are update due to the created message
     /// should behave.
@@ -251,7 +252,7 @@ pub struct PropertyEditorTranslationContext<'b, 'c> {
     /// [fyrox::script::Script](https://docs.rs/fyrox/latest/fyrox/script/struct.Script.html)
     /// when it receives a
     /// [ScriptPropertyEditorMessage::Value](https://docs.rs/fyroxed_base/latest/fyroxed_base/inspector/editors/script/enum.ScriptPropertyEditorMessage.html#variant.Value).
-    pub environment: Option<Arc<dyn InspectorEnvironment>>,
+    pub environment: Option<InspectorEnvironmentContainer>,
     /// The name of the property being edited.
     /// This comes from [ContextEntry::property_name](crate::inspector::ContextEntry).
     pub name: &'b str,
@@ -370,6 +371,18 @@ pub struct PropertyEditorDefinitionContainer {
     /// that plugin.
     pub context_type_id: Mutex<TypeId>,
     definitions: RwLock<FxHashMap<TypeId, PropertyEditorDefinitionContainerEntry>>,
+}
+
+impl PartialEq for PropertyEditorDefinitionContainer {
+    fn eq(&self, other: &Self) -> bool {
+        *self.context_type_id.safe_lock() == *other.context_type_id.safe_lock()
+            && self
+                .definitions
+                .read()
+                .keys()
+                .zip(other.definitions.read().keys())
+                .all(|(a, b)| *a == *b)
+    }
 }
 
 impl Debug for PropertyEditorDefinitionContainer {

--- a/fyrox-ui/src/inspector/editors/refcell.rs
+++ b/fyrox-ui/src/inspector/editors/refcell.rs
@@ -69,7 +69,7 @@ where
 
 impl<T> PropertyEditorDefinition for RefCellPropertyEditorDefinition<T>
 where
-    T: Reflect + Clone,
+    T: Reflect + Clone + PartialEq,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<RefCell<T>>()

--- a/fyrox-ui/src/inspector/editors/style.rs
+++ b/fyrox-ui/src/inspector/editors/style.rs
@@ -77,7 +77,7 @@ pub enum StyledPropertyEditorMessage {
 }
 impl MessageData for StyledPropertyEditorMessage {}
 
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "3a863a0f-7414-44f5-a7aa-7a6668a6d406")]
 #[reflect(derived_type = "UiNode")]
 pub struct StyledPropertySelector {
@@ -308,7 +308,7 @@ impl StyledPropertySelectorBuilder {
     }
 }
 
-#[derive(Debug, Clone, Visit, Reflect)]
+#[derive(Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(type_uuid = "1b8fb74a-3911-4b44-bb71-1a0382ebb9a7")]
 #[reflect(derived_type = "UiNode")]
 pub struct StyledPropertyEditor {

--- a/fyrox-ui/src/inspector/editors/style.rs
+++ b/fyrox-ui/src/inspector/editors/style.rs
@@ -502,7 +502,7 @@ where
 
 impl<T> PropertyEditorDefinition for StyledPropertyEditorDefinition<T>
 where
-    T: Reflect + Clone,
+    T: Reflect + Clone + PartialEq,
 {
     fn value_type_id(&self) -> TypeId {
         TypeId::of::<StyledProperty<T>>()

--- a/fyrox-ui/src/inspector/editors/texture_slice.rs
+++ b/fyrox-ui/src/inspector/editors/texture_slice.rs
@@ -84,7 +84,7 @@ struct DragContext {
     texture_region: Rect<u32>,
 }
 
-#[derive(Clone, Reflect, Visit, Debug)]
+#[derive(Clone, PartialEq, Reflect, Visit, Debug)]
 #[reflect(type_uuid = "bd89b59f-13be-4804-bd9c-ed40cfd48b92")]
 #[reflect(derived_type = "UiNode")]
 pub struct TextureSliceEditor {
@@ -470,7 +470,7 @@ impl TextureSliceEditorBuilder {
     }
 }
 
-#[derive(Clone, Reflect, Visit, Debug)]
+#[derive(Clone, PartialEq, Reflect, Visit, Debug)]
 #[reflect(type_uuid = "0293081d-55fd-4aa2-a06e-d53fba1a2617")]
 #[reflect(derived_type = "UiNode")]
 pub struct TextureSliceEditorWindow {
@@ -694,7 +694,7 @@ impl TextureSliceEditorWindowBuilder {
     }
 }
 
-#[derive(Clone, Reflect, Visit, Debug)]
+#[derive(Clone, PartialEq, Reflect, Visit, Debug)]
 #[reflect(type_uuid = "024f3a3a-6784-4675-bd99-a4c6c19a8d91")]
 #[reflect(derived_type = "UiNode")]
 pub struct TextureSliceFieldEditor {

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -511,7 +511,7 @@ pub trait InspectorEnvironment: Send + Sync + Reflect {
 ///         .build(ctx)
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "c599c0f5-f749-4033-afed-1a9949c937a1"

--- a/fyrox-ui/src/inspector/mod.rs
+++ b/fyrox-ui/src/inspector/mod.rs
@@ -54,6 +54,7 @@ use fyrox_graph::{
     constructor::{ConstructorProvider, GraphNodeConstructor},
     SceneGraph,
 };
+use std::ops::Deref;
 use std::{
     any::{Any, TypeId},
     fmt::{Debug, Display, Formatter},
@@ -430,6 +431,23 @@ impl MessageData for InspectorMessage {}
 /// it can attempt to cast InspectorEnvironment to whatever type it might be.
 pub trait InspectorEnvironment: Send + Sync + Reflect {
     fn name(&self) -> String;
+}
+
+#[derive(Clone)]
+pub struct InspectorEnvironmentContainer(pub Arc<dyn InspectorEnvironment>);
+
+impl PartialEq for InspectorEnvironmentContainer {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.try_compare(&*other.0).unwrap_or_default()
+    }
+}
+
+impl Deref for InspectorEnvironmentContainer {
+    type Target = dyn InspectorEnvironment;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
 }
 
 /// Inspector is a widget, that allows you to generate visual representation for internal fields an arbitrary
@@ -813,7 +831,7 @@ pub struct InspectorContext {
     pub property_definitions: Arc<PropertyEditorDefinitionContainer>,
     /// Untyped information from the application that is using the inspector. This can be used by editors that may be
     /// supplied by that application, if those editors know the actual type of this value to be able to successfully cast it.
-    pub environment: Option<Arc<dyn InspectorEnvironment>>,
+    pub environment: Option<InspectorEnvironmentContainer>,
     /// Type id of the object for which the context was created.
     pub object_type_id: TypeId,
     /// A width of the property name column.
@@ -1009,6 +1027,16 @@ fn make_simple_property_container(
 #[derive(Default, Clone)]
 pub struct PropertyFilter(pub Option<Arc<dyn Fn(&dyn Reflect) -> bool + Send + Sync>>);
 
+impl PartialEq for PropertyFilter {
+    fn eq(&self, other: &Self) -> bool {
+        if let (Some(a), Some(b)) = (self.0.as_ref(), other.0.as_ref()) {
+            Arc::ptr_eq(a, b)
+        } else {
+            false
+        }
+    }
+}
+
 impl PropertyFilter {
     pub fn new<T>(func: T) -> Self
     where
@@ -1046,7 +1074,7 @@ pub struct InspectorContextArgs<'a, 'b, 'c> {
     pub object: &'a dyn Reflect,
     pub ctx: &'b mut BuildContext<'c>,
     pub definition_container: Arc<PropertyEditorDefinitionContainer>,
-    pub environment: Option<Arc<dyn InspectorEnvironment>>,
+    pub environment: Option<InspectorEnvironmentContainer>,
     pub layer_index: usize,
     pub generate_property_string_values: bool,
     pub filter: PropertyFilter,

--- a/fyrox-ui/src/key.rs
+++ b/fyrox-ui/src/key.rs
@@ -187,7 +187,7 @@ impl MessageData for HotKeyEditorMessage {}
 /// ## Messages
 ///
 /// Use [`HotKeyEditorMessage`] message to alternate the state of a hot key widget, or to listen to its changes.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "7bc49843-1302-4e36-b901-63af5cea6c60"
@@ -398,7 +398,7 @@ impl MessageData for KeyBindingEditorMessage {}
 /// ## Messages
 ///
 /// Use [`KeyBindingEditorMessage`] message to alternate the state of a key binding widget, or to listen to its changes.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "150113ce-f95e-4c76-9ac9-4503e78b960f"

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -693,7 +693,7 @@ pub enum RenderMode {
     OnChanges,
 }
 
-#[derive(Reflect)]
+#[derive(Reflect, PartialEq)]
 #[reflect(type_uuid = "0d065c93-ef9c-4dd2-9fe7-e2b33c1a21b6")]
 pub struct UserInterface {
     screen_size: Vector2<f32>,

--- a/fyrox-ui/src/lib.rs
+++ b/fyrox-ui/src/lib.rs
@@ -372,6 +372,12 @@ pub(crate) struct RcUiNodeHandleInner {
     sender: Option<Sender<UiMessage>>,
 }
 
+impl PartialEq for RcUiNodeHandleInner {
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle
+    }
+}
+
 impl Visit for RcUiNodeHandleInner {
     fn visit(&mut self, name: &str, visitor: &mut Visitor) -> VisitResult {
         self.handle.visit(name, visitor)?;
@@ -529,7 +535,7 @@ impl NodeStatistics {
     }
 }
 
-#[derive(Visit, Reflect, Debug, Clone)]
+#[derive(Visit, Reflect, PartialEq, Debug, Clone)]
 #[reflect(type_uuid = "9f9d5633-1568-4611-8709-3eeb615b7c0f")]
 pub struct DragContext {
     pub is_dragging: bool,
@@ -568,7 +574,7 @@ impl Default for MouseState {
     }
 }
 
-#[derive(Copy, Clone, Visit, Reflect, Debug, Default)]
+#[derive(Copy, Clone, Visit, PartialEq, Reflect, Debug, Default)]
 #[reflect(type_uuid = "2f1add9c-5019-4922-9045-0bd5ca2fd63a")]
 pub struct RestrictionEntry {
     /// Handle to UI node to which picking must be restricted to.
@@ -584,7 +590,7 @@ pub struct RestrictionEntry {
     pub stop: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct TooltipEntry {
     pub tooltip: RcUiNodeHandle,
     pub appear_timer: f32,
@@ -620,7 +626,7 @@ pub enum LayoutEvent {
     TransformChanged(Handle<UiNode>),
 }
 
-#[derive(Clone, Debug, Visit, Reflect, Default)]
+#[derive(Clone, Debug, Visit, Reflect, PartialEq, Default)]
 #[reflect(type_uuid = "30bc5bc5-6592-48d8-8647-9bdbbb977ffb")]
 struct DoubleClickEntry {
     timer: f32,
@@ -629,13 +635,19 @@ struct DoubleClickEntry {
 
 struct Clipboard(Option<RefCell<ClipboardContext>>);
 
+impl PartialEq for Clipboard {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
 impl Debug for Clipboard {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "Clipboard")
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, PartialEq, Debug, Clone)]
 struct WidgetMethodsRegistry {
     preview_message: FxHashSet<Handle<UiNode>>,
     on_update: FxHashSet<Handle<UiNode>>,
@@ -681,7 +693,7 @@ pub struct UiUpdateSwitches {
 
 pub type WidgetPool = Pool<UiNode, WidgetContainer>;
 
-#[derive(Default, Debug, Clone, Reflect, Visit)]
+#[derive(Default, Debug, Clone, PartialEq, Reflect, Visit)]
 #[reflect(type_uuid = "b426e937-4050-4539-8041-ade4222539c8")]
 pub enum RenderMode {
     /// The UI will be re-rendered on every frame. This is the default behavior.
@@ -691,6 +703,29 @@ pub enum RenderMode {
     /// sent to it. This option can be useful for offscreen rending of a user interface that changes
     /// infrequently.
     OnChanges,
+}
+
+#[derive(Debug)]
+pub struct UiMessageChannel {
+    pub receiver: Receiver<UiMessage>,
+    pub sender: Sender<UiMessage>,
+}
+
+impl UiMessageChannel {
+    pub fn new() -> Self {
+        let (sender, receiver) = mpsc::channel();
+        Self { receiver, sender }
+    }
+
+    pub fn send(&self, message: UiMessage) {
+        let _ = self.sender.send(message);
+    }
+}
+
+impl PartialEq for UiMessageChannel {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
 }
 
 #[derive(Reflect, PartialEq)]
@@ -709,9 +744,7 @@ pub struct UserInterface {
     cursor_position: Vector2<f32>,
     pub style: StyleResource,
     #[reflect(hidden)]
-    receiver: Receiver<UiMessage>,
-    #[reflect(hidden)]
-    sender: Sender<UiMessage>,
+    ui_message_channel: UiMessageChannel,
     stack: Vec<Handle<UiNode>>,
     picking_stack: Vec<RestrictionEntry>,
     #[reflect(hidden)]
@@ -727,9 +760,9 @@ pub struct UserInterface {
     #[reflect(hidden)]
     clipboard: Clipboard,
     #[reflect(hidden)]
-    layout_events_receiver: Receiver<LayoutEvent>,
+    layout_events_receiver: LayoutEventsReceiver,
     #[reflect(hidden)]
-    layout_events_sender: Sender<LayoutEvent>,
+    layout_events_sender: LayoutEventsSender,
     #[reflect(hidden)]
     z_index_update_set: FxHashSet<Handle<UiNode>>,
     #[reflect(hidden)]
@@ -767,8 +800,7 @@ impl Debug for UserInterface {
             .field("keyboard_focus_node", &self.keyboard_focus_node)
             .field("cursor_position", &self.cursor_position)
             .field("style", &self.style)
-            .field("receiver", &self.receiver)
-            .field("sender", &self.sender)
+            .field("ui_message_channel", &self.ui_message_channel)
             .field("stack", &self.stack)
             .field("picking_stack", &self.picking_stack)
             .field("bubble_queue", &self.bubble_queue)
@@ -842,10 +874,46 @@ impl Visit for UserInterface {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct LayoutEventsSender(pub Sender<LayoutEvent>);
+
+impl PartialEq for LayoutEventsSender {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Deref for LayoutEventsSender {
+    type Target = Sender<LayoutEvent>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct LayoutEventsReceiver(pub Receiver<LayoutEvent>);
+
+impl PartialEq for LayoutEventsReceiver {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Deref for LayoutEventsReceiver {
+    type Target = Receiver<LayoutEvent>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl Clone for UserInterface {
     fn clone(&self) -> Self {
-        let (sender, receiver) = mpsc::channel();
+        let ui_message_channel = UiMessageChannel::new();
         let (layout_events_sender, layout_events_receiver) = mpsc::channel();
+        let layout_events_sender = LayoutEventsSender(layout_events_sender);
+        let layout_events_receiver = LayoutEventsReceiver(layout_events_receiver);
         let mut nodes = Pool::new();
         for (handle, node) in self.nodes.pair_iter() {
             let mut clone = node.clone_boxed();
@@ -865,8 +933,7 @@ impl Clone for UserInterface {
             keyboard_focus_node: self.keyboard_focus_node,
             cursor_position: self.cursor_position,
             style: DEFAULT_STYLE.resource.clone(),
-            receiver,
-            sender,
+            ui_message_channel,
             stack: self.stack.clone(),
             picking_stack: self.picking_stack.clone(),
             bubble_queue: self.bubble_queue.clone(),
@@ -1160,21 +1227,19 @@ pub struct PollResult {
 
 impl UserInterface {
     pub fn new(screen_size: Vector2<f32>) -> UserInterface {
-        let (sender, receiver) = mpsc::channel();
-        Self::new_with_channel(sender, receiver, screen_size)
+        let ui_message_channel = UiMessageChannel::new();
+        Self::new_with_channel(ui_message_channel, screen_size)
     }
 
     pub fn new_with_channel(
-        sender: Sender<UiMessage>,
-        receiver: Receiver<UiMessage>,
+        ui_message_channel: UiMessageChannel,
         screen_size: Vector2<f32>,
     ) -> UserInterface {
         let (layout_events_sender, layout_events_receiver) = mpsc::channel();
         let style = DEFAULT_STYLE.resource.clone();
         let mut ui = UserInterface {
             screen_size,
-            sender,
-            receiver,
+            ui_message_channel,
             visual_debug: false,
             captured_node: Handle::NONE,
             root_canvas: Handle::NONE,
@@ -1195,8 +1260,8 @@ impl UserInterface {
             active_tooltip: Default::default(),
             methods_registry: Default::default(),
             clipboard: Clipboard(ClipboardContext::new().ok().map(RefCell::new)),
-            layout_events_receiver,
-            layout_events_sender,
+            layout_events_receiver: LayoutEventsReceiver(layout_events_receiver),
+            layout_events_sender: LayoutEventsSender(layout_events_sender),
             z_index_update_set: Default::default(),
             default_font: BUILT_IN_FONT.resource(),
             double_click_entries: Default::default(),
@@ -2025,11 +2090,11 @@ impl UserInterface {
     /// Returns instance of message sender which can be used to push messages into queue
     /// from other threads.
     pub fn sender(&self) -> Sender<UiMessage> {
-        self.sender.clone()
+        self.ui_message_channel.sender.clone()
     }
 
     pub fn send_message(&self, message: UiMessage) {
-        self.sender.send(message).unwrap()
+        self.ui_message_channel.send(message)
     }
 
     pub fn try_send_response(&self, message: &UiMessage) -> bool {
@@ -2048,13 +2113,11 @@ impl UserInterface {
     }
 
     pub fn send(&self, handle: Handle<impl ObjectOrVariant<UiNode>>, data: impl MessageData) {
-        self.sender
-            .send(
-                UiMessage::with_data(data)
-                    .with_destination(handle.transmute())
-                    .with_direction(MessageDirection::ToWidget),
-            )
-            .unwrap()
+        self.ui_message_channel.send(
+            UiMessage::with_data(data)
+                .with_destination(handle.transmute())
+                .with_direction(MessageDirection::ToWidget),
+        )
     }
 
     pub fn send_handled(
@@ -2062,25 +2125,21 @@ impl UserInterface {
         handle: Handle<impl ObjectOrVariant<UiNode>>,
         data: impl MessageData,
     ) {
-        self.sender
-            .send(
-                UiMessage::with_data(data)
-                    .with_destination(handle.transmute())
-                    .with_direction(MessageDirection::ToWidget)
-                    .with_handled(true),
-            )
-            .unwrap()
+        self.ui_message_channel.send(
+            UiMessage::with_data(data)
+                .with_destination(handle.transmute())
+                .with_direction(MessageDirection::ToWidget)
+                .with_handled(true),
+        )
     }
 
     pub fn send_sync(&self, handle: Handle<impl ObjectOrVariant<UiNode>>, data: impl MessageData) {
-        self.sender
-            .send(
-                UiMessage::with_data(data)
-                    .with_destination(handle.transmute())
-                    .with_direction(MessageDirection::ToWidget)
-                    .with_delivery_mode(DeliveryMode::SyncOnly),
-            )
-            .unwrap()
+        self.ui_message_channel.send(
+            UiMessage::with_data(data)
+                .with_destination(handle.transmute())
+                .with_direction(MessageDirection::ToWidget)
+                .with_delivery_mode(DeliveryMode::SyncOnly),
+        )
     }
 
     pub fn send_with_flags<T: MessageData>(
@@ -2089,14 +2148,12 @@ impl UserInterface {
         flags: u64,
         data: T,
     ) {
-        self.sender
-            .send(
-                UiMessage::with_data(data)
-                    .with_destination(handle.transmute())
-                    .with_direction(MessageDirection::ToWidget)
-                    .with_flags(flags),
-            )
-            .unwrap()
+        self.ui_message_channel.send(
+            UiMessage::with_data(data)
+                .with_destination(handle.transmute())
+                .with_direction(MessageDirection::ToWidget)
+                .with_flags(flags),
+        )
     }
 
     pub fn send_many<const N: usize, T: MessageData>(
@@ -2120,13 +2177,11 @@ impl UserInterface {
     }
 
     pub fn post<T: MessageData>(&self, handle: Handle<impl ObjectOrVariant<UiNode>>, data: T) {
-        self.sender
-            .send(
-                UiMessage::with_data(data)
-                    .with_destination(handle.transmute())
-                    .with_direction(MessageDirection::FromWidget),
-            )
-            .unwrap()
+        self.ui_message_channel.send(
+            UiMessage::with_data(data)
+                .with_destination(handle.transmute())
+                .with_direction(MessageDirection::FromWidget),
+        )
     }
 
     pub fn post_many<const N: usize, T: MessageData>(
@@ -2248,7 +2303,7 @@ impl UserInterface {
             message: None,
         };
 
-        while let Ok(message) = self.receiver.try_recv() {
+        while let Ok(message) = self.ui_message_channel.receiver.try_recv() {
             poll_result.processed_messages += 1;
             if let Some(message) = self.poll_single_message(message) {
                 poll_result.message = Some(message);
@@ -2584,7 +2639,7 @@ impl UserInterface {
     /// Find any tooltips that are being hovered and activate them.
     /// As well, update their time.
     fn update_tooltips(&mut self, dt: f32) {
-        let sender = self.sender.clone();
+        let sender = self.ui_message_channel.sender.clone();
         if let Some(entry) = self.active_tooltip.as_mut() {
             if entry.shown {
                 entry.disappear_timer -= dt;
@@ -3488,13 +3543,15 @@ impl UserInterface {
         let (mut ui, data) = {
             let data = io.load_file(path.as_ref()).await?;
             let mut visitor = Visitor::load_from_memory(&data)?;
-            let (sender, receiver) = mpsc::channel();
+            let ui_message_channel = UiMessageChannel::new();
             visitor.blackboard.register(constructors);
-            visitor.blackboard.register(Arc::new(sender.clone()));
+            visitor
+                .blackboard
+                .register(Arc::new(ui_message_channel.sender.clone()));
             visitor.blackboard.register(Arc::new(resource_manager));
             visitor.blackboard.register(dyn_type_constructors);
             let mut ui =
-                UserInterface::new_with_channel(sender, receiver, Vector2::new(100.0, 100.0));
+                UserInterface::new_with_channel(ui_message_channel, Vector2::new(100.0, 100.0));
             ui.visit("Ui", &mut visitor)?;
             (ui, data)
         };
@@ -3637,7 +3694,7 @@ impl SceneGraph for UserInterface {
         let node = node.to_base();
         self.isolate_node(node);
 
-        let sender = self.sender.clone();
+        let sender = self.ui_message_channel.sender.clone();
         let mut stack = vec![node];
         while let Some(handle) = stack.pop() {
             if self.prev_picked_node == handle {

--- a/fyrox-ui/src/list_view.rs
+++ b/fyrox-ui/src/list_view.rs
@@ -233,7 +233,7 @@ impl ListViewMessage {
 ///     ui.send(my_list_view, ListViewMessage::BringItemIntoView(my_item));
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[visit(optional)]
 #[reflect(
     derived_type = "UiNode",
@@ -325,7 +325,7 @@ impl ListView {
 }
 
 /// A wrapper for list view items, that is used to add selection functionality to arbitrary items.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "02f21415-5843-42f5-a3e4-b4a21e7739ad"

--- a/fyrox-ui/src/matrix.rs
+++ b/fyrox-ui/src/matrix.rs
@@ -73,7 +73,7 @@ where
 }
 impl<const R: usize, const C: usize, T: NumericType> MessageData for MatrixEditorMessage<R, C, T> {}
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "9f05427a-5862-4574-bb21-ebaf52aa8c72"

--- a/fyrox-ui/src/menu.rs
+++ b/fyrox-ui/src/menu.rs
@@ -197,7 +197,7 @@ impl MessageData for MenuItemMessage {}
 ///         .build(ctx)
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "582a04f3-a7fd-4e70-bbd1-eb95e2275b75"
@@ -344,7 +344,7 @@ enum NavigationDirection {
     Vertical,
 }
 
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[doc(hidden)]
 #[reflect(type_uuid = "667bb0c3-9f55-4850-bb19-b9fdf3f8d27b")]
 pub struct ItemsContainer {
@@ -411,7 +411,7 @@ impl ItemsContainer {
 
 /// Menu item is a widget with arbitrary content, that has a "floating" panel (popup) for sub-items if the menu item. This was menu items can form
 /// arbitrary hierarchies. See [`Menu`] docs for examples.
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "72e002c6-6060-4583-b5b7-0c5500244fef"
@@ -1140,7 +1140,7 @@ impl MenuItemBuilder {
 
 /// A simple wrapper over [`Popup`] widget, that holds the sub-items of a menu item and provides
 /// an ability for keyboard navigation.
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "ad8e9e76-c213-4232-9bab-80ebcabd69fa"

--- a/fyrox-ui/src/messagebox.rs
+++ b/fyrox-ui/src/messagebox.rs
@@ -163,7 +163,7 @@ pub enum MessageBoxButtons {
 ///
 /// There's no way to change the style of the message box, nor add some widgets to it. If you need a custom message box, then you
 /// need to create your own widget. This message box is meant to be used as a standard dialog box for standard situations in the UI.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "b14c0012-4383-45cf-b9a1-231415d95373"

--- a/fyrox-ui/src/navigation.rs
+++ b/fyrox-ui/src/navigation.rs
@@ -74,7 +74,7 @@ use fyrox_graph::SceneGraph;
 ///
 /// This example shows how to create a simple confirmation dialog, that allows a user to use Tab key
 /// to cycle from one button to another. A focused button then can be "clicked" using Enter key.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "135d347b-5019-4743-906c-6df5c295a3be")]
 #[reflect(derived_type = "UiNode")]
 pub struct NavigationLayer {

--- a/fyrox-ui/src/nine_patch.rs
+++ b/fyrox-ui/src/nine_patch.rs
@@ -157,7 +157,7 @@ impl TextureSlice {
 ///         .build(&mut ui.build_ctx())
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(type_uuid = "c345033e-8c10-4186-b101-43f73b85981d")]
 #[reflect(derived_type = "UiNode")]
 pub struct NinePatch {

--- a/fyrox-ui/src/node/container.rs
+++ b/fyrox-ui/src/node/container.rs
@@ -35,7 +35,7 @@ use fyrox_core::visitor::error::VisitError;
 
 /// A wrapper for widget pool record that allows to define custom visit method to have full
 /// control over instantiation process at deserialization.
-#[derive(Debug, Clone, Default, Reflect)]
+#[derive(Debug, Clone, Default, PartialEq, Reflect)]
 #[reflect(type_uuid = "8d572e59-9594-435d-844f-c78cd7696744")]
 pub struct WidgetContainer(Option<UiNode>);
 

--- a/fyrox-ui/src/node/mod.rs
+++ b/fyrox-ui/src/node/mod.rs
@@ -47,6 +47,12 @@ pub mod container;
 #[reflect(type_uuid = "d9b45ecc-91b0-40ea-a92a-4a7dee4667c9")]
 pub struct UiNode(#[reflect(deref, display_name = "UiNode")] pub Box<dyn Control>);
 
+impl PartialEq for UiNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.try_compare(other.0.deref()).unwrap_or_default()
+    }
+}
+
 impl<T: Control> From<T> for UiNode {
     fn from(value: T) -> Self {
         Self(Box::new(value))

--- a/fyrox-ui/src/numeric.rs
+++ b/fyrox-ui/src/numeric.rs
@@ -65,6 +65,7 @@ pub trait NumericType:
     + Copy
     + NumOps
     + PartialOrd
+    + PartialEq
     + Display
     + Bounded
     + Debug
@@ -85,6 +86,7 @@ impl<T> NumericType for T where
         + Copy
         + NumOps
         + PartialOrd
+        + PartialEq
         + Bounded
         + Display
         + Debug
@@ -121,7 +123,7 @@ pub enum NumericUpDownMessage<T: NumericType> {
 impl<T: NumericType> MessageData for NumericUpDownMessage<T> {}
 
 /// Used to store drag info when dragging the cursor on the up/down buttons.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum DragContext<T: NumericType> {
     /// Dragging is just started.
     PreDrag {
@@ -233,7 +235,7 @@ pub enum DragContext<T: NumericType> {
 ///         .build(ctx)
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "f852eda4-18e5-4480-83ae-a607ce1c26f7"

--- a/fyrox-ui/src/path.rs
+++ b/fyrox-ui/src/path.rs
@@ -71,7 +71,7 @@ impl MessageData for PathEditorMessage {}
 ///
 /// To receive the changes, listen to [`PathEditorMessage::Path`] and check for its direction, it should be [`crate::message::MessageDirection::FromWidget`].
 /// To set a new path value, send [`PathEditorMessage::Path`] message, but with [`crate::message::MessageDirection::ToWidget`].
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "51cfe7ec-ec31-4354-9578-047004b213a1"

--- a/fyrox-ui/src/popup.rs
+++ b/fyrox-ui/src/popup.rs
@@ -287,7 +287,7 @@ impl Placement {
 ///
 /// Popup widget can automatically adjust its position to always remain on screen, which is useful for tooltips, dropdown lists,
 /// etc. To enable this option, use [`PopupBuilder::with_smart_placement`] with `true` as the first argument.
-#[derive(Default, Clone, Visit, Debug, Reflect)]
+#[derive(Default, Clone, Visit, Debug, PartialEq, Reflect)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "5c4bf90d-cfe7-464f-bcf8-71deacb14dd8")]
 pub struct Popup {

--- a/fyrox-ui/src/progress_bar.rs
+++ b/fyrox-ui/src/progress_bar.rs
@@ -87,7 +87,7 @@ impl MessageData for ProgressBarMessage {}
 ///     ui.send(progress_bar, ProgressBarMessage::Progress(0.33));
 /// }
 /// ```
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "d6ebb853-d945-46bc-86db-4c8b5d5faf8e"

--- a/fyrox-ui/src/range.rs
+++ b/fyrox-ui/src/range.rs
@@ -106,7 +106,7 @@ impl<T: NumericType> MessageData for RangeEditorMessage<T> {}
 ///
 /// Be very careful about the type of the range when sending a message, you need to send a range of exact type, that match the type
 /// of your editor, otherwise the message have no effect. The same applied to fetching.
-#[derive(Default, Debug, Clone, Reflect, Visit)]
+#[derive(Default, Debug, Clone, PartialEq, Reflect, Visit)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "0eb2948e-8485-490e-8719-18a0bb6fe275"

--- a/fyrox-ui/src/rect.rs
+++ b/fyrox-ui/src/rect.rs
@@ -115,7 +115,7 @@ impl<T: NumericType> MessageData for RectEditorMessage<T> {}
 ///     }
 /// }
 /// ```
-#[derive(Default, Debug, Clone, Visit, Reflect)]
+#[derive(Default, Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "5a3daf9d-f33b-494b-b111-eb55721dc7ac"

--- a/fyrox-ui/src/screen.rs
+++ b/fyrox-ui/src/screen.rs
@@ -105,7 +105,7 @@ use std::cell::Cell;
 ///     .build(ctx)
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "3bc7649f-a1ba-49be-bc4e-e0624654e40c"

--- a/fyrox-ui/src/scroll_bar.rs
+++ b/fyrox-ui/src/scroll_bar.rs
@@ -129,7 +129,7 @@ impl MessageData for ScrollBarMessage {}
 ///
 /// Scroll bar provides arrows to change the current value using a fixed step value. You can change it using
 /// [`ScrollBarBuilder::with_step`] method.
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "92accc96-b334-424d-97ea-332c4787acf6"

--- a/fyrox-ui/src/scroll_panel.rs
+++ b/fyrox-ui/src/scroll_panel.rs
@@ -143,7 +143,7 @@ impl MessageData for ScrollPanelMessage {
 ///     ui.send(scroll_panel, ScrollPanelMessage::BringIntoView(child))
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "1ab4936d-58c8-4cf7-b33c-4b56092f4826"

--- a/fyrox-ui/src/scroll_viewer.rs
+++ b/fyrox-ui/src/scroll_viewer.rs
@@ -166,7 +166,7 @@ impl ScrollViewerMessage {
 ///     ui.send(scroll_viewer, ScrollViewerMessage::BringIntoView(child))
 /// }
 /// ```
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "173e869f-7da0-4ae2-915a-5d545d8150cc"

--- a/fyrox-ui/src/searchbar.rs
+++ b/fyrox-ui/src/searchbar.rs
@@ -97,7 +97,7 @@ impl MessageData for SearchBarMessage {}
 ///     }
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "23db1179-0e07-493d-98fd-2b3c0c795215"

--- a/fyrox-ui/src/selector.rs
+++ b/fyrox-ui/src/selector.rs
@@ -118,7 +118,7 @@ impl MessageData for SelectorMessage {}
 ///     }
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "25118853-5c3c-4197-9e4b-2e3b9d92f4d2")]
 pub struct Selector {

--- a/fyrox-ui/src/stack_panel.rs
+++ b/fyrox-ui/src/stack_panel.rs
@@ -107,7 +107,7 @@ impl MessageData for StackPanelMessage {}
 ///     .build(ctx);
 /// # }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "d868f554-a2c5-4280-abfc-396d10a0e1ed"

--- a/fyrox-ui/src/style/mod.rs
+++ b/fyrox-ui/src/style/mod.rs
@@ -54,7 +54,7 @@ use std::{
 use strum_macros::{AsRefStr, EnumString, VariantNames};
 
 /// A set of potential values for styled properties.
-#[derive(Visit, Reflect, Debug, Clone, AsRefStr, EnumString, VariantNames)]
+#[derive(Visit, PartialEq, Reflect, Debug, Clone, AsRefStr, EnumString, VariantNames)]
 #[reflect(type_uuid = "85b8c1e4-03a2-4a28-acb4-1850d1a29227")]
 pub enum StyleProperty {
     /// A numeric property.
@@ -150,9 +150,9 @@ pub static LIGHT_STYLE: LazyLock<BuiltInResource<Style>> = LazyLock::new(|| {
 /// the style and why do we need to store the value as well? The answer is flexibility. In this
 /// approach, style becomes not necessary and the value can be hardcoded. Also, the values of such
 /// properties can be updated individually.
-#[derive(Clone, Debug, Reflect, Default)]
+#[derive(Clone, Debug, PartialEq, Reflect, Default)]
 #[reflect(
-    bounds = "T: Reflect + Clone",
+    bounds = "T: Reflect + Clone + PartialEq",
     type_uuid = "71e84137-2832-42a1-bcb5-f8ee95784997"
 )]
 pub struct StyledProperty<T> {
@@ -220,7 +220,7 @@ impl<T: Visit> Visit for StyledProperty<T> {
 }
 
 /// Named style property container.
-#[derive(Visit, Reflect, Clone, Default, Debug)]
+#[derive(Visit, PartialEq, Reflect, Clone, Default, Debug)]
 #[reflect(type_uuid = "6238f37c-c067-4dd1-be67-6a8bb8853a59")]
 pub struct StylePropertyContainer {
     /// Name of the property.
@@ -298,7 +298,7 @@ pub struct StylePropertyContainer {
 ///     ui.set_style(StyleResource::new_embedded(style));
 /// }
 /// ```
-#[derive(Visit, Reflect, Clone, Default, Debug)]
+#[derive(Visit, PartialEq, Reflect, Clone, Default, Debug)]
 #[reflect(type_uuid = "38a63b49-d765-4c01-8fb5-202cc43d607e")]
 pub struct Style {
     parent: Option<StyleResource>,

--- a/fyrox-ui/src/style/mod.rs
+++ b/fyrox-ui/src/style/mod.rs
@@ -150,7 +150,7 @@ pub static LIGHT_STYLE: LazyLock<BuiltInResource<Style>> = LazyLock::new(|| {
 /// the style and why do we need to store the value as well? The answer is flexibility. In this
 /// approach, style becomes not necessary and the value can be hardcoded. Also, the values of such
 /// properties can be updated individually.
-#[derive(Clone, Debug, PartialEq, Reflect, Default)]
+#[derive(Clone, Debug, Reflect, Default)]
 #[reflect(
     bounds = "T: Reflect + Clone + PartialEq",
     type_uuid = "71e84137-2832-42a1-bcb5-f8ee95784997"

--- a/fyrox-ui/src/tab_control.rs
+++ b/fyrox-ui/src/tab_control.rs
@@ -205,7 +205,7 @@ pub struct Tab {
 /// };
 /// # }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "d54cfac3-0afc-464b-838a-158b3a2253f5"

--- a/fyrox-ui/src/text.rs
+++ b/fyrox-ui/src/text.rs
@@ -319,7 +319,7 @@ impl MessageData for TextMessage {}
 ///
 /// Please keep in mind, that like any other situation when you "changing" something via messages, you should remember
 /// that the change is **not** immediate.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "22f7f502-7622-4ecb-8c5f-ba436e7ee823"

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -196,6 +196,7 @@ impl SelectionRange {
 /// the filter, and `false` - otherwise.
 pub type FilterCallback = dyn FnMut(char) -> bool + Send;
 
+/// A wrapper over a shared text box filter closure.
 #[derive(Clone)]
 pub struct TextBoxFilter(pub Arc<Mutex<FilterCallback>>);
 

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -50,6 +50,7 @@ use crate::{
 };
 use copypasta::ClipboardProvider;
 use fyrox_graph::constructor::{ConstructorProvider, GraphNodeConstructor};
+use std::ops::Deref;
 use std::{
     cell::RefCell,
     fmt::{Debug, Formatter},
@@ -194,6 +195,23 @@ impl SelectionRange {
 /// Defines a function, that could be used to filter out desired characters. It must return `true` for characters, that pass
 /// the filter, and `false` - otherwise.
 pub type FilterCallback = dyn FnMut(char) -> bool + Send;
+
+#[derive(Clone)]
+pub struct TextBoxFilter(pub Arc<Mutex<FilterCallback>>);
+
+impl PartialEq for TextBoxFilter {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Deref for TextBoxFilter {
+    type Target = Mutex<FilterCallback>;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
 
 /// TextBox is a text widget that allows you to edit text and create specialized input fields. It has various options like
 /// word wrapping, text alignment, and so on.
@@ -427,7 +445,7 @@ pub struct TextBox {
     /// Current character filter of the text box.
     #[visit(skip)]
     #[reflect(hidden)]
-    pub filter: Option<Arc<Mutex<FilterCallback>>>,
+    pub filter: Option<TextBoxFilter>,
     /// Current text commit mode of the text box.
     pub commit_mode: InheritableVariable<TextCommitMode>,
     /// `true` if the multiline mode is active.
@@ -1527,7 +1545,7 @@ pub struct TextBoxBuilder<'a> {
     text: String,
     caret_brush: Brush,
     selection_brush: Brush,
-    filter: Option<Arc<Mutex<FilterCallback>>>,
+    filter: Option<TextBoxFilter>,
     vertical_alignment: VerticalAlignment,
     horizontal_alignment: HorizontalAlignment,
     wrap: WrapMode,
@@ -1613,7 +1631,7 @@ impl<'a> TextBoxBuilder<'a> {
     }
 
     /// Sets the desired character filter of the text box. See [`FilterCallback`] for more info.
-    pub fn with_filter(mut self, filter: Arc<Mutex<FilterCallback>>) -> Self {
+    pub fn with_filter(mut self, filter: TextBoxFilter) -> Self {
         self.filter = Some(filter);
         self
     }

--- a/fyrox-ui/src/text_box.rs
+++ b/fyrox-ui/src/text_box.rs
@@ -393,7 +393,7 @@ pub type FilterCallback = dyn FnMut(char) -> bool + Send;
 ///
 /// You can change brush of caret by using [`TextBoxBuilder::with_caret_brush`] and also selection brush by using
 /// [`TextBoxBuilder::with_selection_brush`], it could be useful if you don't like default colors.
-#[derive(Default, Clone, Visit, Reflect)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "536276f2-a175-4c05-a376-5a7d8bf0d10b"

--- a/fyrox-ui/src/thumb.rs
+++ b/fyrox-ui/src/thumb.rs
@@ -98,7 +98,7 @@ impl MessageData for ThumbMessage {}
 ///
 /// This example creates a new thumb widget 5px wide and shows how to use its messages to get
 /// information about the actual movement.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "71ad2ff4-6e9e-461d-b7c2-867bd4039684")]
 pub struct Thumb {

--- a/fyrox-ui/src/toggle.rs
+++ b/fyrox-ui/src/toggle.rs
@@ -32,7 +32,7 @@ use fyrox_core::pool::ObjectOrVariant;
 use crate::message::MessageData;
 use fyrox_graph::constructor::{ConstructorProvider, GraphNodeConstructor};
 
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(derived_type = "UiNode")]
 #[reflect(type_uuid = "8d8f114d-7fc6-4d7e-8f57-cd4e39958c36")]
 pub struct ToggleButton {

--- a/fyrox-ui/src/tree.rs
+++ b/fyrox-ui/src/tree.rs
@@ -292,7 +292,7 @@ impl MessageData for TreeRootMessage {}
 ///     });
 /// }
 /// ```
-#[derive(Default, Debug, Clone, Visit, Reflect)]
+#[derive(Default, Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "e090e913-393a-4192-a220-e1d87e272170"
@@ -809,7 +809,7 @@ fn build_expander(
 ///     ui.send(tree, TreeRootMessage::Select(new_selection));
 /// }
 /// ```
-#[derive(Default, Debug, Clone, Visit, Reflect)]
+#[derive(Default, Debug, Clone, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "cf7c0476-f779-4e4b-8b7e-01a23ff51a72"

--- a/fyrox-ui/src/utils.rs
+++ b/fyrox-ui/src/utils.rs
@@ -18,10 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+use crate::widget::UserData;
 use crate::{
     border::BorderBuilder,
     button::{Button, ButtonBuilder},
-    core::{algebra::Vector2, color::Color, parking_lot::Mutex, pool::Handle},
+    core::{algebra::Vector2, color::Color, pool::Handle},
     decorator::DecoratorBuilder,
     formatted_text::WrapMode,
     grid::{Column, GridBuilder, Row},
@@ -37,7 +38,6 @@ use fyrox_texture::{
     CompressionOptions, TextureImportOptions, TextureMinificationFilter, TextureResource,
     TextureResourceExtension,
 };
-use std::sync::Arc;
 use uuid::Uuid;
 
 pub enum ArrowDirection {
@@ -233,7 +233,7 @@ pub fn make_dropdown_list_option_universal<T: Send + 'static>(
             BorderBuilder::new(
                 WidgetBuilder::new()
                     .with_height(height)
-                    .with_user_data(Arc::new(Mutex::new(user_data)))
+                    .with_user_data(UserData::new(user_data))
                     .with_child(
                         TextBuilder::new(WidgetBuilder::new().with_margin(text_margin()))
                             .with_vertical_text_alignment(VerticalAlignment::Center)

--- a/fyrox-ui/src/uuid.rs
+++ b/fyrox-ui/src/uuid.rs
@@ -66,7 +66,7 @@ impl MessageData for UuidEditorMessage {}
 ///         .build(ctx)
 /// }
 /// ```
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "667f7f48-2448-42da-91dd-cd743ca7117e"

--- a/fyrox-ui/src/vec.rs
+++ b/fyrox-ui/src/vec.rs
@@ -91,7 +91,7 @@ where
 }
 impl<T: NumericType, const D: usize> MessageData for VecEditorMessage<T, D> {}
 
-#[derive(Clone, Visit, Reflect, Debug)]
+#[derive(Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "0332144f-c70e-456a-812b-f9b89980d2ba"

--- a/fyrox-ui/src/vector_image.rs
+++ b/fyrox-ui/src/vector_image.rs
@@ -197,7 +197,7 @@ impl Primitive {
 ///
 /// Keep in mind that all primitives located in local coordinates. The color of the vector image can be changed by
 /// setting a new foreground brush.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, Visit, PartialEq, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "7e535b65-0178-414e-b310-e208afc0eeb5"

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -41,9 +41,10 @@ use crate::{
         resource::{StyleResource, StyleResourceExt},
         Style, StyledProperty, DEFAULT_STYLE,
     },
-    BuildContext, HorizontalAlignment, LayoutEvent, MouseButton, MouseState, RcUiNodeHandle,
-    Thickness, UiNode, UserInterface, VerticalAlignment,
+    BuildContext, HorizontalAlignment, LayoutEvent, LayoutEventsSender, MouseButton, MouseState,
+    RcUiNodeHandle, Thickness, UiNode, UserInterface, VerticalAlignment,
 };
+use fyrox_core::parking_lot::{MappedMutexGuard, MutexGuard};
 use fyrox_core::pool::ObjectOrVariant;
 use fyrox_graph::SceneGraph;
 use fyrox_material::{Material, MaterialResource};
@@ -54,7 +55,7 @@ use std::{
     cmp::Ordering,
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
-    sync::{mpsc::Sender, Arc},
+    sync::Arc,
 };
 
 /// Sorting predicate that is used to sort widgets by some criteria.
@@ -536,6 +537,25 @@ impl WidgetRenderDataSet {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct UserData(pub Arc<Mutex<dyn Any + Send>>);
+
+impl UserData {
+    pub fn new<T: Any + Send>(v: T) -> Self {
+        Self(Arc::new(Mutex::new(v)))
+    }
+
+    pub fn downcast<T: Any + Send>(&self) -> Option<MappedMutexGuard<T>> {
+        MutexGuard::try_map(self.0.safe_lock(), |v| v.downcast_mut::<T>()).ok()
+    }
+}
+
+impl PartialEq for UserData {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
 /// Widget is a base UI element, that is always used to build derived, more complex, widgets. In general, it is a container
 /// for layout information, basic visual appearance, visibility options, parent-child information. It does almost nothing
 /// on its own, instead, the user interface modifies its state accordingly.
@@ -619,7 +639,7 @@ pub struct Widget {
     /// Optional, user-defined data.
     #[reflect(hidden)]
     #[visit(skip)]
-    pub user_data: Option<Arc<Mutex<dyn Any + Send>>>,
+    pub user_data: Option<UserData>,
     /// A flag, that defines whether the widget should be drawn in a separate drawing pass after any other widget that draws
     /// normally.
     pub draw_on_top: InheritableVariable<bool>,
@@ -675,7 +695,7 @@ pub struct Widget {
     /// Internal sender for layout events.
     #[reflect(hidden)]
     #[visit(skip)]
-    pub layout_events_sender: Option<Sender<LayoutEvent>>,
+    pub layout_events_sender: Option<LayoutEventsSender>,
     /// Unique identifier of the widget.
     pub id: Uuid,
     /// A flag, that indicates whether this widget is a root widget of a hierarchy of widgets
@@ -1564,11 +1584,10 @@ impl Widget {
 
     /// Tries to fetch user-defined data of the specified type `T`.
     #[inline]
-    pub fn user_data_cloned<T: Clone + 'static>(&self) -> Option<T> {
-        self.user_data.as_ref().and_then(|v| {
-            let guard = v.safe_lock();
-            guard.downcast_ref::<T>().cloned()
-        })
+    pub fn user_data_cloned<T: Any + Send + Clone + 'static>(&self) -> Option<T> {
+        self.user_data
+            .as_ref()
+            .and_then(|v| Some(T::clone(&*v.downcast::<T>()?)))
     }
 
     /// Returns current clipping bounds of the widget. It is valid only after at least one layout pass.
@@ -1701,7 +1720,7 @@ pub struct WidgetBuilder {
     /// Whether the drop of the widget is allowed or not.
     pub allow_drop: bool,
     /// User-defined data.
-    pub user_data: Option<Arc<Mutex<dyn Any + Send>>>,
+    pub user_data: Option<UserData>,
     /// Whether to draw the widget on top of any other or not.
     pub draw_on_top: bool,
     /// Whether the widget is enabled or not.
@@ -1981,7 +2000,7 @@ impl WidgetBuilder {
     /// Sets the desired widget user data.
     pub fn with_user_data_value_opt<T: Any + Send>(mut self, user_data: Option<T>) -> Self {
         if let Some(data) = user_data {
-            self.user_data = Some(Arc::new(Mutex::new(data)));
+            self.user_data = Some(UserData::new(data));
         }
         self
     }
@@ -1992,7 +2011,7 @@ impl WidgetBuilder {
     }
 
     /// Sets the desired widget user data.
-    pub fn with_user_data(mut self, user_data: Arc<Mutex<dyn Any + Send>>) -> Self {
+    pub fn with_user_data(mut self, user_data: UserData) -> Self {
         self.user_data = Some(user_data);
         self
     }

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -537,14 +537,17 @@ impl WidgetRenderDataSet {
     }
 }
 
+/// Arbitrary user data wrapped in Arc<Mutex<...>>.
 #[derive(Clone, Debug)]
 pub struct UserData(pub Arc<Mutex<dyn Any + Send>>);
 
 impl UserData {
+    /// Creates new user data instance from the given value.
     pub fn new<T: Any + Send>(v: T) -> Self {
         Self(Arc::new(Mutex::new(v)))
     }
 
+    /// Tries to downcast the underlying data to the given type.
     pub fn downcast<T: Any + Send>(&self) -> Option<MappedMutexGuard<T>> {
         MutexGuard::try_map(self.0.safe_lock(), |v| v.downcast_mut::<T>()).ok()
     }

--- a/fyrox-ui/src/widget.rs
+++ b/fyrox-ui/src/widget.rs
@@ -519,7 +519,7 @@ impl DerefMut for WidgetMaterial {
 }
 
 /// A set of data emitted by a widget during the draw pass.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct WidgetRenderDataSet {
     /// The result of calling the [`crate::control::Control::draw`] method.
     pub draw_result: RenderData,
@@ -539,7 +539,7 @@ impl WidgetRenderDataSet {
 /// Widget is a base UI element, that is always used to build derived, more complex, widgets. In general, it is a container
 /// for layout information, basic visual appearance, visibility options, parent-child information. It does almost nothing
 /// on its own, instead, the user interface modifies its state accordingly.
-#[derive(Default, Debug, Clone, Reflect, Visit)]
+#[derive(Default, Debug, Clone, Reflect, PartialEq, Visit)]
 #[reflect(type_uuid = "77e1b0ed-0d0a-4fae-9956-19bbd7145401")]
 #[visit(optional)]
 pub struct Widget {

--- a/fyrox-ui/src/window.rs
+++ b/fyrox-ui/src/window.rs
@@ -217,7 +217,7 @@ pub enum WindowSizeState {
 /// to interact with anything else until the modal is dismissed.
 ///
 /// Any window can be set and unset as a modal via the *modal* function.
-#[derive(Default, Clone, Visit, Reflect, Debug)]
+#[derive(Default, Clone, PartialEq, Visit, Reflect, Debug)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "9331bf32-8614-4005-874c-5239e56bb15e"
@@ -292,7 +292,7 @@ const GRIP_SIZE: f32 = 6.0;
 const CORNER_GRIP_SIZE: f32 = GRIP_SIZE * 2.0;
 
 /// Kind of a resizing grip.
-#[derive(Copy, Clone, Debug, Visit, Reflect, Default)]
+#[derive(Copy, Clone, Debug, Visit, PartialEq, Reflect, Default)]
 #[reflect(type_uuid = "fea2073e-f44e-45db-a373-c9fcee201c2d")]
 pub enum GripKind {
     /// Left-top corner grip.
@@ -315,7 +315,7 @@ pub enum GripKind {
 }
 
 /// Resizing grip.
-#[derive(Clone, Visit, Default, Debug, Reflect)]
+#[derive(Clone, Visit, PartialEq, Default, Debug, Reflect)]
 #[reflect(type_uuid = "373815d8-77d2-4624-80de-2d851f7fd6e5")]
 pub struct Grip {
     /// Kind of the grip.

--- a/fyrox-ui/src/wrap_panel.rs
+++ b/fyrox-ui/src/wrap_panel.rs
@@ -76,7 +76,7 @@ impl MessageData for WrapPanelMessage {}
 ///
 /// Wrap panel can stack your widgets either in vertical or horizontal direction. Use `.with_orientation` while building
 /// the panel to switch orientation to desired.
-#[derive(Default, Clone, Debug, Visit, Reflect)]
+#[derive(Default, Clone, Debug, Visit, PartialEq, Reflect)]
 #[reflect(
     derived_type = "UiNode",
     type_uuid = "f488ab8e-8f8b-473c-a450-5ac33f1afb39"
@@ -108,7 +108,7 @@ impl ConstructorProvider<UiNode, UserInterface> for WrapPanel {
 crate::define_widget_deref!(WrapPanel);
 
 /// Represents a single line (either vertical or horizontal) with arranged widgets.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Line {
     /// Indices of the children widgets that belongs to this line.
     pub children: Range<usize>,

--- a/project-manager/src/settings.rs
+++ b/project-manager/src/settings.rs
@@ -96,7 +96,7 @@ fn default_run_cargo_update() -> bool {
     true
 }
 
-#[derive(Default, Serialize, Deserialize, Reflect, Clone, Debug)]
+#[derive(Default, Serialize, Deserialize, PartialEq, Reflect, Clone, Debug)]
 #[reflect(type_uuid = "fab68a7a-58ce-40f5-a354-a7789c43efd3")]
 pub struct SettingsData {
     /// Defines a command to run an IDE in a project folder. This command should use either
@@ -213,7 +213,7 @@ impl Settings {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Project {
     pub manifest_path: PathBuf,
     pub name: String,

--- a/template-core/src/lib.rs
+++ b/template-core/src/lib.rs
@@ -175,7 +175,7 @@ use fyrox::{
 pub use fyrox;
 
 #[derive(Default, Visit, Reflect, Debug)]
-#[reflect(non_cloneable, type_uuid = "84a89ed3-796e-4592-92d6-d24c2db302c9")]
+#[reflect(non_cloneable, non_comparable, type_uuid = "84a89ed3-796e-4592-92d6-d24c2db302c9")]
 pub struct Game { }
 
 impl Plugin for Game {
@@ -719,7 +719,7 @@ use fyrox::{{
     plugin::error::GameResult
 }};
 
-#[derive(Visit, Reflect, Default, Debug, Clone)]
+#[derive(Visit, Reflect, Default, Debug, PartialEq, Clone)]
 #[reflect(type_uuid = "{script_uuid}")]
 #[visit(optional)]
 pub struct {script_name} {{


### PR DESCRIPTION
This PR adds `Reflect::try_compare` method, that essentially allows you to check two `dyn Reflect`s for equality. It returns `Option<bool>`, because not every types are comparable.