### PR TITLE
Remove dependency on `memoffset`

### DIFF
--- a/fyrox-core/Cargo.toml
+++ b/fyrox-core/Cargo.toml
@@ -20,7 +20,6 @@ fyrox-math = { path = "../fyrox-math", version = "2.0.0-rc.1" }
 base64 = "0.22.1"
 byteorder = "1.4.3"
 rand = "0.8"
-memoffset = "0.9.0"
 nalgebra = { version = "0.35", features = ["bytemuck", "convert-glam030"] }
 arrayvec = "0.7.2"
 futures = { version = "0.3.17", features = ["thread-pool"] }

--- a/fyrox-core/src/lib.rs
+++ b/fyrox-core/src/lib.rs
@@ -27,9 +27,6 @@
 #![allow(clippy::doc_lazy_continuation)]
 #![allow(mismatched_lifetime_syntaxes)]
 
-#[macro_use]
-extern crate memoffset;
-
 pub use arrayvec;
 pub use byteorder;
 pub use nalgebra as algebra;

--- a/fyrox-core/src/pool/mod.rs
+++ b/fyrox-core/src/pool/mod.rs
@@ -1367,7 +1367,7 @@ where
         let val = ptr as *const T as usize;
         if val >= begin && val < end {
             let record_size = std::mem::size_of::<PoolRecord<T>>();
-            let record_location = (val - offset_of!(PoolRecord<T>, payload)) - begin;
+            let record_location = (val - core::mem::offset_of!(PoolRecord<T>, payload)) - begin;
             if record_location.is_multiple_of(record_size) {
                 let index = record_location / record_size;
                 let index = u32::try_from(index).expect("Index overflowed u32");


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Hi, I may or may not have used your crate but I'd like to say a quick thank you for it anyway!
I'm going down the list of reverse dependencies on `memoffset`.

This PR aims to remove the `memoffset` crate from your dependencies.
[`core::mem::offset_of`](https://doc.rust-lang.org/core/mem/macro.offset_of.html) was stabilised in rustc 1.77 which I believe is at or below your MSRV.

The `memoffset` crate 0.9.1 says that

> If you're using a rustc version greater or equal to 1.77,
> this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

I consider it very unlikely (see [here](https://github.com/rust-lang/rust/issues/111839)) for any usage of the `offset_of!` macro to break but please check anyway.
I hope we can all enjoy the benefits of one less dependency :)


## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
N/A

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
None

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
N/A

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines (I ran `cargo fmt`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (N/A?)
- [x] My changes don't generate new warnings or errors
- [x] No unsafe code introduced (or if introduced, thoroughly justified and documented)
